### PR TITLE
RFC6265bis: Allow `SameSite` cookies to be set for all top-level navigation

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1463,7 +1463,7 @@ user agent MUST process the cookie as follows:
 
         Note: Top-level navigations can create a cookie with any `SameSite`
         value, even if the new cookie wouldn't have been delivered along with
-        the request had it existed.
+        the request had it already existed prior to the navigation.
 
     4.  Abort these steps and ignore the newly created cookie entirely.
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2089,6 +2089,11 @@ Specification document:
 *  Introduced an explicit "None" value for the SameSite attribute:
    <https://github.com/httpwg/http-extensions/issues/788>
 
+## draft-ietf-httpbis-rfc6265bis-04
+
+*  Allow `SameSite` cookies to be set for all top-level navigations.
+   <https://github.com/httpwg/http-extensions/issues/594>
+
 # Acknowledgements
 {:numbered="false"}
 This document is a minor update of RFC 6265, adding small features, and

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1462,7 +1462,7 @@ user agent MUST process the cookie as follows:
         and continue processing the cookie.
 
         Note: Top-level navigations can create a cookie with any `SameSite`
-        value, even if the new cookie wouldn't have been delivered along with
+        value, even if the new cookie wouldn't have been sent along with
         the request had it already existed prior to the navigation.
 
     4.  Abort these steps and ignore the newly created cookie entirely.

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1444,10 +1444,29 @@ user agent MUST process the cookie as follows:
     attribute-value (i.e. either "Strict", "Lax", or "None"). Otherwise, set the
     cookie's same-site-flag to "None".
 
-14. If the cookie's `same-site-flag` is not "None", and the cookie is being set
-    from a context whose "site for cookies" is not an exact match for
-    request-uri's host's registered domain, then abort these steps and ignore
-    the newly created cookie entirely.
+14. If the cookie's `same-site-flag` is not "None":
+
+    1.  If the cookie was received from a "non-HTTP" API, and the API was called
+        from a context whose "site for cookies" is not an exact match for
+        request-uri's host's regisgered domain, then abort these steps and
+        ignore the newly created cookie entirely.
+
+    2.  If the cookie was received from a "same-site" request (as defined in
+        {{same-site-requests}}), skip the remaining substeps and continue
+        processing the cookie.
+
+    3.  If the cookie's `same-site-flag` is "Lax", and the cookie was received
+        from a request which is navigating a top-level browsing context {{HTML}}
+        (e.g. if the request's "reserved client" is either `null` or an
+        environment whose target browsing context is a top-level browing context
+        {{FETCH}}), skip the remaining substeps and continue processing the
+        cookie.
+
+    4.  Abort these steps and ignore the newly created cookie entirely.
+
+        Note: This includes cookies set with `SameSite=Strict` from any
+        non-same-site context, as well as cookies set with `SameSite=Lax` from a
+        context that is neither same-site nor a top-level navigation.
 
 15. If the cookie-name begins with a case-sensitive match for the string
     "__Secure-", abort these steps and ignore the cookie entirely unless the

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1448,25 +1448,24 @@ user agent MUST process the cookie as follows:
 
     1.  If the cookie was received from a "non-HTTP" API, and the API was called
         from a context whose "site for cookies" is not an exact match for
-        request-uri's host's regisgered domain, then abort these steps and
+        request-uri's host's registered domain, then abort these steps and
         ignore the newly created cookie entirely.
 
     2.  If the cookie was received from a "same-site" request (as defined in
         {{same-site-requests}}), skip the remaining substeps and continue
         processing the cookie.
 
-    3.  If the cookie's `same-site-flag` is "Lax", and the cookie was received
-        from a request which is navigating a top-level browsing context {{HTML}}
-        (e.g. if the request's "reserved client" is either `null` or an
-        environment whose target browsing context is a top-level browing context
-        {{FETCH}}), skip the remaining substeps and continue processing the
-        cookie.
+    3.  If the cookie was received from a request which is navigating a
+        top-level browsing context {{HTML}} (e.g. if the request's "reserved
+        client" is either `null` or an environment whose "target browsing
+        context" is a top-level browing context), skip the remaining substeps
+        and continue processing the cookie.
+
+        Note: Top-level navigations can create a cookie with any `SameSite`
+        value, even if the new cookie wouldn't have been delivered along with
+        the request had it existed.
 
     4.  Abort these steps and ignore the newly created cookie entirely.
-
-        Note: This includes cookies set with `SameSite=Strict` from any
-        non-same-site context, as well as cookies set with `SameSite=Lax` from a
-        context that is neither same-site nor a top-level navigation.
 
 15. If the cookie-name begins with a case-sensitive match for the string
     "__Secure-", abort these steps and ignore the cookie entirely unless the


### PR DESCRIPTION
Based on the discussion in httpwg/http-extensions#594, this patch aligns
the specification with Firefox's status quo behavior: allowing
`SameSite=*` cookies to be set from all top-level navigations, not just
navigations for which `SameSite=*` cookies would also be sent.