### PR TITLE
[SH] make boolean ABNF case-sensitive

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -385,7 +385,7 @@ The ABNF for a Boolean in HTTP/1 headers is:
 
 ~~~ abnf
 sh-boolean = "?" boolean
-boolean    = "T" / "F"
+boolean    = %54 / %56  ; capital "T" or "F"
 ~~~
 
 In HTTP/1 headers, a byte sequence is indicated with a leading "?" character. For example:


### PR DESCRIPTION
the `boolean` ABNF rule is case-*in*sensitive, but the algorithm for parsing (and the test case in the separate repo) enforce capitals only.