### PR TITLE
Fix: #936. Cache semantics impacts on Digest and on the representation.

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -237,7 +237,7 @@ transformations (eg. transfer codings for HTTP/1.1 see 6.1 of
 
 A representation digest consists of
 the value of a checksum computed on the entire selected `representation data`
-(see Section 7 of {{SEMANTICS}}) of a resource identified as per (see Section 7.3.2 of {{SEMANTICS}})
+(see Section 7 of {{SEMANTICS}}) of a resource identified according to Section 7.3.2 of {{SEMANTICS}}
 together with an indication of the algorithm used (and any parameters)
 
 ~~~ abnf
@@ -281,9 +281,6 @@ validation instead of verifying every received representation-data-digest.
 A sender MAY send a representation-data-digest using a digest-algorithm without
 knowing whether the recipient supports the digest-algorithm, or even knowing
 that the recipient will ignore it.
-
-Digest MAY be cached and the freshness information of the resource, eventually conveyed by validator
- header fields or other cache headers, apply to its value too.
 
 Digest can be sent in a trailer section. When using incremental digest-algorithms
 this allows the sender and the receiver to dynamically compute the digest value

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -282,8 +282,8 @@ A sender MAY send a representation-data-digest using a digest-algorithm without
 knowing whether the recipient supports the digest-algorithm, or even knowing
 that the recipient will ignore it.
 
-Digest MAY be cached and the freshness information of the resource eventually conveyed by validator
- header fields or other cache headers apply to its value too.
+Digest MAY be cached and the freshness information of the resource, eventually conveyed by validator
+ header fields or other cache headers, apply to its value too.
 
 Digest can be sent in a trailer section. When using incremental digest-algorithms
 this allows the sender and the receiver to dynamically compute the digest value

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -236,7 +236,8 @@ transformations (eg. transfer codings for HTTP/1.1 see 6.1 of
 {{resource-representation}} contains several examples to help illustrate those effects.
 
 A representation digest consists of
-the value of a checksum computed on the entire selected `representation data` of a resource
+the value of a checksum computed on the entire selected `representation data`
+(see Section 7 of {{SEMANTICS}}) of a resource identified as per (see Section 7.3.2 of {{SEMANTICS}})
 together with an indication of the algorithm used (and any parameters)
 
 ~~~ abnf
@@ -263,9 +264,6 @@ response.
    Digest = "Digest" ":" OWS 1#representation-data-digest
 ~~~
 
-The resource is specified by the effective request URI and any `validator field`
-contained in the message.
-
 The relationship between Content-Location (see Section 7.2.5 of
 {{SEMANTICS}}) and Digest is demonstrated in
 {{post-not-request-uri}}. A comprehensive set of examples showing the impacts of
@@ -283,6 +281,9 @@ validation instead of verifying every received representation-data-digest.
 A sender MAY send a representation-data-digest using a digest-algorithm without
 knowing whether the recipient supports the digest-algorithm, or even knowing
 that the recipient will ignore it.
+
+Digest MAY be cached and the freshness information of the resource eventually conveyed by validator
+ header fields or other cache headers apply to its value too.
 
 Digest can be sent in a trailer section. When using incremental digest-algorithms
 this allows the sender and the receiver to dynamically compute the digest value


### PR DESCRIPTION
## This PR

Clarifies the following points:

- resource identification is inherited from SEMANTICS
- validator fields (ETags & Last Modified) which apply to the identified resource, apply to Digest too.