### PR TITLE
Precise signification of http/1.1 ALPN token.

### DIFF
--- a/draft-ietf-httpbis-alt-svc.xml
+++ b/draft-ietf-httpbis-alt-svc.xml
@@ -242,7 +242,8 @@
 <t>
    Note that for the purpose of identifying an alternative service, the
    "http/1.1" token defined by <xref target="RFC7301"/> identifies HTTP/1.1 over
-   TLS.
+   TLS. In addition, neither <xref target="RFC7301"/>, nor this document
+   defines a token that identifies HTTP/1.1 over unsecured TCP.
 </t>
 <t>
    The remainder of this section describes requirements that are common to alternative

--- a/draft-ietf-httpbis-alt-svc.xml
+++ b/draft-ietf-httpbis-alt-svc.xml
@@ -240,6 +240,11 @@
    (<xref target="frame"/>).
 </t>
 <t>
+   Note that for the purpose of identifying an alternative service, the
+   "http/1.1" token defined by <xref target="RFC7301"/> identifies HTTP/1.1 over
+   TLS.
+</t>
+<t>
    The remainder of this section describes requirements that are common to alternative
    services, regardless of how they are discovered.
 </t>


### PR DESCRIPTION
The `http/1.1` ALPN token identifies HTTP/1.1 over TLS.