### PR TITLE
Fix VCHAR references in draft-ietf-httpbis-header-structure.md

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -98,7 +98,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 described in BCP 14 {{!RFC2119}} {{!RFC8174}} when, and only when, they appear in all capitals, as
 shown here.
 
-This document uses the Augmented Backus-Naur Form (ABNF) notation of {{!RFC5234}}, including the VCHAR, DIGIT, ALPHA and DQUOTE rules from that document. It also includes the OWS rule from {{!RFC7230}}.
+This document uses the Augmented Backus-Naur Form (ABNF) notation of {{!RFC5234}}, including the VCHAR, SP, DIGIT, ALPHA and DQUOTE rules from that document. It also includes the OWS rule from {{!RFC7230}}.
 
 This document uses algorithms to specify parsing and serialisation behaviours, and ABNF to illustrate expected syntax.
 
@@ -654,7 +654,7 @@ Given an ASCII string input_string, return an unquoted string. input_string is m
          2. If next_char is not DQUOTE or "\\", fail parsing.
          3. Append next_char to output_string.
    3. Else, if char is DQUOTE, return output_string.
-   4. Else, if char is in the range %x00-1f or %x7f (i.e., is not in VCHAR), fail parsing.
+   4. Else, if char is in the range %x00-1f or %x7f (i.e., is not in VCHAR or SP), fail parsing.
    4. Else, append char to output_string.
 6. Otherwise, fail parsing.
 

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -464,7 +464,7 @@ Given a float as input:
 
 Given a string as input:
 
-0. If input is not a sequence of characters, or contains characters outside the range allowed by VCHAR, fail serialisation.
+0. If input is not a sequence of characters, or contains characters outside the range allowed by VCHAR or SP, fail serialisation.
 1. Let output be an empty string.
 2. Append DQUOTE to output.
 3. For each character char in input:


### PR DESCRIPTION
Fix #664. Step 4.4 equates "the range %x00-1f or %x7f" to "not in VCHAR", but VCHAR doesn't include %x20; this change adds "or SP" and imports SP from RFC5234.