### PR TITLE
Convert Variants to use Structured Headers.

### DIFF
--- a/draft-ietf-httpbis-variants.md
+++ b/draft-ietf-httpbis-variants.md
@@ -219,6 +219,8 @@ Variant-Key: gzip;fr, "identity";fr
 
 indicates that this response can be used for requests whose Accept-Encoding algorithm selects "gzip" or "identity", as long as the Accept-Language algorithm selects "fr" -- perhaps because there is no gzip-compressed French representation.
 
+When more than one Variant-Key value is in a response, the first one present MUST correspond to the request that caused that response to be generated.
+
 Parsing is strict. For example:
 
 ~~~ example

--- a/draft-ietf-httpbis-variants.md
+++ b/draft-ietf-httpbis-variants.md
@@ -248,8 +248,8 @@ Given incoming-request (a mapping of field-names to lists of field values), and 
 1. If stored-responses is empty, return an empty list.
 2. Order stored-responses by the "Date" header field, most recent to least recent.
 3. Let sorted-variants be an empty list.
-4. If the freshest member of stored-responses (as per {{!RFC7234}}, Section 4.2) has one or more "Variants" header field(s):
-   1. Select one member of stored-responses and let variants-header be its "Variants" header field-value(s), parsed according to {{variants}}. This SHOULD be the most recent response, but MAY be from an older one as long as it is still fresh.
+4. If the freshest member of stored-responses (as per {{!RFC7234}}, Section 4.2) has one or more "Variants" header field(s) that successfully parse according to {{variants}}:
+   1. Select one member of stored-responses with a "Variants" header field-value(s) that successfully parses according to {{variants}} and let variants-header be this parsed value. This SHOULD be the most recent response, but MAY be from an older one as long as it is still fresh.
    2. For each variant-axis in variants-header:
       1. If variant-axis' field-name corresponds to the request header field identified by a content negotiation mechanism that the implementation supports:
          1. Let request-value be the field-value associated with field-name in incoming-request (after being combined as allowed by Section 3.2.2 of {{RFC7230}}), or null if field-name is not in incoming-request.


### PR DESCRIPTION
Fixes #570. I think this also fixes #743, but I might have missed something.

Misc changes that aren't actually necessary to use Structured Headers:

* "variant-item" became "variant-axis".
* I defined what clients ("caches"?) MUST do when a server violates one of its MUSTs.
* I removed the (incorrect) `token / "/" / "?" / "\" / "[" / "]" / ":" / "@" / "(" / ")"` definition of available-value in favor of allowing arbitrary [Structured Header strings](https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#string). It wasn't clear what excluding characters like `{` was gaining us, and the restriction would have required extra words when parsing the headers.
* I removed {{gen-variant-key}} entirely and had Compute Possible Keys return a list of lists that could be directly compared against the Structured Header parse of `Variant-Key`. It would be difficult to keep the old behavior of returning a list of strings without re-adding some restriction on an available-value, for example by requiring that they don't contain spaces.
* I simplified Compute Possible Keys a bit.