### PR TITLE
Restructure structure

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -76,9 +76,9 @@ Specifying the syntax of new HTTP header fields is an onerous task; even with th
 
 Once a header field is defined, bespoke parsers for it often need to be written, because each header has slightly different handling of what looks like common syntax.
 
-This document introduces a set of common data structures for use in HTTP header field values to address these problems. In particular, it defines a generic, abstract model for header field values, along with a concrete serialisation for expressing that model in textual HTTP headers, as used by HTTP/1 {{?RFC7230}} and HTTP/2 {{?RFC7540}}.
+This document introduces a set of common data structures for use in HTTP header field values to address these problems. In particular, it defines a generic, abstract model for header field values, along with a concrete serialisation for expressing that model in HTTP/1 {{?RFC7230}} and HTTP/2 {{?RFC7540}} header fields.
 
-HTTP headers that are defined as "Structured Headers" use the types defined in this specification to define their syntax and basic handling rules, thereby simplifying both their definition and parsing.
+HTTP headers that are defined as "Structured Headers" use the types defined in this specification to define their syntax and basic handling rules, thereby simplifying both their definition by specification writers and handling by implementations.
 
 Additionally, future versions of HTTP can define alternative serialisations of the abstract model of these structures, allowing headers that use it to be transmitted more efficiently without being redefined.
 
@@ -86,9 +86,9 @@ Note that it is not a goal of this document to redefine the syntax of existing H
 
 To specify a header field that is a Structured Header, see {{specify}}.
 
-{{types}} defines a number of abstract data types that can be used in Structured Headers. Dictionaries and lists are only usable at the "top" level, while the remaining types can be specified appear at the top level or inside those structures.
+{{types}} defines a number of abstract data types that can be used in Structured Headers.
 
-Those abstract types can be serialised into textual headers -- such as those used in HTTP/1 and HTTP/2 -- using the algorithms described in {{text}}.
+Those abstract types can be serialised into and parsed from textual headers -- such as those used in HTTP/1 and HTTP/2 -- using the algorithms described in {{text}}.
 
 
 ## Notational Conventions

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -366,12 +366,11 @@ This section defines how to serialise and parse Structured Headers in HTTP/1 tex
 
 Given a structured defined in this specification:
 
