### PR TITLE
fix contradictory definintions with HTTP/1.1

### DIFF
--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -133,6 +133,12 @@ Server response:
   [... rest of the response body is ommitted from the example ...]
 ~~~
 
+As is the case with any informational response, a server might emit more than one 103 (Early Hints)
+response prior to sending a final response.
+This can happen for example when a caching intermediary generates a 103 (Early Hints) response based
+on the header fields of a stale-cached response, then forwards a 103 (Early Hints) response and a
+final response that were sent from the origin server in response to a revalidation request.
+
 # Security Considerations
 
 Some clients might have issues handling 103 (Early Hints), since informational responses are rarely

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -93,12 +93,17 @@ send a final response with the header fields included in the informational respo
 A client can speculatively evaluate the header fields included in a 103 (Early Hints) response while
 waiting for the final response. For example, a client might recognize a Link header field value
 containing the relation type "preload" and start fetching the target resource.
-
 However, these header fields only provide hints to the client; they do not replace the header
-fields on the final response. Aside from performance optimizations, such evaluation of the 103
+fields on the final response.
+
+Aside from performance optimizations, such evaluation of the 103
 (Early Hints) response's header fields MUST NOT affect how the final response is processed. A
 client MUST NOT interpret the 103 (Early Hints) response header fields as if they applied to
 the informational response itself (e.g., as metadata about the 103 (Early Hints) response).
+
+A server MUST NOT omit sending the header fields of a final response even if they have been sent as
+part of a 103 (Early Hints) response.
+The server SHOULD only send the header fields that are likely to help the client carry out speculative operations as part of the 103 (Early Hints) response, instead of including all the header fields that are likely to be seen in the final response.
 
 An intermediary MAY send HTTP/2 ([RFC7540]) server pushes using the information found in the 103 (Early Hints) response.
 

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -90,6 +90,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 The 103 (Early Hints) informational status code indicates to the client that the server is likely to
 send a final response with the header fields included in the informational response.
 
+Typically, a server will include the header fields sent in a 103 (Early Hints) response in the final
+response as well. However, there might be cases when this is not desirable, such as when the server
+learns that they are not correct before the final response is sent.
+
 A client can speculatively evaluate the header fields included in a 103 (Early Hints) response while
 waiting for the final response. For example, a client might recognize a Link header field value
 containing the relation type "preload" and start fetching the target resource.
@@ -100,10 +104,6 @@ Aside from performance optimizations, such evaluation of the 103
 (Early Hints) response's header fields MUST NOT affect how the final response is processed. A
 client MUST NOT interpret the 103 (Early Hints) response header fields as if they applied to
 the informational response itself (e.g., as metadata about the 103 (Early Hints) response).
-
-A server MUST NOT omit sending the header fields of a final response even if they have been sent as
-part of a 103 (Early Hints) response.
-The server SHOULD only send the header fields that are likely to help the client carry out speculative operations as part of the 103 (Early Hints) response, instead of including all the header fields that are likely to be seen in the final response.
 
 An intermediary MAY send HTTP/2 ([RFC7540]) server pushes using the information found in the 103 (Early Hints) response.
 

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -90,9 +90,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 The 103 (Early Hints) informational status code indicates to the client that the server is likely to
 send a final response with the header fields included in the informational response.
 
-A server MUST NOT include Content-Length, Transfer-Encoding, or any hop-by-hop header fields
-([RFC7230], Section 6.1) in a 103 (Early Hints) response.
-
 A client can speculatively evaluate the header fields included in a 103 (Early Hints) response while
 waiting for the final response. For example, a client might recognize a Link header field value
 containing the relation type "preload" and start fetching the target resource.
@@ -103,8 +100,7 @@ fields on the final response. Aside from performance optimizations, such evaluat
 client MUST NOT interpret the 103 (Early Hints) response header fields as if they applied to
 the informational response itself (e.g., as metadata about the 103 (Early Hints) response).
 
-An intermediary MAY drop the informational response. It MAY send HTTP/2 ([RFC7540]) server pushes
-using the information found in the 103 (Early Hints) response.
+An intermediary MAY send HTTP/2 ([RFC7540]) server pushes using the information found in the 103 (Early Hints) response.
 
 The following example illustrates a typical message exchange that involves a 103 (Early Hints) response.
 

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -105,8 +105,6 @@ Aside from performance optimizations, such evaluation of the 103
 client MUST NOT interpret the 103 (Early Hints) response header fields as if they applied to
 the informational response itself (e.g., as metadata about the 103 (Early Hints) response).
 
-An intermediary MAY send HTTP/2 ([RFC7540]) server pushes using the information found in the 103 (Early Hints) response.
-
 The following example illustrates a typical message exchange that involves a 103 (Early Hints) response.
 
 Client request:


### PR DESCRIPTION
* removes statements that are either redundant or contradicts with RFC 7230, 7231
* clarifies how a server is expected to do when generating a response