### PR TITLE
Mention rejection of 0-RTT

### DIFF
--- a/draft-ietf-httpbis-replay.md
+++ b/draft-ietf-httpbis-replay.md
@@ -115,8 +115,7 @@ to mitigate the risks of replay:
    data being replayed and ensure a fixed upper limit to the number of replays.
 
 2. The server can reject early data.  A server cannot selectively reject early
-   data, so this results in all requests that are sent in early data being
-   rejected.
+   data, so this results in all requests sent in early data being rejected.
 
 3. The server can choose to delay processing of early data until after the TLS
    handshake completes. By deferring processing, it can ensure that only a

--- a/draft-ietf-httpbis-replay.md
+++ b/draft-ietf-httpbis-replay.md
@@ -114,16 +114,19 @@ to mitigate the risks of replay:
    anti-replay techniques reduce but don't completely eliminate the chance of
    data being replayed and ensure a fixed upper limit to the number of replays.
 
-2. The server can choose whether it will process early data before the TLS
-   handshake completes. By deferring processing, it can ensure that only a
-   successfully completed connection is used for the request(s) therein.
-   This provides the server with some assurance that the early data was not
-   replayed.
+2. The server can reject early data.  A server cannot selectively reject early
+   data, so this results in all requests that are sent in early data being
+   rejected.
 
-3. If the server receives multiple requests in early data, it can determine
+3. The server can choose to delay processing of early data until after the TLS
+   handshake completes. By deferring processing, it can ensure that only a
+   successfully completed connection is used for the request(s) therein.  This
+   provides the server with some assurance that the early data was not replayed.
+
+4. If the server receives multiple requests in early data, it can determine
    whether to defer HTTP processing on a per-request basis.
 
-4. The server can cause a client to retry a request and not use early data by
+5. The server can cause a client to retry a request and not use early data by
    responding with the 425 (Too Early) status code ({{status}}), in cases where
    the risk of replay is judged too great.
 

--- a/draft-ietf-httpbis-replay.md
+++ b/draft-ietf-httpbis-replay.md
@@ -115,7 +115,7 @@ to mitigate the risks of replay:
    data being replayed and ensure a fixed upper limit to the number of replays.
 
 2. The server can reject early data.  A server cannot selectively reject early
-   data, so this results in all requests sent in early data being rejected.
+   data, so this results in all requests sent in early data being discarded.
 
 3. The server can choose to delay processing of early data until after the TLS
    handshake completes. By deferring processing, it can ensure that only a


### PR DESCRIPTION
Our basic list of mitigations missed a fairly obvious one.

Mentioning it should help with the class of confusion Magnus N. had with the draft.

I decided not to include a note about the server being unable to examine early data before making this decision.  That's just something people will need to discover for themselves.  Generally, you have to decide whether you want 0-RTT without seeing any of it.  Partly this is because it avoids a potential deadlock, but mostly it's because the TLS stack will not even decrypt 0-RTT if it is rejected.