### PR TITLE
Use the right amount of base64 padding in binary content examples.

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -500,7 +500,7 @@ base64 = ALPHA / DIGIT / "+" / "/" / "="
 For example, a header whose value is defined as binary content could look like:
 
 ~~~ example
-ExampleBinaryHeader: *cHJldGVuZCB0aGlzIGlzIGJpbmFyeSBjb250ZW50Lg*
+ExampleBinaryHeader: *cHJldGVuZCB0aGlzIGlzIGJpbmFyeSBjb250ZW50Lg==*
 ~~~
 
 


### PR DESCRIPTION
Since be5ab4c153be0a10d301d7d55c425a5025b1ab40 required it.

I'd probably have kept padding forbidden to save a couple bytes here and there, and made Python folks append the right number of `=`s, but whatever.