### PR TITLE
Structured Headers: Allow lists as dictionary values.

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -181,7 +181,7 @@ This section defines the abstract value types that can be composed into Structur
 
 ## Dictionaries {#dictionary}
 
-Dictionaries are ordered maps of key-value pairs, where the keys are short, textual strings and the values are items ({{item}}) or lists thereof ({{list}}). There can be one or more members, and keys are required to be unique.
+Dictionaries are ordered maps of key-value pairs, where the keys are short, textual strings and the values are items ({{item}}) or arrays thereof. There can be one or more members, and keys are required to be unique.
 
 Implementations MUST provide access to dictionaries both by index and by key. Specifications MAY use either means of accessing the members.
 
@@ -191,7 +191,7 @@ The ABNF for dictionaries in HTTP/1 headers is:
 sh-dictionary  = dict-member *( OWS "," OWS dict-member )
 dict-member    = member-name "=" member-value
 member-name    = key
-member-value   = sh-item | inner-list
+member-value   = sh-item / inner-list
 key            = lcalpha *( lcalpha / DIGIT / "_" / "-" )
 lcalpha        = %x61-7A ; a-z
 ~~~

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -896,7 +896,7 @@ Structured headers intentionally limits the complexity of data structures, to as
 Sometimes, this can be achieved by creating limited substructures in values, and/or using more than one header. For example, consider:
 
 ~~~
-Example-Thing: name="Widget", cost=89.2, descriptions="foo bar"
+Example-Thing: name="Widget", cost=89.2, descriptions=foo;bar
 Example-Description: foo; url="https://example.net"; context=123,
                      bar; url="https://example.org"; context=456
 ~~~

--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -181,7 +181,7 @@ This section defines the abstract value types that can be composed into Structur
 
 ## Dictionaries {#dictionary}
 
-Dictionaries are ordered maps of key-value pairs, where the keys are short, textual strings and the values are items ({{item}}). There can be one or more members, and keys are required to be unique.
+Dictionaries are ordered maps of key-value pairs, where the keys are short, textual strings and the values are items ({{item}}) or lists thereof ({{list}}). There can be one or more members, and keys are required to be unique.
 
 Implementations MUST provide access to dictionaries both by index and by key. Specifications MAY use either means of accessing the members.
 
@@ -191,15 +191,15 @@ The ABNF for dictionaries in HTTP/1 headers is:
 sh-dictionary  = dict-member *( OWS "," OWS dict-member )
 dict-member    = member-name "=" member-value
 member-name    = key
-member-value   = sh-item
+member-value   = sh-item | inner-list
 key            = lcalpha *( lcalpha / DIGIT / "_" / "-" )
 lcalpha        = %x61-7A ; a-z
 ~~~
 
-In HTTP/1, keys and values are separated by "=" (without whitespace), and key/value pairs are separated by a comma with optional whitespace. For example:
+In HTTP/1, keys and values are separated by "=" (without whitespace), and key/value pairs are separated by a comma with optional whitespace. Each member of a list value is separated by a semicolon and optional whitespace. For example:
 
 ~~~ example
-Example-DictHeader: en="Applepie", da=*w4ZibGV0w6ZydGU=*
+Example-DictHeader: en="Applepie", li=item1;item2, da=*w4ZibGV0w6ZydGU=*
 ~~~
 
 Typically, a header field specification will define the semantics of individual keys, as well as whether their presence is required or optional. Recipients MUST ignore keys that are undefined or unknown, unless the header field's specification specifically disallows them.
@@ -924,6 +924,7 @@ _RFC Editor: Please remove this section before publication._
 ## Since draft-ietf-httpbis-header-structure-10
 
 * Update abstract (#799).
+* Support lists as dictionary member values (#816).
 
 
 ## Since draft-ietf-httpbis-header-structure-09


### PR DESCRIPTION
This patch allows 'inner-list' as a valid dictionary member value. Fixes #816.