### PR TITLE
Avoid ambiguity with "may not" and a "MAY" requirement

### DIFF
--- a/draft-ietf-httpbis-legally-restricted-status.xml
+++ b/draft-ietf-httpbis-legally-restricted-status.xml
@@ -103,9 +103,9 @@
       <t>This status code indicates that the server is denying access
       to the resource as a consequence of a legal demand.</t> 
       
-      <t>The server in question may not be an origin server.  This type of
-      legal demand typically most directly affects the operations of ISPs and
-      search engines.</t>
+      <t>The server in question is not necessarily an origin server.  This type
+      of legal demand typically most directly affects the operations of ISPs
+      and search engines.</t>
 
       <t>Responses using this status code SHOULD include an explanation,
       in the response body, of the details of the legal demand: the party


### PR DESCRIPTION
RFC 2119 defines "MAY" as a keyword, which may cause confusion with "may not", even though the latter is not uppercased.

This hopefully better clarifies that the server in question may or may not be an origin server, as opposed to implying that origin servers are prevented from returning a 451 response status.