### PR TITLE
Use stand_alone for markdown

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -8,6 +8,9 @@ area: Applications and Real-Time
 workgroup: HTTP
 keyword: Internet-Draft
 
+stand_alone: yes
+pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline, docmapping]
+
 author:
  -
     ins: P-H. Kamp

--- a/draft-ietf-httpbis-immutable.md
+++ b/draft-ietf-httpbis-immutable.md
@@ -7,6 +7,9 @@ ipr: trust200902
 area: Applications and Real-Time
 workgroup: HTTP
 
+stand_alone: yes
+pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline, docmapping]
+
 author:
  - 
   ins: P. McManus


### PR DESCRIPTION
This includes a common set of processing instructions for the markdown files.  The results should be more consistent with other drafts in the repo.  

This is partly selfish.  I found that this is necessary on my machine because java is flaky and kramdown-rfc2629 creates entity references that it can't handle. 