### PR TITLE
Man-in-the-middle protection via SETTINGS

### DIFF
--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -317,8 +317,8 @@ In order to ensure that the TLS connection is direct to the server, rather than
 via a TLS-terminating proxy, each side will separately compute and confirm the
 value of this setting.  The setting is derived from a TLS exporter (see Section
 7.5 of [I-D.ietf-tls-tls13] and {{?RFC5705}} for more details on exporters).
-Clients MAY use an early exporter during their 0-RTT flight, but MUST send an
-updated SETTINGS frame using a regular exporter after the TLS handshake
+Clients MUST NOT use an early exporter during their 0-RTT flight, but MUST send
+an updated SETTINGS frame using a regular exporter after the TLS handshake
 completes.
 
 The exporter is constructed with the following input:
@@ -332,14 +332,13 @@ The exporter is constructed with the following input:
 The resulting exporter is converted to a setting value as:
 
 ~~~
-Exporter & 0x3fffffff | (Early ? 0xc0000000 : 0x80000000)
+(Exporter & 0x3fffffff) | 0x80000000
 ~~~
 
-That is, the most significant bit will always be set, and the next most
-significant bit indicates whether the value is derived from an early exporter.
-Each endpoint will compute the expected value from their peer.  If the setting
-is not received, or if the value received is not the expected value, the
-frames defined in this document SHOULD NOT be sent.
+That is, the most significant bit will always be set, regardless of the value of
+the exporter. Each endpoint will compute the expected value from their peer.  If
+the setting is not received, or if the value received is not the expected value,
+the frames defined in this document SHOULD NOT be sent.
 
 ## Making certificates or requests available {#cert-available}
 

--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -339,7 +339,7 @@ That is, the most significant bit will always be set, and the next most
 significant bit indicates whether the value is derived from an early exporter.
 Each endpoint will compute the expected value from their peer.  If the setting
 is not received, or if the value received is not the expected value, the
-frames defined in this document MUST NOT be sent.
+frames defined in this document SHOULD NOT be sent.
 
 ## Making certificates or requests available {#cert-available}
 

--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -872,7 +872,7 @@ this document.
 
 ## Since draft-ietf-httpbis-http2-secondary-certs-01:
 
-Nothing yet.
+- Use SETTINGS to disable when a TLS-terminating proxy is present (#617,#651)
 
 ## Since draft-ietf-httpbis-http2-secondary-certs-00:
 


### PR DESCRIPTION
Fixes #617.

Specifies an exporter-derived value in SETTINGS to prove that the TLS connection is between the same endpoints as the HTTP connection.  If there is a TLS-terminating proxy intermediating the connection, the expected value will not match the received value, and the work of producing exported authenticators can be skipped.

One open question is around the use of early exporters.  I think this is probably something we want, so that servers can send additional certificates in their 0.5-RTT flight to 0-RTT clients.  However, should clients be required to supply a value derived from a regular exporter after the handshake finishes?  This is a minor pain in H2, but in HTTP/QUIC would require defining a separate frame type to carry the updated token.  The obvious value is that the server could still validate the token after forgetting the 0-RTT secret, but it seems like the server could as easily validate the setting early and remember the result even after discarding the secret.  Is there any additional security benefit to the client re-proving the connection is end-to-end after the handshake completes?