### PR TITLE
Two editorial nits.

### DIFF
--- a/draft-ietf-httpbis-origin-frame.md
+++ b/draft-ietf-httpbis-origin-frame.md
@@ -166,7 +166,7 @@ Once an Origin Set has been initialised for a connection, clients that implement
 change these behaviors in the following ways:
 
 * Clients MUST NOT consult DNS to establish the connection's authority for new requests. The TLS
-  certificate MUST stil be used to do so, as described in {{!RFC7540}} Section 9.1.1.
+  certificate MUST still be used to do so, as described in {{!RFC7540}} Section 9.1.1.
 
 * Clients sending a new request SHOULD use an existing connection if the request's origin is in that connection's Origin Set, unless there are operational reasons for creating a new connection.
 
@@ -180,8 +180,8 @@ Section 4.2.1.6).
 
 Because ORIGIN can change the set of origins a connection is used for over time, it is possible
 that a client might have more than one viable connection to an origin open at any time. When this
-occurs, clients SHOULD not emit new requests on any connection whose Origin Set is a subset of
-another connection's Origin Set, and SHOULD close it once all outstanding requests are satisfied.
+occurs, clients SHOULD not emit new requests on any connection whose Origin Set is a proper subset
+of another connection's Origin Set, and SHOULD close it once all outstanding requests are satisfied.
 
 
 # IANA Considerations


### PR DESCRIPTION
1. Fix one typo.
2. Technically, a set is always a subset of itself.  Therefore current wording implies that if two connections have identical Origin Sets, then neither should be used for new requests, and both should be closed.  Fix this by saying "proper subset" instead of "subset".