### PR TITLE
bcp56bis: redirects

### DIFF
--- a/draft-ietf-httpbis-bcp56bis.md
+++ b/draft-ietf-httpbis-bcp56bis.md
@@ -529,9 +529,9 @@ of an application's specification.
 
 ### Redirection {#redirects}
 
-The 3xx series of status codes specified in {{!I-D.ietf-httpbis-semantics}}, Section 9.4 direct the
+The 3xx series of status codes specified in Section 9.4 {{!I-D.ietf-httpbis-semantics}} direct the
 user agent to another resource to satisfy the request. The most common of these are 301, 302, 307
-and 308 ({{?RFC7538}}), all of which use the Location response header field to indicate where the
+and 308, all of which use the Location response header field to indicate where the
 client should send the request to.
 
 There are two ways that this group of status codes differ:


### PR DESCRIPTION
- fix one reference
- drop 308 reference, it's now in the base spec