### PR TITLE
Making tls-commit and tls-ports mutually exclusive

### DIFF
--- a/draft-ietf-httpbis-http2-encryption.md
+++ b/draft-ietf-httpbis-http2-encryption.md
@@ -232,7 +232,6 @@ origin makes such a commitment for the duration of the origin object lifetime.
 ~~~ example
 {
   "http://www.example.com": {
-    "tls-ports": [443,8080],
     "tls-commit": true,
     "lifetime": 3600
   }
@@ -243,6 +242,9 @@ Including `tls-commit` creates a commitment to provide a secured alternative ser
 advertised period. Clients that receive this commitment can assume that a secured alternative
 service will be available for the origin object lifetime. Clients might however choose to limit
 this time (see {{pinrisks}}).
+
+The `tls-ports` member is ignored when the `tls-commit` member is provided.  A server that is
+able to strongly authenticate can run on any port.
 
 
 ## Client Handling of A Commitment

--- a/draft-ietf-httpbis-http2-encryption.md
+++ b/draft-ietf-httpbis-http2-encryption.md
@@ -244,7 +244,10 @@ service will be available for the origin object lifetime. Clients might however 
 this time (see {{pinrisks}}).
 
 The `tls-ports` member is ignored when the `tls-commit` member is provided.  A server that is
-able to strongly authenticate can run on any port.
+able to strongly authenticate can run on any host or port.  Though a client will not discover
+such a server using the process in this document, it might learn that a strongly authenticated
+server exists by other means, such as when a connection is reused (see Section 9.1.1 of
+[RFC7540]).
 
 
 ## Client Handling of A Commitment


### PR DESCRIPTION
This probably isn't the end of this issue though.  We require that an opportunistic upgrade uses the same hostname.  The text I added here lifts the requirement regarding port numbers, but should it also say that the hostname needs to remain the same?

I've left this open here, but I think that we probably should leave the hostname requirement in place.  That way, we still retain some of the aspects of http:// authority.