### PR TITLE
define `cache-digest` header in appendix

### DIFF
--- a/draft-ietf-httpbis-cache-digest.md
+++ b/draft-ietf-httpbis-cache-digest.md
@@ -37,6 +37,8 @@ normative:
   RFC7540:
 
 informative:
+  RFC4648:
+  RFC5234:
   RFC6265:
   Rice:
     title: Adaptive variable-length coding for efficient compression of spacecraft television data
@@ -49,7 +51,6 @@ informative:
       name: James Plaunt
     date: 1971
     seriesinfo: IEEE Transactions on Communication Technology 19.6
-
 
 --- abstract
 
@@ -286,6 +287,37 @@ Additionally, User Agents SHOULD NOT send CACHE_DIGEST when in "privacy mode."
 
 --- back
 
+# Encoding the CACHE_DIGEST frame as an HTTP Header
+
+Some HTTP/2 protocol stacks do not provide an interface to inject arbitrary HTTP/2 frames while allowing the application to send additional HTTP request headers.
+When using such an implementation, it is sensible to send Cache Digests as HTTP headers, even though doing so consumes more bandwidth when compared to using HTTP/2 frames due to the fact that the digests need to be associated to every HTTP request as opposed to just sending once per connection.
+
+For the sake of interoperability with clients that are constrained to using headers, this appendix defines how a CACHE_DIGEST frame can be encoded as an HTTP header named `Cache-Digest`.
+
+The definition uses the Augmented Backus-Naur Form (ABNF) notation of {{RFC5234}} with the list rule extension defined in {{RFC7230}}, Appendix B.
+
+~~~ abnf7230
+  Cache-Digest  = 1#digest-entity
+  digest-entity = digest-value *(OWS ";" OWS digest-flag)
+  digest-value  = <Digest-Value encoded using base64url>
+  digest-flag   = token
+~~~
+
+A Cache-Digest request header is defined as a list construct of cache-digest-entities.
+Each cache-digest-entity corresponds to a CACHE_DIGEST frame.
+
+Digest-Value is encoded using base64url {{RFC4648}}, Section 5.
+Flags that are set are encoded as digest-flags by their names that are compared case-insensitively.
+
+Origin is omitted in the header form.
+The value is implied from the value of the `:authority` pseudo header.
+Client MUST only send Cache-Digest headers containing digests that belong to the origin specified by the HTTP request.
+
+The example below contains one digest of fresh resource and has only the `COMPLETE` flag set.
+
+~~~ example
+  Cache-Digest: AfdA; complete
+~~~
 
 # Acknowledgements
 

--- a/draft-ietf-httpbis-cache-digest.md
+++ b/draft-ietf-httpbis-cache-digest.md
@@ -51,6 +51,18 @@ informative:
       name: James Plaunt
     date: 1971
     seriesinfo: IEEE Transactions on Communication Technology 19.6
+  Service-Workers:
+    title: Service Workers 1
+    author:
+    - name: Alex Russell
+    - name: Jungkee Song
+    - name: Jake Archibald
+    - name: Marijn Kruisselbrink
+    date: 2016/10/11
+    target: https://www.w3.org/TR/2016/WD-service-workers-1/
+  Fetch:
+    title: Fetch Standard
+    target: https://fetch.spec.whatwg.org/
 
 --- abstract
 
@@ -264,8 +276,8 @@ we can determine whether there is a match in the digest using the following algo
 
 # IANA Considerations
 
-This draft currently has no requirements for IANA. If the CACHE_DIGEST frame is standardised, it
-will need to be assigned a frame type.
+This draft currently has no requirements for IANA.
+If the specification is standardised, the CACHE_DIGEST frame will need to be assigned a frame type and the Cache-Digest header will need to be registered.
 
 # Security Considerations
 
@@ -289,10 +301,9 @@ Additionally, User Agents SHOULD NOT send CACHE_DIGEST when in "privacy mode."
 
 # Encoding the CACHE_DIGEST frame as an HTTP Header
 
-Some HTTP/2 protocol stacks do not provide an interface to inject arbitrary HTTP/2 frames while allowing the application to send additional HTTP request headers.
-When using such an implementation, it is sensible to send Cache Digests as HTTP headers, even though doing so consumes more bandwidth when compared to using HTTP/2 frames due to the fact that the digests need to be associated to every HTTP request as opposed to just sending once per connection.
+On some web browsers that support Service Workers {{Service-Workers}} but not Cache Digests (yet), it is possible to achieve the benefit of using Cache Digests by emulating the frame using HTTP Headers.
 
-For the sake of interoperability with clients that are constrained to using headers, this appendix defines how a CACHE_DIGEST frame can be encoded as an HTTP header named `Cache-Digest`.
+For the sake of interoperability with such clients, this appendix defines how a CACHE_DIGEST frame can be encoded as an HTTP header named `Cache-Digest`.
 
 The definition uses the Augmented Backus-Naur Form (ABNF) notation of {{RFC5234}} with the list rule extension defined in {{RFC7230}}, Appendix B.
 
@@ -318,6 +329,11 @@ The example below contains one digest of fresh resource and has only the `COMPLE
 ~~~ example
   Cache-Digest: AfdA; complete
 ~~~
+
+Clients MUST associate Cache-Digest headers to every HTTP request, since Fetch {{Fetch}} - the HTTP API supported by Service Workers - does not define the order in which the issued requests will be sent to the server nor guarantees that all the requests will be transmitted using a single HTTP/2 connection.
+
+Also, due to the fact that any header that is supplied to Fetch is required to be end-to-end, there is an ambiguity in what a Cache-Digest header respresents when a request is transmitted through a proxy.
+The header may represent the cache state of a client or that of a proxy, depending on how the proxy handles the header.
 
 # Acknowledgements
 


### PR DESCRIPTION
#256.

Since I wasn't sure if we can make normative references from an appendix, RFC5234 (ABNF) and RFC4648 (Base64) has been added as informative references.