### PR TITLE
Renaming to ALPN

### DIFF
--- a/draft-ietf-httpbis-tunnel-protocol.xml
+++ b/draft-ietf-httpbis-tunnel-protocol.xml
@@ -4,7 +4,8 @@
 <!DOCTYPE rfc [
 <!-- One method to get references from the online citation libraries.
      There has to be one entity for each item to be referenced.
-     An alternate method (rfc include) is described in the references. --><!ENTITY RFC2119 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
+     An alternate method (rfc include) is described in the references. -->
+<!ENTITY RFC2119 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
 <!ENTITY RFC3864 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3864.xml">
 <!ENTITY RFC3986 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3986.xml">
 <!ENTITY RFC5246 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5246.xml">
@@ -27,7 +28,7 @@
 <rfc category="std" docName="draft-ietf-httpbis-tunnel-protocol-latest" ipr="trust200902"      xmlns:x="http://purl.org/net/xml2rfc/ext">
   <x:feedback template="mailto:ietf-http-wg@w3.org?subject={docname},%20%22{section}%22&amp;body=&lt;{ref}&gt;:"/>
   <front>
-    <title abbrev="Tunnel-Protocol">The Tunnel-Protocol HTTP Header Field</title>
+    <title abbrev="The ALPN Header">The ALPN HTTP Header Field</title>
 
     <author fullname="Andrew Hutton" initials="A." surname="Hutton">
       <organization>Unify</organization>
@@ -81,7 +82,7 @@
       <t>
         This specification allows HTTP CONNECT requests to indicate what
         protocol will be used within the tunnel once established, using the
-        Tunnel-Protocol header field.
+        ALPN header field.
        </t>
     </abstract>
 
@@ -115,13 +116,13 @@
         virtual connections, through one or more proxies.
       </t>
       <t>
-        The HTTP Tunnel-Protocol header field identifies the protocol that will
+        The HTTP ALPN header field identifies the protocol that will
         be spoken within the tunnel, using the Application Layer Protocol
         Negotiation identifier (ALPN, <xref target="RFC7301"/>).
       </t>
       <t>
         When the CONNECT method is used to establish a tunnel, the
-        Tunnel-Protocol header field can be used to identify the protocol that
+        ALPN header field can be used to identify the protocol that
         the client intends to use with that tunnel.  For a tunnel that is then
         secured using <xref target="RFC5246">TLS</xref>, the header field
         carries the same application protocol label as will be carried within
@@ -129,7 +130,7 @@
         protocols, all of those application protocols are indicated.
       </t>
       <t>
-        The Tunnel-Protocol header field carries an indication of client intent
+        The ALPN header field carries an indication of client intent
         only.  In TLS, the final choice of application protocol is made by the
         server from the set of choices presented by the client.  Other protocols
         could negotiate protocols differently.
@@ -151,9 +152,9 @@
       </section>
     </section>
 
-   <section title="The Tunnel-Protocol HTTP Header Field" anchor="tp">
+   <section title="The ALPN HTTP Header Field" anchor="tp">
       <t>
-        Clients include the Tunnel-Protocol header field in an HTTP CONNECT
+        Clients include the ALPN header field in an HTTP CONNECT
         request to indicate the application layer protocol that will be used within
         the tunnel, or the set of protocols that might be used within the
         tunnel.
@@ -170,13 +171,13 @@
 
      <section title="Syntax">
         <t>
-          The ABNF (Augmented Backus-Naur Form) syntax for the Tunnel-Protocol
+          The ABNF (Augmented Backus-Naur Form) syntax for the ALPN
           header field is given below.  It is based on the Generic Grammar
           defined in <xref x:sec="2" x:fmt="of" target="RFC7230"/>.
         </t>
         <figure>
           <artwork type="abnf2616"><![CDATA[
-Tunnel-Protocol = "Tunnel-Protocol":" 1#protocol-id
+ALPN = "ALPN":" 1#protocol-id
 protocol-id     = token ; percent-encoded ALPN protocol identifier
 ]]></artwork>
         </figure>
@@ -212,7 +213,7 @@ protocol-id     = token ; percent-encoded ALPN protocol identifier
           <artwork type="message/http; msgtype=&#34;request&#34;" x:indent-with="  ">
 CONNECT www.example.com HTTP/1.1
 Host: www.example.com
-Tunnel-Protocol: h2, http%2F1.1
+ALPN: h2, http%2F1.1
 </artwork>
         </figure>
       </section>
@@ -223,11 +224,11 @@ Tunnel-Protocol: h2, http%2F1.1
         HTTP header fields are registered within the "Message Headers" registry
         maintained at <eref
         target="https://www.iana.org/assignments/message-headers"/>.  This
-        document defines and registers the Tunnel-Protocol header field,
+        document defines and registers the ALPN header field,
         according to <xref target="RFC3864"/> as follows:
         <list style="hanging">
           <t hangText="Header Field Name:">
-            Tunnel-Protocol
+            ALPN
           </t>
           <t hangText="Protocol:">
             http
@@ -257,23 +258,23 @@ Tunnel-Protocol: h2, http%2F1.1
         configurable whitelist of safe request targets."
       </t>
       <t>
-        The Tunnel-Protocol header field described in this document is an
+        The ALPN header field described in this document is an
         OPTIONAL header field. Clients and HTTP proxies could choose to not support
         the header and therefore fail to provide it, or ignore it when
         present. If the header is not available or ignored, a proxy cannot
         identify the purpose of the tunnel and use this as input to any
         authorization decision regarding the tunnel. This is indistinguishable
         from the case where either client or proxy does not support the
-        Tunnel-Protocol header field.
+        ALPN header field.
       </t>
       <t>
-        The value of the Tunnel-Protocol header field could be falsified by a
+        The value of the ALPN header field could be falsified by a
         client.  If the data being sent through the tunnel is encrypted (for
         example, with <xref target="RFC5246">TLS</xref>), then the proxy might
         not be able to directly inspect the data to verify that the claimed
         protocol is the one which is actually being used, though a proxy might
         be able to perform traffic analysis <xref target="TRAFFIC"/>.  A proxy
-        therefore cannot rely on the value of the Tunnel-Protocol header field
+        therefore cannot rely on the value of the ALPN header field
         as a policy input in all cases.
       </t>
     </section>


### PR DESCRIPTION
Last call discussion identified this as a solution to the confusion that exists around the intent of the header field.

Closes #57.