### PR TITLE
Fix the number of members in a list.

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -392,7 +392,7 @@ Lists are arrays of items ({{item}}) or parameterised labels ({{param}}), with o
 In the textual HTTP serialisation, each member is separated by a comma and optional whitespace.
 
 ~~~ abnf
-list = list_member 1*1024( OWS "," OWS list_member )
+list = list_member 0*1023( OWS "," OWS list_member )
 list_member = item / parameterised
 ~~~
 


### PR DESCRIPTION
The counts forgot to include the initial required member.

The parsing algorithm also doesn't enforce any bounds on the number of items, but I haven't fixed that here.