-1. If the structure is a dictionary, let output be the result of Serialising a Dictionary {#ser-dictionary}.
-2. If the structure is a list, let output be the result of Serialising a List {#ser-list}.
-3. If the structure is a parameterised list, let output be the result of Serialising a Parameterised List {#ser-param-list}.
-4. If the structure is an item, let output be the result of Serialising an Item {#ser-item}.
-5. If the structure is anything else (including an identifier), fail serialisation.
-6. Return output.
+1. If the structure is a dictionary, return the result of Serialising a Dictionary {#ser-dictionary}.
+2. If the structure is a list, return the result of Serialising a List {#ser-list}.
+3. If the structure is a parameterised list, return the result of Serialising a Parameterised List {#ser-param-list}.
+4. If the structure is an item, return the result of Serialising an Item {#ser-item}.
+5. Otherwise, fail serialisation.
 
 
 ### Serialising a Dictionary {#ser-dictionary}

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -53,7 +53,7 @@ informative:
 
 --- abstract
 
-This document describes a set of data types and parsing algorithms associated with them that are intended to make it easier and safer to define and handle HTTP header fields. It is intended for use by new specifications of HTTP header fields as well as revisions of existing header field specifications when doing so does not cause interoperability issues.
+This document describes a set of data types and algorithms associated with them that are intended to make it easier and safer to define and handle HTTP header fields. It is intended for use by new specifications of HTTP header fields as well as revisions of existing header field specifications when doing so does not cause interoperability issues.
 
 
 --- note_Note_to_Readers
@@ -74,7 +74,7 @@ Implementations are tracked at <https://github.com/httpwg/wiki/wiki/Structured-H
 
 Specifying the syntax of new HTTP header fields is an onerous task; even with the guidance in {{?RFC7231}}, Section 8.3.1, there are many decisions -- and pitfalls -- for a prospective HTTP header field author.
 
-Once a header field is defined, bespoke parsers for it often need to be written, because each header has slightly different handling of what looks like common syntax.
+Once a header field is defined, bespoke parsers and serialisers often need to be written, because each header has slightly different handling of what looks like common syntax.
 
 This document introduces a set of common data structures for use in HTTP header field values to address these problems. In particular, it defines a generic, abstract model for header field values, along with a concrete serialisation for expressing that model in HTTP/1 {{?RFC7230}} header fields.
 
@@ -100,7 +100,7 @@ shown here.
 
 This document uses the Augmented Backus-Naur Form (ABNF) notation of {{!RFC5234}}, including the DIGIT, ALPHA and DQUOTE rules from that document. It also includes the OWS rule from {{!RFC7230}}.
 
-This document uses algorithms to specify normative parsing behaviours, and ABNF to illustrate expected syntax. Implementations MUST follow the normative algorithms, but MAY vary in implementation so as the behaviours are indistinguishable from specified behaviour. If there is disagreement between the algorithms and ABNF, the specified algorithms take precedence.
+This document uses algorithms to specify normative parsing/serialisation behaviours, and ABNF to illustrate expected syntax. Implementations MUST follow the normative algorithms, but MAY vary in implementation so as the behaviours are indistinguishable from specified behaviour. If there is disagreement between the algorithms and ABNF, the specified algorithms take precedence.
 
 
 # Defining New Structured Headers {#specify}

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -597,6 +597,12 @@ of a Structured Headers. In some circumstances, this will cause parsing to fail,
 
 # Changes
 
+## Since draft-ietf-httpbis-header-structure-05
+
+* Reorganise specification to separate parsing out.
+* Allow referencing specs to use ABNF.
+
+
 ## Since draft-ietf-httpbis-header-structure-04
 
 * Remove identifiers from item.

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -342,7 +342,7 @@ sh_binary = "*" *(base64) "*"
 base64    = ALPHA / DIGIT / "+" / "/" / "="
 ~~~
 
-In HTTP/1 headers, binary content is delimited with asterisks and encoded using base64. For example:
+In HTTP/1 headers, binary content is delimited with asterisks and encoded using base64 ({{!RFC4648}}, Section 4). For example:
 
 ~~~ example
 Example-BinaryHeader: *cHJldGVuZCB0aGlzIGlzIGJpbmFyeSBjb250ZW50Lg==*
@@ -358,38 +358,11 @@ This section defines how to serialise and parse Structured Headers in HTTP/1 tex
 
 ## Serialising Structured Headers into HTTP/1 {#text-serialise}
 
-### Serialising a Dictionary
 
-### Serialising a List
-
-### Serialising a Parameterised List
-
-In HTTP/1 headers, each parameterised identifier is separated by a comma and optional whitespace. Parameters are delimited from each other using semicolons (";"), and equals ("=") delimits the parameter name from its value.
-
-### Serialising an Item
-
-### Serialising a Number
-
-In HTTP/1 headers, floats are allowed a maximum of fifteen digits between the integer and fractional part, with at least one required on each side, along with an optional "-" indicating negative numbers.
-
-
-### Serialising a String
-
-### Serialising an Identifier
 
 ### Serialising Binary Content
 
-The textual HTTP serialisation encodes the data using Base 64 Encoding {{!RFC4648}}, Section 4, and surrounds it with a pair of asterisks ("\*") to delimit from other content.
-
-The encoded data is required to be padded with "=", as per {{!RFC4648}}, Section 3.2. It is
-RECOMMENDED that parsers reject encoded data that is not properly padded, although this might
-not be possible with some base64 implementations.
-
-Likewise, encoded data is required to have pad bits set to zero, as per {{!RFC4648}}, Section 3.5.
-It is RECOMMENDED that parsers fail on encoded data that has non-zero pad bits, although this might
-not be possible with some base64 implementations.
-
-This specification does not relax the requirements in {{!RFC4648}}, Section 3.1 and 3.3; therefore, parsers MUST fail on characters outside the base64 alphabet, and on line feeds in encoded data.
+The encoded data is required to be padded with "=", as per {{!RFC4648}}, Section 3.2. Likewise, encoded data is required to have pad bits set to zero, as per {{!RFC4648}}, Section 3.5.
 
 
 ## Parsing HTTP/1 Header Fields into Structured Headers {#text-parse}
@@ -574,10 +547,15 @@ Given an ASCII string input_string, return binary content. input_string is modif
 2. Discard the first character of input_string.
 3. Let b64_content be the result of removing content of input_string up to but not including the first instance of the character "\*". If there is not a "\*" character before the end of input_string, fail parsing.
 4. Consume the "\*" character at the beginning of input_string.
-5. Let binary_content be the result of Base 64 Decoding {{!RFC4648}} b64_content, synthesising padding if necessary (note the requirements about recipient behaviour in {{binary}}).
+5. Let binary_content be the result of Base 64 Decoding {{!RFC4648}} b64_content, synthesising padding if necessary (note the requirements about recipient behaviour below).
 6. Return binary_content.
 
+As per {{!RFC4648}}, Section 3.2, it is RECOMMENDED that parsers reject encoded data that is not
+properly padded, although this might not be possible in some base64 implementations.
 
+As per {{!RFC4648}}, Section 3.5, it is RECOMMENDED that parsers fail on encoded data that has non-zero pad bits, although this might not be possible in some base64 implementations.
+
+This specification does not relax the requirements in {{!RFC4648}}, Section 3.1 and 3.3; therefore, parsers MUST fail on characters outside the base64 alphabet, and on line feeds in encoded data.
 
 
 # IANA Considerations

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -76,7 +76,7 @@ Specifying the syntax of new HTTP header fields is an onerous task; even with th
 
 Once a header field is defined, bespoke parsers for it often need to be written, because each header has slightly different handling of what looks like common syntax.
 
-This document introduces a set of common data structures for use in HTTP header field values to address these problems. In particular, it defines a generic, abstract model for header field values, along with a concrete serialisation for expressing that model in HTTP/1 {{?RFC7230}} and HTTP/2 {{?RFC7540}} header fields.
+This document introduces a set of common data structures for use in HTTP header field values to address these problems. In particular, it defines a generic, abstract model for header field values, along with a concrete serialisation for expressing that model in HTTP/1 {{?RFC7230}} header fields.
 
 HTTP headers that are defined as "Structured Headers" use the types defined in this specification to define their syntax and basic handling rules, thereby simplifying both their definition by specification writers and handling by implementations.
 
@@ -88,7 +88,7 @@ To specify a header field that is a Structured Header, see {{specify}}.
 
 {{types}} defines a number of abstract data types that can be used in Structured Headers.
 
-Those abstract types can be serialised into and parsed from textual headers -- such as those used in HTTP/1 and HTTP/2 -- using the algorithms described in {{text}}.
+Those abstract types can be serialised into and parsed from textual headers -- such as those used in HTTP/1 -- using the algorithms described in {{text}}.
 
 
 ## Notational Conventions
@@ -160,7 +160,7 @@ This specification defines minimums for the length or number of various structur
 
 # Structured Header Data Types {#types}
 
-This section defines the abstract value types that can be composed into Structured Headers, along with the textual HTTP serialisations of them.
+This section defines the abstract value types that can be composed into Structured Headers. The ABNF provided represents the on-wire format in HTTP/1.
 
 
 ## Dictionaries {#dictionary}
@@ -176,7 +176,7 @@ sh_dictionary  = dict-member *( OWS "," OWS dict-member )
 dict-member = identifier "=" sh_item
 ~~~
 
-In the textual HTTP serialisation, keys and values are separated by "=" (without whitespace), and key/value pairs are separated by a comma with optional whitespace. For example, a header field whose value is defined as a dictionary could look like:
+In HTTP/1 headers, keys and values are separated by "=" (without whitespace), and key/value pairs are separated by a comma with optional whitespace. For example, a header field whose value is defined as a dictionary could look like:
 
 ~~~ example
 Example-DictHeader: foo=1.23, en="Applepie", da=*w4ZibGV0w6ZydGUK=*
@@ -198,7 +198,7 @@ sh_list = list-member *( OWS "," OWS list-member )
 list-member = sh_item
 ~~~
 
-In the textual HTTP serialisation, each member is separated by a comma and optional whitespace. For example, a header field whose value is defined as a list of strings could look like:
+In HTTP/1 headers, each member is separated by a comma and optional whitespace. For example, a header field whose value is defined as a list of strings could look like:
 
 ~~~ example
 Example-StrListHeader: "foo", "bar", "It was the best of times."
@@ -221,7 +221,7 @@ sh_param-list = param-id *( OWS "," OWS param-id )
 param-id   = identifier *( OWS ";" OWS identifier [ "=" sh_item ] )
 ~~~
 
-In the textual HTTP serialisation, each parameterised identifier is separated by a comma and optional whitespace. Parameters are delimited from each other using semicolons (";"), and equals ("=") delimits the parameter name from its value. For example,
+In HTTP/1 headers, each parameterised identifier is separated by a comma and optional whitespace. Parameters are delimited from each other using semicolons (";"), and equals ("=") delimits the parameter name from its value. For example,
 
 ~~~ example
 Example-ParamListHeader: abc_123;a=1;b=2; c, def_456, ghi;q="19";r=foo
@@ -264,8 +264,6 @@ Example-IntegerHeader: 42
 
 Floats are integers with a fractional part, that can be stored as IEEE 754 double precision numbers (binary64) ({{IEEE754}}).
 
-The textual HTTP serialisation of floats allows a maximum of fifteen digits between the integer and fractional part, with at least one required on each side, along with an optional "-" indicating negative numbers.
-
 The ABNF for floats is:
 
 ~~~ abnf
@@ -287,6 +285,8 @@ sh_float    = ["-"] (
 ~~~
 
 Values that do not conform to the ABNF above are invalid, and MUST fail parsing.
+
+In HTTP/1 headers, floats are allowed a maximum of fifteen digits between the integer and fractional part, with at least one required on each side, along with an optional "-" indicating negative numbers.
 
 For example, a header whose value is defined as a float could look like:
 
@@ -310,7 +310,7 @@ unescaped    = %x20-21 / %x23-5B / %x5D-7E
 escaped      = "\" ( DQUOTE / "\" )
 ~~~
 
-The textual HTTP serialisation of strings uses a backslash ("\\") to escape double quotes and backslashes in strings.
+In HTTP/1 headers, strings use a backslash ("\\") to escape double quotes and backslashes.
 
 For example, a header whose value is defined as a string could look like:
 
@@ -374,10 +374,11 @@ Parsers MUST support binary content with at least 16384 octets after decoding.
 
 
 
-# Textual Structured Headers {#text}
+# Structured Headers in HTTP/1 {#text}
 
+This section defines how to serialise and parse Structured Headers in HTTP/1 textual header fields, and protocols compatible with them (e.g., in HTTP/2 {{?RFC7540}} before HPACK {{?RFC7541}} is applied).
 
-## Parsing Textual Header Fields {#text-parse}
+## Parsing HTTP/1 Header Fields {#text-parse}
 
 When a receiving implementation parses textual HTTP header fields (e.g., in HTTP/1 or HTTP/2) that are known to be Structured Headers, it is important that care be taken, as there are a number of edge cases that can cause interoperability or even security problems. This section specifies the algorithm for doing so.
 

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -131,13 +131,14 @@ dictionary ([RFCxxxx], Section Y.Y). Its ABNF is:
 The dictionary MUST contain:
 
 * Exactly one member whose key is "foo", and whose value is an
-  integer ([RFCxxxx], Section Y.Y), indicating the number of foos in
-  the message.
+  integer ([RFCxxxx], Section Y.Y), indicating the number of foos
+  in the message.
 * Exactly one member whose key is "barUrls", and whose value is a
   string ([RFCxxxx], Section Y.Y), conveying the Bar URLs for the
   message. See below for processing requirements.
 
-If the parsed header field does not contain both, it MUST be ignored.
+If the parsed header field does not contain both, it MUST be
+ignored.
 
 "foo" MUST be between 0 and 10, inclusive; other values MUST cause
 the header to be ignored.
@@ -151,8 +152,8 @@ If a member of barURLs is not a valid URI-reference, it MUST cause
 that value to be ignored.
 
 If a member of barURLs is a relative reference ([RFC3986],
-Section 4.2), it MUST be resolved ([RFC3986], Section 5) before being
-used.
+Section 4.2), it MUST be resolved ([RFC3986], Section 5) before
+being used.
 ~~~
 
 This specification defines minimums for the length or number of various structures supported by Structured Headers implementations. It does not specify maximum sizes in most cases, but header authors should be aware that HTTP implementations do impose various limits on the size of individual header fields, the total number of fields, and/or the size of the entire header block.
@@ -179,7 +180,7 @@ member-value   = sh-item
 In HTTP/1, keys and values are separated by "=" (without whitespace), and key/value pairs are separated by a comma with optional whitespace. For example:
 
 ~~~ example
-Example-DictHeader: foo=1.23, en="Applepie", da=*w4ZibGV0w6ZydGUK=*
+Example-DictHeader: en="Applepie", da=*w4ZibGV0w6ZydGUK=*
 ~~~
 
 Typically, a header field specification will define the semantics of individual keys, as well as whether their presence is required or optional. Recipients MUST ignore keys that are undefined or unknown, unless the header field's specification specifically disallows them.
@@ -229,7 +230,7 @@ param-value   = sh-item
 In HTTP/1, each param-id is separated by a comma and optional whitespace (as in Lists), and the parameters are separated by semicolons. For example:
 
 ~~~ example
-Example-ParamListHeader: abc_123;a=1;b=2; c, def_456, ghi;q="19";r=foo
+Example-ParamListHeader: abc_123;a=1;b=2; cdef_456, ghi;q="9";r=w
 ~~~
 
 Parsers MUST support parameterised lists containing at least 1024 members, and support members with at least 256 parameters.
@@ -350,7 +351,7 @@ base64    = ALPHA / DIGIT / "+" / "/" / "="
 In HTTP/1 headers, binary content is delimited with asterisks and encoded using base64 ({{!RFC4648}}, Section 4). For example:
 
 ~~~ example
-Example-BinaryHeader: *cHJldGVuZCB0aGlzIGlzIGJpbmFyeSBjb250ZW50Lg==*
+Example-BinaryHdr: *cHJldGVuZCB0aGlzIGlzIGJpbmFyeSBjb250ZW50Lg==*
 ~~~
 
 Parsers MUST support binary content with at least 16384 octets after decoding.

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -105,17 +105,15 @@ This document uses algorithms to specify normative parsing behaviours, and ABNF 
 
 # Defining New Structured Headers {#specify}
 
-A HTTP header that uses the structures in this specification need to be defined to do so
-explicitly; recipients and generators need to know that the requirements of this document are in
-effect. The simplest way to do that is by referencing this document in its definition.
+To define a HTTP header as a structured header, its specification needs to:
 
-The field's definition will also need to specify the field-value's allowed syntax, in terms of the types described in {{types}}, along with their associated semantics. Syntax definitions are encouraged to use the ABNF rules beginning with "sh_" defined in this specification.
+* Reference this specification. Recipients and generators of the header need to know that the requirements of this document are in effect.
 
-A header field definition cannot relax or otherwise modify the requirements of this specification, or change the nature of its data structures; doing so would preclude handling by generic software.
+* Specify the header field's allowed syntax for values, in terms of the types described in {{types}}, along with their associated semantics. Syntax definitions are encouraged to use the ABNF rules beginning with "sh_" defined in this specification.
 
-However, header field authors are encouraged to clearly state additional constraints upon the syntax, as well as the consequences when those constraints are violated. When Structured Headers parsing fails, the header is discarded (see {{text-parse}}); in most situations, header-specific constraints should do likewise.
+* Specify any additional constraints upon the syntax of the structured sued, as well as the consequences when those constraints are violated. When Structured Headers parsing fails, the header is discarded (see {{text-parse}}); in most situations, header-specific constraints should do likewise.
 
-Such constraints could include additional structure inside those defined here (e.g., a list of URLs {{?RFC3986}} inside a string).
+Note that a header field definition cannot relax the requirements of a structure or its processing; they can only add additional constraints, because doing so would preclude handling by generic software.
 
 For example:
 
@@ -158,11 +156,6 @@ used.
 ~~~
 
 This specification defines minimums for the length or number of various structures supported by Structured Headers implementations. It does not specify maximum sizes in most cases, but header authors should be aware that HTTP implementations do impose various limits on the size of individual header fields, the total number of fields, and/or the size of the entire header block.
-
-Note that specifications using Structured Headers do not re-specify its ABNF or parsing algorithms; instead, they should be specified in terms of its abstract data structures.
-
-Also, empty header field values are not allowed, and therefore parsing for them will fail.
-
 
 
 # Structured Header Data Types {#types}

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -710,6 +710,7 @@ of a Structured Headers. In some circumstances, this will cause parsing to fail,
 
 * Reorganise specification to separate parsing out.
 * Allow referencing specs to use ABNF.
+* Define serialisation algorithms.
 
 
 ## Since draft-ietf-httpbis-header-structure-04


### PR DESCRIPTION
Separate parsing out, and add serialisation. Also, allow referencing specs to use ABNF.