### PR TITLE
replay: fix TLS section ref

### DIFF
--- a/draft-ietf-httpbis-replay.md
+++ b/draft-ietf-httpbis-replay.md
@@ -198,7 +198,7 @@ reject early data.  The client then retries the request, resulting in the
 request being processed twice.  Replays are also possible if there are multiple
 server instances that will accept early data, or if the same server accepts
 early data multiple times (though this would be in violation of requirements in
-Section 8 of {{!TLS13}}).
+Section 9 of {{!TLS13}}).
 
 Clients that use early data MUST retry requests upon receipt of a 425 (Too
 Early) status code; see {{status}}.


### PR DESCRIPTION
I believe Section 8 has moved to 9 (FWIW: it's dangerous to use section number references to drafts without specifying the draft number)