### PR TITLE
Clarify handling of invalid SameSite values (fixes #389)

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -667,7 +667,7 @@ If the "SameSite" attribute's value is "Strict", the cookie will only be sent
 along with "same-site" requests. If the value is "Lax", the cookie will be sent
 with same-site requests, and with "cross-site" top-level navigations, as
 described in {{strict-lax}}. If the "SameSite" attribute's value is neither of
-these, the cookie will be ignored.
+these, the attribute will be ignored.
 
 ### Cookie Name Prefixes
 
@@ -2049,6 +2049,11 @@ Specification document:
 
    *   Fixed the "site for cookies" algorithm to return something that makes
        sense: <https://github.com/httpwg/http-extensions/issues/302>
+
+## draft-ietf-httpbis-rfc6265bis-03
+
+*  Clarified handling of invalid SameSite values:
+   <https://github.com/httpwg/http-extensions/issues/389>
 
 # Acknowledgements
 {:numbered="false"}


### PR DESCRIPTION
There is currently a discrepancy in the spec regarding invalid values
in the SameSite cookie attribute.

For example, this cookie:

  Set-Cookie: foo=bar; SameSite=bogus

is expected to be dropped entirely according to the "Server Requirements"
under Section 4.1.2.7:

  If the "SameSite" attribute's value is neither of these [ "Lax",
  "Strict" ], the cookie will be ignored.

whereas under Section 5.3.7 of "User Agent Requirements", the cookie
is to be kept but the attribute is ignored:

  If cookie-av's attribute-value is not a case-insensitive match for
  "Strict" or "Lax", ignore the "cookie-av".

Additionally, the end of Section 4.1.2 also matches the behavior
described in Section 5.3.7:

  User agents ignore unrecognized cookie attributes (but not the entire
  cookie).

From a forward-compatibility point of view, the behavior described in
section 5.3.7 is the ideal one since it allows for future expansion
of this feature such as:

  Set-Cookie: foo=bar; SameSite=medium