### PR TITLE
Shortnames in gh-pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 LIBDIR := lib
 USE_XSLT := true
 DISABLE_RIBBON := true
+GHPAGES_EXTRA = $(foreach ext,.html .txt,$(addsuffix $(ext),$(foreach draft,$(drafts),$(shell echo $(draft) | sed -e 's/draft-ietf-httpbis-//'))))
+
 include $(LIBDIR)/main.mk
 
 $(LIBDIR)/main.mk:
@@ -11,3 +13,6 @@ else
 	git clone -q --depth 10 $(CLONE_ARGS) \
 	    -b master https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif
+
+$(GHPAGES_EXTRA):
+	ln -sf draft-ietf-httpbis-$@ $@

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,9 @@ endif
 
 $(GHPAGES_EXTRA):
 	ln -sf draft-ietf-httpbis-$@ $@
+
+.PHONY: clean-extra
+clean:: clean-extra
+
+clean-extra:
+	-rm -f $(GHPAGES_EXTRA)

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,5 @@ endif
 $(GHPAGES_EXTRA):
 	ln -sf draft-ietf-httpbis-$@ $@
 
-.PHONY: clean-extra
-clean:: clean-extra
-
-clean-extra:
+clean::
 	-rm -f $(GHPAGES_EXTRA)

--- a/draft-ietf-httpbis-bcp56bis.md
+++ b/draft-ietf-httpbis-bcp56bis.md
@@ -1,7 +1,7 @@
 ---
 title: On the use of HTTP as a Substrate
 docname: draft-ietf-httpbis-bcp56bis-00
-date: 2017
+date: {DATE}
 category: bcp
 obsoletes: 3205
 
@@ -47,7 +47,7 @@ practices for these protocols' use of HTTP.
 
 --- note_Note_to_Readers_
 
