### PR TITLE
Stop over-caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ jobs:
       - restore_cache:
           name: "Restoring cache - Git"
           keys:
-            - v1-cache-git-{{ .Branch }}-{{ .Revision }}
-            - v1-cache-git-{{ .Branch }}
-            - v1-cache-git-master
-            - v1-cache-git-
+            - v2-cache-git-{{ .Branch }}-{{ .Revision }}
+            - v2-cache-git-{{ .Branch }}
+            - v2-cache-git-master
+            - v2-cache-git-
 
       - restore_cache:
           name: "Restoring cache - References"
@@ -69,9 +69,9 @@ jobs:
 
       - save_cache:
           name: "Saving Cache - Git"
-          key: v1-cache-git-{{ .Branch }}-{{ .Revision }}
+          key: v2-cache-git-{{ .Branch }}-{{ .Revision }}
           paths:
-            - ~/draft
+            - ~/draft/.git
 
       - save_cache:
           name: "Saving Cache - Drafts"


### PR DESCRIPTION
I think that narrowing this to `.git` should suffice.  A copy of the i-d-template and Julian's XSLT repositories are cached in the docker image.