### PR TITLE
Going down for maintenance?

### DIFF
--- a/draft-ietf-httpbis-alt-svc.xml
+++ b/draft-ietf-httpbis-alt-svc.xml
@@ -109,9 +109,8 @@
 <t>For example:
   <list style="symbols">
     <t>
-       An origin server might wish to redirect a client to a different server when it
-       needs to go down for maintenance, or it has found a server in a
-       location that is more local to the client.
+       An origin server might wish to redirect clients to different servers when it
+       is under load, or it has found a server in a location that is more local to the client.
     </t>
     <t>
        An origin server might wish to offer access to its resources using a new


### PR DESCRIPTION
Spec commends the use of Alt-Svc when a server is "going down for maintenance."  But new clients will always be trying to contact the origin server, and existing clients may always fall back to it for various reasons.  Alt-Svc isn't a redundancy strategy for the origin, and I don't think we should present it as one here.  Servers will still need to cluster, anycast, etc. or shed load by changing DNS.