### PR TITLE
Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ discussion and their resolution.
 
 Before filing a new issue, please consider a few things:
 
-* Issues should be just that; issues with our deliverables, **not questions or support requests**.
+* Issues should be just that; issues with our deliverables, **not proposals, questions or support requests**.
 
 * Please review the issues list to make sure that you aren't filing a duplicate.
 
@@ -76,19 +76,13 @@ Issues will be labeled by the Chairs as either `editorial` or `design`:
 
 The `open` design issues in the issues list are those that we are currently or plan to discuss.
 When a design issue is `closed`, it implies that the issue's proposed resolution is reflected in
-the drafts.
+the draft; if a closed design issue is labeled with `has-consensus`, it means that the incorporated resolution has Working Group consensus.
 
-The editors can also propose resolutions to design issues for the group's consideration by
-incorporating them into the draft(s). When they do so, the issue will be closed and flagged with
-the `proposal` label.
+Design issues can be discussed on the mailing list or the issues list. The editors can also propose resolutions to design issues for the group's consideration by incorporating them into the draft(s).
 
-When a new draft is published, the design issues that have been closed since the last draft will be
-highlighted on the mailing list, to aid reviewers. 
+When a new draft is published, the design issues that have been closed since the last draft will be highlighted on the mailing list, to aid reviewers. Once consensus is confirmed, those issues will be labeled with `has-consensus`.
 
-If new information (in the judgement of the Chairs) about a decision comes to light, or there is an
-objection to a proposed resolution flagged with `proposal`, the issue will be reopened by the
-Chairs. If there is no objection, the `proposal` flag will be removed from those issues, to denote
-that their resolution has been accepted.
+Note that whether or not a design issue is closed does **not** reflect consensus of the Working Group; an issue's `open`/`closed` state is only used to organise our discussions. If you have a question or problem with an issue in the `closed` state, please comment on it (either in the issues list or mailing list), and we'll adjust its state accordingly. Note that reopening issues with `has-consensus` requires new information.
 
 
 ## Pull Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,21 +67,18 @@ Issues will be labeled by the Chairs as either `editorial` or `design`:
 
 * **Editorial** issues can be dealt with by the editor(s) without consensus or notification. Typically, any discussion will take place on the issue itself.
 
-Consensus for the resolution of a design issue can be established in a few different ways:
+The `open` design issues in the issues list are those that we are currently or plan to discuss.
+When a design issue is `closed`, it implies that the issue's proposed resolution is reflected in
+the drafts.
 
-* Through discussion on the mailing list. Once a resolution is found, it will be recorded in the issue.
-
-* Through discussion on the issues list. Once a resolution is found, it will be confirmed on the mailing list before consensus is declared. 
-
-The editors can also propose resolutions for the group's consideration by incorporating them into
-the draft(s); when doing so, the issue should not be closed until consensus is declared.
-
-Issues that have consensus will be labelled as `editor-ready`. After the editor has incorporated a
-resolution into the specification, the issue can be closed.
+The editors can also propose resolutions to design issues for the group's consideration by
+incorporating them into the draft(s). When they do so, the issue will be closed and flagged with
+the `proposal` label.
 
 When a new draft is published, the design issues that have been closed since the last draft will be
-highlighted on the mailing list, to aid reviewers. If substantive new information is brought to our
-attention, issues can be reopened by the Chairs.
+highlighted on the mailing list, to aid reviewers. If new information (in the judgement of the
+Chairs) about a decision comes to light, or there is an objection to a proposed resolution flagged
+with `proposal`, the issue will be reopened by the Chairs.
 
 
 ## Pull Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing to HTTP
 
