### PR TITLE
[SH] make 'parse number from text' less greedy

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -627,7 +627,7 @@ NOTE: This algorithm parses both Integers {{integer}} and Floats {{float}}, and 
    1. Let char be the result of removing the first character of input_string.
    2. If char is a DIGIT, append it to input_number.
    3. Else, if type is "integer" and char is ".", append char to input_number and set type to "float".
-   4. Otherwise, fail parsing.
+   4. Otherwise, exit the loop.
    5. If type is "integer" and input_number contains more than 19 characters, fail parsing.
    6. If type is "float" and input_number contains more than 16 characters, fail parsing.
 8. If type is "integer":

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -627,7 +627,7 @@ NOTE: This algorithm parses both Integers {{integer}} and Floats {{float}}, and 
    1. Let char be the result of removing the first character of input_string.
    2. If char is a DIGIT, append it to input_number.
    3. Else, if type is "integer" and char is ".", append char to input_number and set type to "float".
-   4. Otherwise, exit the loop.
+   4. Otherwise, prepend char to input_string, and exit the loop.
    5. If type is "integer" and input_number contains more than 19 characters, fail parsing.
    6. If type is "float" and input_number contains more than 16 characters, fail parsing.
 8. If type is "integer":


### PR DESCRIPTION
Makes "Parse a Number from Text" not be greedy, and return (not fail) when it encounters a non-digit character.

Resolves #668 