### PR TITLE
Incorporate exported authenticator requests

### DIFF
--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -522,7 +522,7 @@ error of type `PROTOCOL_ERROR`.
 The referenced certificate chain needs to conform to the requirements expressed
 in the `CERTIFICATE_REQUEST` to the best of the sender's ability, or the
 recipient is likely to reject it as unsuitable despite properly validating the
-authenticator.  If the recipicent considers the certificate unsuitable, it MAY
+authenticator.  If the recipient considers the certificate unsuitable, it MAY
 at its discretion either return an error at the HTTP semantic layer, or respond
 with a stream error {{RFC7540}} on any stream where the certificate is used.
 {{errors}} defines certificate-related error codes which might be applicable.

--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -568,7 +568,7 @@ The Exported Authenticator `request` API defined in
 [I-D.ietf-tls-exported-authenticator] takes as input a set of desired
 certificate characteristics and a `certificate_request_context`. When generating
 exported authenticators for use with this extension, the
-`certificate_request_context` MUST be the two-octet Cert-ID.
+`certificate_request_context` MUST be the two-octet Request-ID.
 
 The TLS library on the authenticating peer will provide mechanisms to select an
 appropriate certificate to respond to the transported request.  TLS libraries on
@@ -643,10 +643,11 @@ Upon receipt of a completed authenticator, an endpoint MUST perform the
 following steps:
  - Using the `get context` API, retrieve the `certificate_request_context` used
    to generate the authenticator, if any.
- - Verify that the `certificate_request_context` is one previously generated or,
-   when processed by a client, is absent.
+ - Verify that the `certificate_request_context` is the Request-ID of a
+   previously-sent `CERTIFICATE_REQUEST` frame.  Alternatively, on clients the
+   `certificate_request_context` MAY also be empty.
  - Use the `validate` API to confirm the validity of the authenticator with
-   regard to the generated request.
+   regard to the generated request (if any).
 
 Once the authenticator is accepted, the endpoint can perform any other checks
 for the acceptability of the certificate itself.

--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -66,7 +66,7 @@ scenarios.
 
 --- note_Note_to_Readers
 
-Discussion of this draft takes place on the HTTP working group mailing list 
+Discussion of this draft takes place on the HTTP working group mailing list
 (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
 
 Working Group information can be found at <http://httpwg.github.io/>; source
@@ -566,9 +566,10 @@ Request:
 
 The Exported Authenticator `request` API defined in
 [I-D.ietf-tls-exported-authenticator] takes as input a set of desired
-certificate characteristics and a `certificate_request_context`. When generating
-exported authenticators for use with this extension, the
-`certificate_request_context` MUST be the two-octet Request-ID.
+certificate characteristics and a `certificate_request_context`, which needs to
+be unpredictable. When generating exported authenticators for use with this
+extension, the `certificate_request_context` MUST be the two-octet Request-ID,
+followed by at least six random octets.
 
 The TLS library on the authenticating peer will provide mechanisms to select an
 appropriate certificate to respond to the transported request.  TLS libraries on
@@ -637,15 +638,15 @@ received on any other stream MUST be rejected with a stream error of type
 
 The Exported Authenticator API defined in [I-D.ietf-tls-exported-authenticator]
 takes as input a request, a set of certificates, and supporting information
-about the certificate (OCSP, SCT, etc.).
+about the certificate (OCSP, SCT, etc.).  The result is an opaque token which is
+used when generating the `CERTIFICATE` frame.
 
-Upon receipt of a completed authenticator, an endpoint MUST perform the
-following steps:
+Upon receipt of a `CERTIFICATE` frame, an endpoint MUST perform the following
+steps to validate the token it contains:
  - Using the `get context` API, retrieve the `certificate_request_context` used
    to generate the authenticator, if any.
- - Verify that the `certificate_request_context` is the Request-ID of a
-   previously-sent `CERTIFICATE_REQUEST` frame.  Alternatively, on clients the
-   `certificate_request_context` MAY also be empty.
+ - Verify that the `certificate_request_context` is either empty (clients only)
+   or the Request-ID of a previously-sent `CERTIFICATE_REQUEST` frame.
  - Use the `validate` API to confirm the validity of the authenticator with
    regard to the generated request (if any).
 

--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -519,13 +519,13 @@ preceding `CERTIFICATE` frame. Receipt of a `USE_CERTIFICATE` frame before the
 necessary frames have been received on stream zero MUST also result in a stream
 error of type `PROTOCOL_ERROR`.
 
-The referenced certificate chain MUST conform to the requirements expressed in
-the `CERTIFICATE_REQUEST` to the best of the sender's ability.
-
-If these requirements are not satisfied, the recipient MAY at its discretion
-either return an error at the HTTP semantic layer, or respond with a stream
-error {{RFC7540}} on any stream where the certificate is used. {{errors}}
-defines certificate-related error codes which might be applicable.
+The referenced certificate chain needs to conform to the requirements expressed
+in the `CERTIFICATE_REQUEST` to the best of the sender's ability, or the
+recipient is likely to reject it as unsuitable despite properly validating the
+authenticator.  If the recipicent considers the certificate unsuitable, it MAY
+at its discretion either return an error at the HTTP semantic layer, or respond
+with a stream error {{RFC7540}} on any stream where the certificate is used.
+{{errors}} defines certificate-related error codes which might be applicable.
 
 ## The CERTIFICATE_REQUEST Frame {#http-cert-request}
 
@@ -568,8 +568,8 @@ The Exported Authenticator `request` API defined in
 [I-D.ietf-tls-exported-authenticator] takes as input a set of desired
 certificate characteristics and a `certificate_request_context`, which needs to
 be unpredictable. When generating exported authenticators for use with this
-extension, the `certificate_request_context` MUST be the two-octet Request-ID,
-followed by at least six random octets.
+extension, the `certificate_request_context` MUST contain both the two-octet
+Request-ID as well as at least 96 bits of additional entropy.
 
 The TLS library on the authenticating peer will provide mechanisms to select an
 appropriate certificate to respond to the transported request.  TLS libraries on
@@ -646,7 +646,7 @@ steps to validate the token it contains:
  - Using the `get context` API, retrieve the `certificate_request_context` used
    to generate the authenticator, if any.
  - Verify that the `certificate_request_context` is either empty (clients only)
-   or the Request-ID of a previously-sent `CERTIFICATE_REQUEST` frame.
+   or contains the Request-ID of a previously-sent `CERTIFICATE_REQUEST` frame.
  - Use the `validate` API to confirm the validity of the authenticator with
    regard to the generated request (if any).
 


### PR DESCRIPTION
Tracking changes from tlswg/tls-exported-authenticator#9 to create an exported authenticator request message at the TLS layer as well.

This is a straight port of https://github.com/MikeBishop/http2-certs/pull/18/; feedback there has already been addressed, modulo one issue I'll be adding to this repo.