-Before submitting feedback, please familiarize yourself with our current issues
-list, [charter](https://datatracker.ietf.org/wg/httpbis/about/) and [working
-group home page](https://httpwg.github.io/). If you're new to this, you may
-also want to read the [Tao of the IETF](https://www.ietf.org/tao.html).
+Before submitting feedback, please familiarize yourself with our current issues list,
+[charter](https://datatracker.ietf.org/wg/httpbis/about/) and [working group home
+page](https://httpwg.github.io/). If you're new to this, you may also want to read the [Tao of the
+IETF](https://www.ietf.org/tao.html).
 
 **Be aware that all contributions fall under the "NOTE WELL" terms outlined below.**
 
@@ -32,29 +32,28 @@ The Working Group has a few venues for discussion:
 
 * We also discuss specific issues on the [issues list](https://github.com/httpwg/http-extensions/issues) itself. If you don't want to use Github to follow these discussions, you can subscribe to the [issue announce list](https://www.ietf.org/mailman/listinfo/http-issues).
 
-To be active in the Working Group, you can participate in any of these places. Most activity takes place on the mailing list, but if you just want to comment on and raise issues, that's fine too.
+To be active in the Working Group, you can participate in any of these places. Most activity takes
+place on the mailing list, but if you just want to comment on and raise issues, that's fine too.
 
 
 ## Raising Issues
 
-We use our [issues list](https://github.com/httpwg/http-extensions/issues) to 
-track items for discussion and their resolution.
+We use our [issues list](https://github.com/httpwg/http-extensions/issues) to track items for
+discussion and their resolution.
 
 Before filing a new issue, please consider a few things:
 
-* Issues should be just that; issues with our deliverables, **not questions or
-  support requests**.
-* Please review the issues list to make sure that you aren't filing a
-  duplicate.
+* Issues should be just that; issues with our deliverables, **not questions or support requests**.
+* Please review the issues list to make sure that you aren't filing a duplicate.
 * If you're not sure how to phrase your issue, please ask on the [mailing list](https://lists.w3.org/Archives/Public/ietf-http-wg/).
 
 Issues can also be raised on the [Working Group mailing
-list](https://lists.w3.org/Archives/Public/ietf-http-wg/) by clearly marking them as such (e.g., 
-in the `Subject:` line). 
+list](https://lists.w3.org/Archives/Public/ietf-http-wg/) by clearly marking them as such (e.g., in
+the `Subject:` line).
 
-Be aware that issues might be rephrased, changed in scope, or combined with others, so that the group
-can focus its efforts. If you feel that such a change loses an important part of your original
-issue, please bring it up, either in comments or on the list.
+Be aware that issues might be rephrased, changed in scope, or combined with others, so that the
+group can focus its efforts. If you feel that such a change loses an important part of your
+original issue, please bring it up, either in comments or on the list.
 
 Off-topic and duplicate issues will be closed without discussion. Note that comments on individual
 commits will only be responded to with best effort, and may not be seen.
@@ -74,17 +73,21 @@ Consensus for the resolution of a design issue can be established in a few diffe
 
 * Through discussion on the issues list. Once a resolution is found, it will be confirmed on the mailing list before consensus is declared. 
 
-The editors can also propose resolutions for the group's consideration by incorporating them into the draft(s); when doing so, the issue should not be closed until consensus is declared.
+The editors can also propose resolutions for the group's consideration by incorporating them into
+the draft(s); when doing so, the issue should not be closed until consensus is declared.
 
-Issues that have consensus will be labelled as `editor-ready`. After the editor has incorporated a resolution into the specification, the issue can be closed.
+Issues that have consensus will be labelled as `editor-ready`. After the editor has incorporated a
+resolution into the specification, the issue can be closed.
 
-When a new draft is published, the design issues that have been closed since the last draft will be highlighted on the mailing list, to aid reviewers. If substantive new information is brought to our attention, issues can be reopened by the Chairs.
+When a new draft is published, the design issues that have been closed since the last draft will be
+highlighted on the mailing list, to aid reviewers. If substantive new information is brought to our
+attention, issues can be reopened by the Chairs.
 
 
 ## Pull Requests
 
-We welcome pull requests, both for editorial suggestions and to resolve open
-issues. In the latter case, please identify the relevant issue.
+We welcome pull requests, both for editorial suggestions and to resolve open issues. In the latter
+case, please identify the relevant issue.
 
 Please do not use a pull request to open a new design issue.
 
@@ -97,12 +100,11 @@ to all Working Group communications and meetings.
 
 ## NOTE WELL
 
-Any submission to the [IETF](https://www.ietf.org/) intended by the Contributor
-for publication as all or part of an IETF Internet-Draft or RFC and any
-statement made within the context of an IETF activity is considered an "IETF
-Contribution". Such statements include oral statements in IETF sessions, as
-well as written and electronic communications made at any time or place, which
-are addressed to:
+Any submission to the [IETF](https://www.ietf.org/) intended by the Contributor for publication as
+all or part of an IETF Internet-Draft or RFC and any statement made within the context of an IETF
+activity is considered an "IETF Contribution". Such statements include oral statements in IETF
+sessions, as well as written and electronic communications made at any time or place, which are
+addressed to:
 
  * The IETF plenary session
  * The IESG, or any member thereof on behalf of the IESG
@@ -117,15 +119,15 @@ are addressed to:
    [RFC 3979](https://tools.ietf.org/html/rfc3979) 
    (updated by [RFC 4879](https://tools.ietf.org/html/rfc4879)).
 
-Statements made outside of an IETF session, mailing list or other function,
-that are clearly not intended to be input to an IETF activity, group or
-function, are not IETF Contributions in the context of this notice.
+Statements made outside of an IETF session, mailing list or other function, that are clearly not
+intended to be input to an IETF activity, group or function, are not IETF Contributions in the
+context of this notice.
 
-Please consult [RFC 5378](https://tools.ietf.org/html/rfc5378) and [RFC 
-3979](https://tools.ietf.org/html/rfc3979) for details.
+Please consult [RFC 5378](https://tools.ietf.org/html/rfc5378) and
+[RFC3979](https://tools.ietf.org/html/rfc3979) for details.
 
-A participant in any IETF activity is deemed to accept all IETF rules of
-process, as documented in Best Current Practices RFCs and IESG Statements.
+A participant in any IETF activity is deemed to accept all IETF rules of process, as documented in
+Best Current Practices RFCs and IESG Statements.
 
-A participant in any IETF activity acknowledges that written, audio and video
-records of meetings may be made and may be available to the public.
+A participant in any IETF activity acknowledges that written, audio and video records of meetings
+may be made and may be available to the public.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,8 @@ Please do not use a pull request to open a new design issue.
 
 ## Code of Conduct
 
-The [IETF Guidelines for Conduct](https://tools.ietf.org/html/rfc7154) applies 
-to all Working Group communications and meetings.
+The [IETF Guidelines for Conduct](https://tools.ietf.org/html/rfc7154) applies to all Working Group
+communications and meetings.
 
 
 ## NOTE WELL

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,12 @@ incorporating them into the draft(s). When they do so, the issue will be closed 
 the `proposal` label.
 
 When a new draft is published, the design issues that have been closed since the last draft will be
-highlighted on the mailing list, to aid reviewers. If new information (in the judgement of the
-Chairs) about a decision comes to light, or there is an objection to a proposed resolution flagged
-with `proposal`, the issue will be reopened by the Chairs.
+highlighted on the mailing list, to aid reviewers. 
+
+If new information (in the judgement of the Chairs) about a decision comes to light, or there is an
+objection to a proposed resolution flagged with `proposal`, the issue will be reopened by the
+Chairs. Otherwise, the `proposal` flag will be removed from those issues, to denote that their
+resolution has been accepted.
 
 
 ## Pull Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to HTTP
 
-Before submitting feedback, please familiarize yourself with our current issues list,
+Anyone can contribute to HTTP; you don't have to join the Working Group, because there is no "membership" -- anyone who participates in the work, as outlined below, is part of the HTTP Working Group.
+
+Before doing so, it's a good idea to familiarize yourself with our current issues list,
 [charter](https://datatracker.ietf.org/wg/httpbis/about/), and [working group home
 page](https://httpwg.github.io/). If you're new to this, you may also want to read the [Tao of the
 IETF](https://www.ietf.org/tao.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,8 @@ highlighted on the mailing list, to aid reviewers.
 
 If new information (in the judgement of the Chairs) about a decision comes to light, or there is an
 objection to a proposed resolution flagged with `proposal`, the issue will be reopened by the
-Chairs. Otherwise, the `proposal` flag will be removed from those issues, to denote that their
-resolution has been accepted.
+Chairs. If there is no objection, the `proposal` flag will be removed from those issues, to denote
+that their resolution has been accepted.
 
 
 ## Pull Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing to HTTP
 
 Before submitting feedback, please familiarize yourself with our current issues
-list and review the [working group home page](https://httpwg.github.io/). If
-you're new to this, you may also want to read the [Tao of the
-IETF](https://www.ietf.org/tao.html).
+list, [charter](https://datatracker.ietf.org/wg/httpbis/about/) and [working
+group home page](https://httpwg.github.io/). If you're new to this, you may
+also want to read the [Tao of the IETF](https://www.ietf.org/tao.html).
 
 **Be aware that all contributions fall under the "NOTE WELL" terms outlined below.**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,11 @@ commits will only be responded to with best effort, and may not be seen.
 
 ## Resolving Issues
 
+As in all IETF Working Groups, final consensus of the Working Group is determined during Working
+Group Last Call; consensus established in discussion of issues provides a limited precedent, to
+prevent revisiting topics unnecessarily. Our issues list provides a mechanism for tracking those
+discussions and their outcome.
+
 Issues will be labeled by the Chairs as either `editorial` or `design`:
 
 * **Design** issues require discussion and consensus in the Working Group. This discussion can happen both in the issue and on the [Working Group mailing list](https://lists.w3.org/Archives/Public/ietf-http-wg/), as outlined below. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ commits will only be responded to with best effort, and may not be seen.
 
 ## Resolving Issues
 
-Issues will be labeled by the Chairs as either `editorial` or `design`.
+Issues will be labeled by the Chairs as either `editorial` or `design`:
 
 * **Design** issues require discussion and consensus in the Working Group. This discussion can happen both in the issue and on the [Working Group mailing list](https://lists.w3.org/Archives/Public/ietf-http-wg/), as outlined below. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Issues will be labeled by the Chairs as either `editorial` or `design`:
 
 * **Design** issues require discussion and consensus in the Working Group. This discussion can happen both in the issue and on the [Working Group mailing list](https://lists.w3.org/Archives/Public/ietf-http-wg/), as outlined below. 
 
-* **Editorial** issues can be closed by the editor(s) without consensus or notification. Typically, any discussion will take place on the issue itself.
+* **Editorial** issues can be dealt with by the editor(s) without consensus or notification. Typically, any discussion will take place on the issue itself.
 
 Consensus for the resolution of a design issue can be established in a few different ways:
 


### PR DESCRIPTION
Revise contributing.md to reflect our working practices more closely.

Specifically, editors can make proposals in the drafts that close issues, as long as they remember to label them `proposal`.

This is more aligned with the quicwg process; it's different (they use `has-consensus`) because we have a large number of existing issues with consensus.