### PR TITLE
change frame type of origin to 0xc to avoid conflict

### DIFF
--- a/draft-ietf-httpbis-origin-frame.md
+++ b/draft-ietf-httpbis-origin-frame.md
@@ -78,7 +78,7 @@ for the connection it occurs within.
 
 ## Syntax {#syntax}
 
-The ORIGIN frame type is 0xb (decimal 11).
+The ORIGIN frame type is 0xc (decimal 12).
 
 ~~~~
 +-------------------------------+-------------------------------+
@@ -189,7 +189,7 @@ another connection's Origin Set, and SHOULD close it once all outstanding reques
 This specification adds an entry to the "HTTP/2 Frame Type" registry.
 
 * Frame Type: ORIGIN
-* Code: 0xb
+* Code: 0xc
 * Specification: [this document]
 
 


### PR DESCRIPTION
While testing firefox's implementation of this draft Vlad determined that some versions of Chrome throw PROTOCOL_ERROR and close the connection if it receives a type 0xB frame with a non zero length on stream 0.

Other frame type numbers, such as 0xC do not seem to have that problem.

testing indicates this is fixed in version 59 and is a problem previous to that. (57 is in release as I write this).

presumably this is related to historical code around BLOCKED which was proposed to use 0xB.

Prudence says to just use a different code point for the moment.