### PR TITLE
Register header, frame type with IANA

### DIFF
--- a/draft-ietf-httpbis-cache-digest.md
+++ b/draft-ietf-httpbis-cache-digest.md
@@ -106,8 +106,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # The CACHE_DIGEST Frame
 
-The CACHE_DIGEST frame type is 0xf1. NOTE: This is an experimental value; if standardised, a
-permanent value will be assigned.
+The CACHE_DIGEST frame type is 0xd (decimal 13).
 
 ~~~~
 +-------------------------------+-------------------------------+
@@ -276,8 +275,20 @@ we can determine whether there is a match in the digest using the following algo
 
 # IANA Considerations
 
-This draft currently has no requirements for IANA.
-If the specification is standardised, the CACHE_DIGEST frame will need to be assigned a frame type and the Cache-Digest header will need to be registered.
+This document registers the following entry in the Permanent Message Headers Registry, as per {{?RFC3864}}:
+
+* Header field name: Cache-Digest
+* Applicable protocol: http
+* Status: experimental
+* Author/Change controller: IESG
+* Specification document(s): [this document]
+
+This document registers the following entry in the HTTP/2 Frame Type Registry, as per {{?RFC7540}}:
+
+* Frame Type: CACHE_DIGEST
+* Code: 0xd
+* Specification: [this document]
+
 
 # Security Considerations
 

--- a/draft-ietf-httpbis-cache-digest.md
+++ b/draft-ietf-httpbis-cache-digest.md
@@ -283,7 +283,7 @@ This document registers the following entry in the Permanent Message Headers Reg
 * Author/Change controller: IESG
 * Specification document(s): [this document]
 
-This document registers the following entry in the HTTP/2 Frame Type Registry, as per {{?RFC7540}}:
+This document registers the following entry in the HTTP/2 Frame Type Registry, as per {{RFC7540}}:
 
 * Frame Type: CACHE_DIGEST
 * Code: 0xd


### PR DESCRIPTION
The header needs to be registered if it's going to appear in an RFC.

Looking at 7540, I think the frame type needs to be registered as well, since "Experimental Use" is private / local only.