### PR TITLE
Falsification

### DIFF
--- a/draft-ietf-httpbis-tunnel-protocol.xml
+++ b/draft-ietf-httpbis-tunnel-protocol.xml
@@ -266,6 +266,14 @@ Tunnel-Protocol: h2, http%2F1.1
         from the case where either client or proxy does not support the
         Tunnel-Protocol header field.
       </t>
+      <t>
+        The value of the Tunnel-Protocol header field could be falsified by a
+        client.  The use of protocols like <xref target="RFC5246">TLS</xref>
+        make it very difficult or impossible to verify that the header field is
+        correct even after a connection is established.  A proxy therefore
+        cannot rely on the value of the Tunnel-Protocol header field as a policy
+        input in all cases.
+      </t>
     </section>
   </middle>
 

--- a/draft-ietf-httpbis-tunnel-protocol.xml
+++ b/draft-ietf-httpbis-tunnel-protocol.xml
@@ -268,11 +268,13 @@ Tunnel-Protocol: h2, http%2F1.1
       </t>
       <t>
         The value of the Tunnel-Protocol header field could be falsified by a
-        client.  The use of protocols like <xref target="RFC5246">TLS</xref>
-        make it very difficult or impossible to verify that the header field is
-        correct even after a connection is established.  A proxy therefore
-        cannot rely on the value of the Tunnel-Protocol header field as a policy
-        input in all cases.
+        client.  If the data being sent through the tunnel is encrypted (for
+        example, with <xref target="RFC5246">TLS</xref>), then the proxy might
+        not be able to directly inspect the data to verify that the claimed
+        protocol is the one which is actually being used, though a proxy might
+        be able to perform traffic analysis <xref target="TRAFFIC"/>.  A proxy
+        therefore cannot rely on the value of the Tunnel-Protocol header field
+        as a policy input in all cases.
       </t>
     </section>
   </middle>
@@ -290,6 +292,21 @@ Tunnel-Protocol: h2, http%2F1.1
    <references title="Informative References">
       &RFC5246;
       &RFC5766;
+
+      <reference anchor="TRAFFIC"
+                 target="https://alfredo.pironti.eu/research/publications/full/identifying-website-users-tls-traffic-analysis-new-attacks-and-effective-counterme">
+        <front>
+          <title>
+            Website Users by TLS Traffic Analysis: New Attacks and Effective
+            Countermeasures, Revision 1
+          </title>
+          <author initials="A." surname="Pironti"/>
+          <author initials="P-Y." surname="Strub"/>
+          <author initials="K." surname="Bhargavan"/>
+          <date year="2012"/>
+        </front>
+      </reference>
+
     </references>
   </back>
 </rfc>


### PR DESCRIPTION
This adds a section regarding falsification of Tunnel-Protocol.  I didn't expand this to note that WebRTC won't suffer from this problem because the application won't be able to set the header field.  That seemed like too much detail.