### PR TITLE
You can't actually receive a 425 if the handshake doesn't complete

### DIFF
--- a/draft-ietf-httpbis-replay.md
+++ b/draft-ietf-httpbis-replay.md
@@ -276,9 +276,7 @@ processing a request that might be replayed.
 
 Clients (user-agents and intermediaries) that sent the request in early data
 MUST automatically retry the request when receiving a 4NN (Too Early)
-response status code. Such retries MUST NOT be sent in early data, and SHOULD
-NOT be sent if the TLS handshake on the original connection does not
-successfully complete.
+response status code. Such retries MUST NOT be sent in early data.
 
 Intermediaries that receive a 4NN (Too Early) status code MAY automatically
 retry requests after allowing the handshake to complete unless the original


### PR DESCRIPTION
@mcmanus was confused by the text here and I confess that I don't remember why
it was added.  There are actually esoteric cases where you get server data that
you can read before the handshake is complete (QUIC tends to enable that sort
of mess), but there is no circumstance where the client can read the 425 but
can't also determine whether that the handshake is not done to its
satisfaction.  The client might decide that it wants to abort and not provide a
certificate or something, but most implementations don't really allow that sort
of messing around.