### PR TITLE
Disallow trailing whitespace in #parse-param-list

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -572,8 +572,8 @@ Given an ASCII string input_string, return a list of parameterised identifiers. 
 2. While input_string is not empty:
    1. Let item be the result of running Parse Parameterised Identifier from Text ({{parse-param-id}}) with input_string.
    2. Append item to items.
-   3. Discard any leading OWS from input_string.
-   4. If input_string is empty, return items.
+   3. If input_string is empty, return items.
+   4. Discard any leading OWS from input_string.
    5. Consume the first character of input_string; if it is not COMMA, fail parsing.
    6. Discard any leading OWS from input_string.
    7. If input_string is empty, fail parsing.


### PR DESCRIPTION
This corresponds with the ABNF in the #param section.