### PR TITLE
Alt-Svc Editorial Nits

### DIFF
--- a/draft-ietf-httpbis-alt-svc.xml
+++ b/draft-ietf-httpbis-alt-svc.xml
@@ -136,8 +136,8 @@
    service was used (<xref target="indicator"/>).
 </t>
 <t>
-   It also introduces a new status code in <xref target="status"/>, so that origin servers (or
-   their nominated alternatives) can indicate that they are not authoritative for
+   It also recommends a status code in <xref target="status"/> that origin servers (or
+   their nominated alternatives) can use to indicate that they are not authoritative for
    a given origin, in cases where the wrong location is used.
 </t>
 
@@ -205,8 +205,8 @@ uri-host      = &lt;uri-host, see <xref target="RFC7230" x:rel="#uri"/>&gt;
    The alternative service is essentially alternative routing information that can
    also be used to reach the origin in the same way that DNS CNAME or SRV records
    define routing information at the name resolution level. Each origin maps to a
-   set of these routes &mdash; the default route is derived from origin itself and the
-   other routes are introduced based on alternative-protocol information.
+   set of these routes &mdash; the default route is derived from the origin itself
+   and the other routes are introduced based on alternative-protocol information.
 </t>
 <t>
    Furthermore, it is important to note that the first member of an alternative
@@ -290,7 +290,7 @@ uri-host      = &lt;uri-host, see <xref target="RFC7230" x:rel="#uri"/>&gt;
    Clients with existing connections to an alternative service do not need to
    stop using it when its freshness lifetime ends; i.e., the caching
    mechanism is intended for limiting how long an alternative service can be used
-   for establishing new requests, not limiting the use of existing ones.
+   for establishing new connections, not limiting the use of existing ones.
 </t>
 <t>
    Clients ought to consider that changes in network configurations can
@@ -331,7 +331,7 @@ uri-host      = &lt;uri-host, see <xref target="RFC7230" x:rel="#uri"/>&gt;
    HTTP; or, an alternative service might itself advertise an alternative.
 </t>
 <t>
-   When a client uses an alternative service for a request, it can indicate
+   When a client uses an alternative service for a request, it &SHOULD; indicate
    this to the server using the  Alt-Used header field (<xref
       target="indicator"/>).
 </t>
@@ -778,8 +778,8 @@ Alt-Used: alternate.example.net
    could conceivably track client requests.
 </t>
 <t>
-   Clients concerned by the additional fingerprinting can choose to ignore alternative
-   service advertisements.
+   Clients concerned by the additional fingerprinting &MAY; choose to ignore alternative
+   service advertisements or omit the Alt-Used header.
 </t>
 <t>
    In a user agent, any alternative service information &MUST; be removed when origin-specific data
@@ -790,8 +790,8 @@ Alt-Used: alternate.example.net
 <section title="Confusion Regarding Request Scheme" anchor="confusion-regarding-request-scheme">
 <t>
    Alternative Services &MUST-NOT; be advertised for a protocol that is not
-   designed to carry the scheme. In particular, HTTP/1.1 over TLS cannot carry
-   safely requests for http resources.
+   designed to carry the scheme. In particular, HTTP/1.1 over TLS cannot safely
+   carry requests for http resources.
 </t>
 </section>
 


### PR DESCRIPTION
Assorted:
  - Alt-Svc doesn't introduce 421, just points to RFC 7540
  - Missing "the" in overview
  - Requests != connections in HTTP/2; presuming you mean connections throughout
  - Non-normative "can" mismatch with normative SHOULD later in the document
  - Clients who wish to avoid tracking are also permitted to just drop Alt-Used; turned to normative MAY to match earlier text
  - Word order in scheme confusion text