### PR TITLE
replay: refer to actual header field registry

### DIFF
--- a/draft-ietf-httpbis-replay.md
+++ b/draft-ietf-httpbis-replay.md
@@ -370,7 +370,7 @@ correctly handling replays of the same requests.
 # IANA Considerations
 
 This document registers the `Early-Data` header field in the "Message Headers"
-registry {{!HEADERS=RFC3864}}.
+registry located at <https://www.iana.org/assignments/message-headers>.
 
 Header field name:
 


### PR DESCRIPTION
....instead of RFC defining it.