### PR TITLE
Specify recommended HTTP status code for connnection_limit_reached

### DIFF
--- a/draft-ietf-httpbis-proxy-status.md
+++ b/draft-ietf-httpbis-proxy-status.md
@@ -212,7 +212,7 @@ This section lists the Proxy Status Types defined by this document. See {{regist
 * Name: connnection_limit_reached
 * Description: The intermediary is configured to limit the number of connections it has to the next hop, and that limit has been passed.
 * Extra Parameters: None.
-* Recommended HTTP status code:
+* Recommended HTTP status code: 503
 
 ## HTTP Response Status
 


### PR DESCRIPTION
Rationale for 503 is that the service is unavailable due to too many
connections.

429 could potentially be an option as well, but that seems more specific to a single user hitting a rate limit, while `connnection_limit_reached` seems more related to a global limit.

/cc @mnot @PiotrSikora 