### PR TITLE
[SH] reference IEEE 754-2019

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -38,17 +38,16 @@ normative:
 
 informative:
   IEEE754:
-    target: http://ieeexplore.ieee.org/document/4610935/
+    target: https://ieeexplore.ieee.org/document/8766229
     title: IEEE Standard for Floating-Point Arithmetic
     author:
     -
       organization: IEEE
-    date: 2008-08
+    date: 2019-07
     seriesinfo:
-      IEEE: 754-2008
-      DOI:  10.1109/IEEESTD.2008.4610935
-      ISBN: 978-0-7381-5752-8
-    annotation: See also <http://grouper.ieee.org/groups/754/>.
+      IEEE: 754-2019
+      DOI:  10.1109/IEEESTD.2019.8766229
+      ISBN: 978-1-5044-5924-2
 
   UTF-8:
     title: UTF-8, a transformation format of ISO 10646


### PR DESCRIPTION
Incidentally fixes in #918 by removing the annotation.

According to IEEE's site and references the target should be <https://ieeexplore.ieee.org/servlet/opac?punumber=8766227> but I've kept the equivalent of the current address.