### PR TITLE
Clarify TLS 1.3 post-handshake auth with HTTP/2

### DIFF
--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -39,6 +39,7 @@ normative:
   I-D.ietf-tls-exported-authenticator:
 
 informative:
+  RFC7301:
   RFC7838:
 
 
@@ -231,6 +232,14 @@ identifier could be added to TLS 1.2 by means of an extension to TLS.
 Unfortunately, many TLS 1.2 implementations do not permit application data to
 continue during a renegotiation. This is problematic for a multiplexed protocol
 like HTTP/2.
+
+TLS 1.3's post-handshake client authentication mechanism shares similar problems
+for use with HTTP/2. HTTP/2 clients that offer multiple ALPN {{RFC7301}}
+protocols in a TLS ClientHello MAY include the `post_handshake_auth` extension
+to support those other protocols, but this does not indicate support for
+post-handshake client authentication in HTTP/2. HTTP/2 servers MUST NOT send
+post-handshake TLS CertificateRequest messages, even if the client offered the
+`post_handshake_auth` extension.
 
 ## HTTP-Layer Certificate Authentication
 


### PR DESCRIPTION
HTTP/2 blocked renegotiation for a number of reasons. Among other
problems, as this document notes in section 1.2.3, there is no defined
way to correlate application-visible renegotiation events
(CertificateRequest) with HTTP/2 requests. In essence, the prohibition
is a reflection of TLS+renegotiation being the wrong API shape for
HTTP/2 (and most protocols).

TLS 1.3 removed renegotiation, but added post-handshake client
authentication to replace some of renegotiation's use cases. This
retains the problems above. However, with the feature renamed,
RFC7540's prohibition no longer applies and we're stuck with an
incompatibility between RFC8446 and RFC7540.

Post-handshake authentication is optional in TLS 1.3 and advertised with
an extension, but this is not sufficient. Most HTTP/2 clients are also
HTTP/1.1 clients and TLS parameters are negotiated in parallel. An
HTTP/1.1+HTTP/2 client that advertises the extension for HTTP/1.1 (see
section 1.2.2 of this document) also advertises it for HTTP/2.

By a strict composition of the existing specification text,
HTTP/2-capable clients cannot offer post-handshake authentication to
HTTP/1.1 servers.

In reality, existing HTTP/2 servers won't use this mechanism because no
one has defined a request correlation. Thus we can fix all this by
clarifying that TLS 1.3 post-handshake auth is forbidden whether or not
the client offered it.

If some future use case comes up, it can define an overriding extension
with a correlation mechanism. It would already need to do so, because
existing clients wouldn't know about the correlation. This is unlikely
to happen anyway because this document *is* that use case, and it
already defines a separate mechanism.