### PR TITLE
clarify multi-103 behavior

### DIFF
--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -146,7 +146,7 @@ final response that were sent from the origin server in response to a revalidati
 
 A server MAY emit multiple 103 (Early Hints) responses with additional header fields as new information becomes available while the request is being processed.
 It does not need to repeat the fields that were already emitted, though it doesn't have to exclude them either.
-The client may consider any combination of header fields received in multiple 103 (Early Hints) responses when anticipating the list of header fields expected in the final response.
+The client can consider any combination of header fields received in multiple 103 (Early Hints) responses when anticipating the list of header fields expected in the final response.
 
 # Security Considerations
 

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -146,6 +146,31 @@ A server MAY emit multiple 103 (Early Hints) responses with additional header fi
 It does not need to repeat the fields that were already emitted, though it doesn't have to exclude them either.
 The client can consider any combination of header fields received in multiple 103 (Early Hints) responses when anticipating the list of header fields expected in the final response.
 
+The following example illustrates a series of responses that a server might emit.
+In the example, the server uses two 103 (Early Hints) responses to notify the client that it is likely to send three Link header fields in the final response.
+Two of the three expected header fields are found in the final response.
+The other header field is replaced by another Link header field that contains a different value.
+
+~~~ example
+  HTTP/1.1 103 Early Hints
+  Link: </main.css>; rel=preload; as=style
+
+  HTTP/1.1 103 Early Hints
+  Link: </style.css>; rel=preload; as=style
+  Link: </script.js>; rel=preload; as=script
+
+  HTTP/1.1 200 OK
+  Date: Fri, 26 May 2017 10:02:11 GMT
+  Content-Length: 1234
+  Content-Type: text/html; charset=utf-8
+  Link: </main.css>; rel=preload; as=style
+  Link: </newstyle.css>; rel=preload; as=style
+  Link: </script.js>; rel=preload; as=script
+
+  <!doctype html>
+  [... rest of the response body is omitted from the example ...]
+~~~
+
 # Security Considerations
 
 Some clients might have issues handling 103 (Early Hints), since informational responses are rarely

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -105,6 +105,9 @@ Aside from performance optimizations, such evaluation of the 103
 client MUST NOT interpret the 103 (Early Hints) response header fields as if they applied to
 the informational response itself (e.g., as metadata about the 103 (Early Hints) response).
 
+A server MAY use a 103 (Early Hints) response to indicate only some of the header fields that are expected to be found in the final response.
+A client SHOULD NOT interpret the nonexistence of a header field in a 103 (Early Hints) response as a speculation that the header field is unlikely to be part of the final response.
+
 The following example illustrates a typical message exchange that involves a 103 (Early Hints) response.
 
 Client request:

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -133,11 +133,16 @@ Server response:
   [... rest of the response body is ommitted from the example ...]
 ~~~
 
+## Multiple Early Hints
+
 As is the case with any informational response, a server might emit more than one 103 (Early Hints)
 response prior to sending a final response.
 This can happen for example when a caching intermediary generates a 103 (Early Hints) response based
 on the header fields of a stale-cached response, then forwards a 103 (Early Hints) response and a
 final response that were sent from the origin server in response to a revalidation request.
+
+Since the nonexistence of a header field within a 103 (Early Hints) response does not indicate the absence of that header field in the final response, a server MAY omit a header field that was included in one 103 (Early Hints) response in the following 103 (Early Hints) responses, even when it is still expected that the header field will be part of the final response.
+A client SHOULD NOT consider the disappearance of a header field in the following 103 (Early Hints) responses as an indication that the server has retracted the expectation that the header field will be found in the final response.
 
 # Security Considerations
 

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -144,8 +144,9 @@ This can happen for example when a caching intermediary generates a 103 (Early H
 on the header fields of a stale-cached response, then forwards a 103 (Early Hints) response and a
 final response that were sent from the origin server in response to a revalidation request.
 
-Since the nonexistence of a header field within a 103 (Early Hints) response does not indicate the absence of that header field in the final response, a server can omit a header field that was included in one 103 (Early Hints) response in the following 103 (Early Hints) responses, even when it is still anticipated that the header field will be part of the final response.
-What a client would expect in the final response is a union of the header fields that were found in the multiple 103 (Early Hints) responses.
+A server MAY emit multiple 103 (Early Hints) responses with additional header fields as new information becomes available while the request is being processed.
+It does not need to repeat the fields that were already emitted, though it is doesn't have to exclude them either.
+The client may consider any combination of header fields received in multiple 103 (Early Hints) responses when anticipating the list of header fields expected in the final response.
 
 # Security Considerations
 

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -144,8 +144,8 @@ This can happen for example when a caching intermediary generates a 103 (Early H
 on the header fields of a stale-cached response, then forwards a 103 (Early Hints) response and a
 final response that were sent from the origin server in response to a revalidation request.
 
-Since the nonexistence of a header field within a 103 (Early Hints) response does not indicate the absence of that header field in the final response, a server MAY omit a header field that was included in one 103 (Early Hints) response in the following 103 (Early Hints) responses, even when it is still expected that the header field will be part of the final response.
-A client SHOULD NOT consider the disappearance of a header field in the following 103 (Early Hints) responses as an indication that the server has retracted the expectation that the header field will be found in the final response.
+Since the nonexistence of a header field within a 103 (Early Hints) response does not indicate the absence of that header field in the final response, a server can omit a header field that was included in one 103 (Early Hints) response in the following 103 (Early Hints) responses, even when it is still anticipated that the header field will be part of the final response.
+What a client would expect in the final response is a union of the header fields that were found in the multiple 103 (Early Hints) responses.
 
 # Security Considerations
 

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -136,8 +136,6 @@ Server response:
   [... rest of the response body is ommitted from the example ...]
 ~~~
 
-## Multiple Early Hints
-
 As is the case with any informational response, a server might emit more than one 103 (Early Hints)
 response prior to sending a final response.
 This can happen for example when a caching intermediary generates a 103 (Early Hints) response based

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -145,7 +145,7 @@ on the header fields of a stale-cached response, then forwards a 103 (Early Hint
 final response that were sent from the origin server in response to a revalidation request.
 
 A server MAY emit multiple 103 (Early Hints) responses with additional header fields as new information becomes available while the request is being processed.
-It does not need to repeat the fields that were already emitted, though it is doesn't have to exclude them either.
+It does not need to repeat the fields that were already emitted, though it doesn't have to exclude them either.
 The client may consider any combination of header fields received in multiple 103 (Early Hints) responses when anticipating the list of header fields expected in the final response.
 
 # Security Considerations


### PR DESCRIPTION
Clarify that the disappearance of a header field (that once existed in a 103 response) from the following 103 responses does not indicate the retraction of the expectation that the header field will be included in the final response.

closes #371 