-Discussion of this draft takes place on the HTTP working group mailing list 
+Discussion of this draft takes place on the HTTP working group mailing list
 (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
 
 Working Group information can be found at <http://httpwg.github.io/>; source code and issues list

--- a/draft-ietf-httpbis-cache-digest.md
+++ b/draft-ietf-httpbis-cache-digest.md
@@ -1,7 +1,7 @@
 ---
 title: Cache Digests for HTTP/2
 docname: draft-ietf-httpbis-cache-digest-latest
-date: 2017
+date: {DATE}
 category: exp
 
 ipr: trust200902

--- a/draft-ietf-httpbis-client-hints.md
+++ b/draft-ietf-httpbis-client-hints.md
@@ -2,7 +2,7 @@
 title: HTTP Client Hints
 abbrev:
 docname: draft-ietf-httpbis-client-hints-latest
-date: 2017
+date: {DATE}
 category: exp
 
 ipr: trust200902

--- a/draft-ietf-httpbis-early-hints.md
+++ b/draft-ietf-httpbis-early-hints.md
@@ -2,7 +2,7 @@
 title: An HTTP Status Code for Indicating Hints
 abbrev: Early Hints
 docname: draft-ietf-httpbis-early-hints-latest
-date: 2017
+date: {DATE}
 category: exp
 
 ipr: trust200902

--- a/draft-ietf-httpbis-expect-ct.md
+++ b/draft-ietf-httpbis-expect-ct.md
@@ -2,7 +2,7 @@
 title: "Expect-CT Extension for HTTP"
 abbrev: "Expect-CT"
 docname: draft-ietf-httpbis-expect-ct-latest
-date: 2017
+date: {DATE}
 category: exp
 area: Applications and Real-Time
 workgroup: HTTP
@@ -135,7 +135,7 @@ CT-qualified
 
 CT Policy
   : See Certificate Transparency Policy.
-  
+
 Effective Expect-CT Date
   : is the time at which a UA observed a valid Expect-CT header for a given
   host.
@@ -186,7 +186,7 @@ directive-value     = token / quoted-string
 ~~~
 {: #expect-ct-syntax title="Syntax of the Expect-CT header field"}
 
-Optional white space (`OWS`) is used as defined in Section 3.2.3 of 
+Optional white space (`OWS`) is used as defined in Section 3.2.3 of
 {{!RFC7230}}. `token` and `quoted-string` are used as defined in Section 3.2.6
 of {{!RFC7230}}.
 

--- a/draft-ietf-httpbis-h2-websockets.md
+++ b/draft-ietf-httpbis-h2-websockets.md
@@ -2,7 +2,7 @@
 title: Bootstrapping WebSockets with HTTP/2
 abbrev: H2 Websockets
 docname: draft-ietf-httpbis-h2-websockets-latest
-date: 2017-12-19
+date: {DATE}
 category: std
 area: Applications and Real Time
 workgroup: HTTPbis
@@ -13,7 +13,7 @@ stand_alone: yes
 pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline]
 
 author:
- - 
+ -
   ins: P. McManus
   name: Patrick McManus
   organization: Mozilla
@@ -28,7 +28,7 @@ over a single stream of an HTTP/2 connection.
 
 --- note_Note_to_Readers_
 
-Discussion of this draft takes place on the HTTP working group mailing list 
+Discussion of this draft takes place on the HTTP working group mailing list
 (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
 
 Working Group information can be found at <http://httpwg.github.io/>; source code and issues list
@@ -167,7 +167,7 @@ this point is OPEN as defined by {{!RFC6455}}, Section 4.1.
 ## Example
 ~~~
 [[ From Client ]]                       [[ From Server ]]
- 
+
                                         SETTINGS
                                         ENABLE_CONNECT_PROTOCOL = 1
 

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -1,7 +1,7 @@
 ---
 title: Structured Headers for HTTP
 docname: draft-ietf-httpbis-header-structure-latest
-date: 2017
+date: {DATE}
 category: std
 ipr: trust200902
 area: Applications and Real-Time

--- a/draft-ietf-httpbis-key.md
+++ b/draft-ietf-httpbis-key.md
@@ -2,7 +2,7 @@
 title: The Key HTTP Response Header Field
 abbrev: Key
 docname: draft-ietf-httpbis-key-latest
-date: 2017
+date: {DATE}
 category: std
 
 ipr: trust200902
@@ -28,17 +28,17 @@ author:
  -
     ins: M. Nottingham
     name: Mark Nottingham
-    organization: 
+    organization:
     email: mnot@mnot.net
     uri: https://www.mnot.net/
-    
+
 normative:
   RFC2119:
   RFC5234:
   RFC7230:
   RFC7231:
   RFC7234:
-  
+
 informative:
   RFC5226:
   RFC6265:
@@ -61,10 +61,10 @@ risk of fingerprinting.
 
 --- note_Note_to_Readers
 
-Discussion of this draft takes place on the HTTP working group mailing list 
+Discussion of this draft takes place on the HTTP working group mailing list
 (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
 
-Working Group information can be found at <http://httpwg.github.io/>; source 
+Working Group information can be found at <http://httpwg.github.io/>; source
 code and issues list for this draft can be found at <https://github.com/httpwg/http-extensions/labels/key>.
 
 --- middle
@@ -108,7 +108,7 @@ For example, this response header field:
 ~~~
 
 indicates that the selected response depends upon the "_sess" and "ID" cookie values.
- 
+
 This Key:
 
 ~~~ example
@@ -136,7 +136,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This document uses the Augmented Backus-Naur Form (ABNF) notation of {{RFC5234}} (including the
 DQUOTE rule), and the list rule extension defined in {{RFC7230}}, Section 7. It includes by
-reference the field-name, quoted-string and quoted-pair rules from that document, the OWS rule from 
+reference the field-name, quoted-string and quoted-pair rules from that document, the OWS rule from
 {{RFC7230}} and the parameter rule from {{RFC7231}}.
 
 
@@ -172,13 +172,13 @@ The following header fields have the same effect:
   Vary: Accept-Encoding, Cookie
   Key: Accept-Encoding, Cookie
 ~~~
-  
+
 However, Key's use of parameters allows:
 
 ~~~ example
   Key: Accept-Encoding, Cookie; param=foo
 ~~~
-  
+
 to indicate that the secondary cache key depends upon the Accept-Encoding header field and the
 "foo" Cookie.
 
@@ -197,7 +197,7 @@ parameters may define further capabilities.
 
 ## Relationship with Vary
 
-Origin servers SHOULD still send Vary when using Key, to ensure backwards compatibility. 
+Origin servers SHOULD still send Vary when using Key, to ensure backwards compatibility.
 
 For example,
 
@@ -249,7 +249,7 @@ response) using Key, the following steps are taken:
 2. Let `key_value` be the result of Creating a Header Field Value ({{value}}) with `key` as the `target_field_name` and the most recently seen response header list for the resource as `header_list`.
 3. Let `secondary_key` be an empty string.
 4. Create `key_list` by splitting `key_value` on "," characters, excepting "," characters within quoted strings, as per {{RFC7230}}, Section 3.2.6.
-5. For `key_item` in `key_list`: 
+5. For `key_item` in `key_list`:
 
    {: style="format %d)" counter="b"}
    1. Remove any leading and trailing WSP from `key_item`.
@@ -267,7 +267,7 @@ response) using Key, the following steps are taken:
       4. If `param_name` does not identify a Key parameter processing algorithm that is implemented, fail parameter processing ({{fail-param}}) and skip to the next `key_item`.
       5. Let `param_value` be the string after the first "=" character in `parameter`.
       6. If the first and last characters of `param_value` are both DQUOTE:
-      
+
          {: style="format %d)" counter="d"}
          1. Remove the first and last characters of `param_value`.
          2. Replace quoted-pairs within `param_value` with the octet following the backslash, as per {{RFC7230}}, Section 3.2.6.
@@ -285,7 +285,7 @@ Likewise, while the secondary cache key associated with both stored and presente
 required to use the most recently seen Key header field for the resource in question, this can be
 achieved using a variety of implementation strategies, including (but not limited to):
 
-* Generating a new secondary cache key for every stored response associated with the resource upon each request. 
+* Generating a new secondary cache key for every stored response associated with the resource upon each request.
 * Caching the secondary cache key with the stored request/response pair and re-generating it when the Key header field is observed to change.
 * Caching the secondary cache key with the stored response and invalidating the stored response(s) when the Key header field is observed to change.
 
@@ -296,7 +296,7 @@ Given a header field name `target_field_name` and `header_list`, a list of (`fie
 `field_value`) tuples:
 
 {: style="format %d)"  counter="e"}
-1. Let `target_field_values` be an empty list. 
+1. Let `target_field_values` be an empty list.
 3. For each (`field_name`, `field_value`) tuple in `header_list`:
 
    {: style="format %d)"  counter="f"}
@@ -316,7 +316,7 @@ When this happens, implementations MUST either behave as if the whole Key header
 present (i.e., abort processing of Key, ignoring it entirely and falling back to Vary), or assure
 that the nominated header fields being compared match, as per {{RFC7234}}, Section 4.1 (i.e., treat
 the failing portion of the Key header as falling back to Vary, but continuing to process the rest).
-  
+
 
 ## Key Parameters
 
@@ -371,7 +371,7 @@ Bar: 12
 Bar: 10
 Bar: 14, 1
 ~~~
- 
+
 
 ### partition
 
@@ -564,7 +564,7 @@ equivalent):
    {: style="format %d)" counter="p"}
    1. If the "=" character does not occur within `header_item`, skip to the next `header_item`.
    2. Let `item_name` be the string occurring before the first "=" character in `header_item`.
-   3. If `item_name` does not case-insensitively match `parameter_value`, skip to the next `header_item`. 
+   3. If `item_name` does not case-insensitively match `parameter_value`, skip to the next `header_item`.
    4. Return the string occurring after the first "=" character in `header_item`.
 5. Return the empty string.
 

--- a/draft-ietf-httpbis-origin-frame.md
+++ b/draft-ietf-httpbis-origin-frame.md
@@ -2,7 +2,7 @@
 title: The ORIGIN HTTP/2 Frame
 abbrev: ORIGIN Frames
 docname: draft-ietf-httpbis-origin-frame-latest
-date: 2017
+date: {DATE}
 category: std
 
 ipr: trust200902

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1,7 +1,7 @@
 ---
 title: "Cookies: HTTP State Management Mechanism"
 docname: draft-ietf-httpbis-rfc6265bis-latest
-date: 2017
+date: {DATE}
 category: std
 obsoletes: 6265
 
@@ -139,7 +139,7 @@ informative:
       ins: J. Mitchell
     seriesinfo:
       DOI: 10.1145/1455770.1455782
-      ISBN: 978-1-59593-810-7 
+      ISBN: 978-1-59593-810-7
       ACM: "CCS '08: Proceedings of the 15th ACM conference on Computer and communications security (pages 75-88)"
   Aggarwal2010:
     author:
@@ -260,7 +260,7 @@ interpreted as described in {{RFC2119}}.
 Requirements phrased in the imperative as part of algorithms (such as "strip any
 leading space characters" or "return false and abort these steps") are to be
 interpreted with the meaning of the key word ("MUST", "SHOULD", "MAY", etc.)
-used in introducing the algorithm. 
+used in introducing the algorithm.
 
 Conformance requirements phrased as algorithms or specific steps can be
 implemented in any manner, so long as the end result is equivalent. In
@@ -1196,7 +1196,7 @@ user agent MUST process the cookie-av as follows.
 
 4.  If delta-seconds is less than or equal to zero (0), let expiry-time be
     the earliest representable date and time. Otherwise, let the expiry-time
-    be the current date and time plus delta-seconds seconds. 
+    be the current date and time plus delta-seconds seconds.
 
 5.  Append an attribute to the cookie-attribute-list with an attribute-name
     of Max-Age and an attribute-value of expiry-time.


### PR DESCRIPTION
Uses the added feature in https://github.com/martinthomson/i-d-template/pull/129 to drop shortname copies of the drafts in gh-pages to fix the broken links.  These are actual copies, not symlinks, but git keeps those relatively cheap.

Shouldn't break anything to have in the Makefile without that change, either.