### PR TITLE
Adding a note about 303 See Other

### DIFF
--- a/draft-ietf-httpbis-bcp56bis.md
+++ b/draft-ietf-httpbis-bcp56bis.md
@@ -558,6 +558,11 @@ This table summarises their relationships:
 | Allows changing the request method from POST to GET | 301       | 302       |
 | Does not allow changing the request method          | 308       | 307       |
 
+A common use-case for redirects that change the request method to GET, is communicate to a browser
+that the result of an operation can be found at a different location. The appropriate status code
+for this is 303 See Other. This status code is widely supported and the recommended status code
+for these purposes.
+
 As noted in {{?I-D.ietf-httpbis-semantics}}, a user agent is allowed to automatically follow a 3xx
 redirect that has a Location response header field, even if they don't understand the semantics of
 the specific status code. However, they aren't required to do so; therefore, if an application

--- a/draft-ietf-httpbis-bcp56bis.md
+++ b/draft-ietf-httpbis-bcp56bis.md
@@ -558,10 +558,10 @@ This table summarises their relationships:
 | Allows changing the request method from POST to GET | 301       | 302       |
 | Does not allow changing the request method          | 308       | 307       |
 
-A common use-case for redirects that change the request method to GET, is communicate to a browser
+A common use-case for redirects that change the request method to GET is to communicate to the browser
 that the result of an operation can be found at a different location. The appropriate status code
-for this is 303 See Other. This status code is widely supported and the recommended status code
-for these purposes.
+for this is 303 See Other. This status code is widely supported and is the recommended status code
+for such purposes.
 
 As noted in {{?I-D.ietf-httpbis-semantics}}, a user agent is allowed to automatically follow a 3xx
 redirect that has a Location response header field, even if they don't understand the semantics of


### PR DESCRIPTION
I noticed in my testing that 303 See Other works pretty much everywhere. A very common case for application developers is to send browsers a redirect after a POST. Almost every framework will default to using 302 for this, but really they should be using 303.

Let me know if you don't like the wording, happy to make edits.