### PR TITLE
Clients use Empty Authenticator as well

### DIFF
--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -420,6 +420,13 @@ Client                                      Server
 ~~~
 {: #ex-http2-server-requested title="Client-Requested Certificate"}
 
+If a client receives a `PUSH_PROMISE` referencing an origin for which it has not
+yet received the server's certificate, this is a fatal connection error (see
+section 8.2 of [RFC7540]).  To avoid this, servers MUST supply the associated
+certificates before pushing resources from a different origin.
+
+### Requiring additional client certificates
+
 Likewise, the server sends a `CERTIFICATE_NEEDED` frame for each stream where
 certificate authentication is required.  The client answers with a
 `USE_CERTIFICATE` frame indicating the certificate to use on that stream. If the
@@ -438,11 +445,6 @@ Client                                      Server
    <----------------------- (stream N) 200 OK --
 ~~~
 {: #ex-http2-client-requested title="Reactive Certificate Authentication"}
-
-If a client receives a `PUSH_PROMISE` referencing an origin for which it has not
-yet received the server's certificate, this is a fatal connection error (see
-section 8.2 of [RFC7540]).  To avoid this, servers MUST supply the associated
-certificates before pushing resources from a different origin.
 
 # Certificates Frames for HTTP/2 {#certs-http2}
 

--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -446,6 +446,15 @@ Client                                      Server
 ~~~
 {: #ex-http2-client-requested title="Reactive Certificate Authentication"}
 
+If the client does not have the desired certificate, it instead sends an Empty
+Authenticator, as described in Section 5 of
+[I-D.ietf-tls-exported-authenticator], in a `CERTIFICATE` frame in response to
+the request, followed by a `USE_CERTIFICATE` frame which references the Empty
+Authenticator.  In this case, or if the client has not advertised support for
+HTTP-layer certificates, the server processes the request based solely on the
+certificate provided during the TLS handshake, if any.  This might result in an
+error response via HTTP, such as a status code 403 (Not Authorized).
+
 # Certificates Frames for HTTP/2 {#certs-http2}
 
 The `CERTIFICATE_REQUEST` and `CERTIFICATE_NEEDED` frames are correlated by


### PR DESCRIPTION
Follow-on to #586; in the process of fixing this, I noticed that I'd added a "server" header but missed adding a corresponding "client" header, so the client discussion appeared in the server section.