### PR TITLE
Get and side effects fix

### DIFF
--- a/draft-ietf-httpbis-bcp56bis.md
+++ b/draft-ietf-httpbis-bcp56bis.md
@@ -453,7 +453,7 @@ implementations can and do retry HTTP GET requests that fail.
 Finally, note that while HTTP allows GET requests to have a body syntactically, this is done only
 to allow parsers to be generic; as per {{!RFC7231}}, Section 4.3.1, a body on a GET has no meaning,
 and will be either ignored or rejected by generic HTTP software. As a result, applications that use
-HTTP SHOULD NOT define GET to have any sde effects upon their resources.
+HTTP SHOULD NOT define GET to have any side effects upon their resources.
 
 
 


### PR DESCRIPTION
This just fixes a typo, but this text has more problems.

I'm having trouble connecting this final sentence to the text that precedes it.  I think that the point is that including a body on GET is unwise because it might cause explosions.  A point about side effects needs far more exposition, especially since GET is defined to be free from overt side effects (safe, idempotent, and all that business).  If this were just another statement and the "As a result" is dropped, that's different.