### PR TITLE
editorial changes

### DIFF
--- a/draft-ietf-httpbis-http2-encryption.md
+++ b/draft-ietf-httpbis-http2-encryption.md
@@ -78,8 +78,8 @@ level of protection as afforded to `https` URIs, but instead to increase the lik
 active attack can be detected.
 
 A final (but significant) goal is to provide for ease of implementation, deployment and operation.
-This mechanism is expected to have a minimal impact upon performance, and a trivial administrative
-effort to configure.
+This mechanism is expected to have a minimal impact upon performance, and require a trivial
+administrative effort to configure.
 
 
 ## Notational Conventions
@@ -110,9 +110,9 @@ expire, in order minimize the delays that might be incurred.
 
 # Server Authentication {#auth}
 
-By their nature, "http" URIs do not require cryptographically strong server authentication; that is
-only implied by "https" URIs. Furthermore, doing so (as per {{RFC2818}}) creates a number of
-operational challenges. For these reasons, server authentication is not mandatory for "http" URIs
+By their nature, `http` URIs do not require cryptographically strong server authentication; that is
+only implied by `https` URIs. Furthermore, doing so (as per {{RFC2818}}) creates a number of
+operational challenges. For these reasons, server authentication is not mandatory for `http` URIs
 when using the mechanism described in this specification.
 
 When connecting to an alternative service for an `http` URI, clients are not required to perform the
@@ -233,7 +233,7 @@ over time.
 
 Once a server has indicated that it will support authenticated TLS, a client MAY use key pinning
 {{RFC7469}} or any other mechanism that would otherwise be restricted to use
-with "https" URIs, provided that the mechanism can be restricted to a single HTTP origin.
+with `https` URIs, provided that the mechanism can be restricted to a single HTTP origin.
 
 
 


### PR DESCRIPTION
* consistent use of `http` instead of "http"
* make S1.1, P3 a bit more readable