### PR TITLE
Fix caching for tags by fetching them first

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,16 @@ jobs:
             - v1-cache-references-{{ epoch }}
             - v1-cache-references-
 
+      # Workaround for https://discuss.circleci.com/t/22437 (works for public repos only)
+      - run:
+          name: Checkout Workaround
+          command: |
+            if [ -n "$CIRCLE_TAG" ] && [ -d .git ]; then
+              git fetch -f $(echo "$CIRCLE_REPOSITORY_URL" | \
+                             sed -e 's,/^git.github.com:,https://github.com/,') \
+                        "refs/tags/$CIRCLE_TAG:refs/tags/$CIRCLE_TAG"
+            fi
+
       - checkout
 
       # Build txt and html versions of drafts


### PR DESCRIPTION
The caching of `.git` leads to interesting issues on circle, which has a bug in its checkout logic for tags.  This works around that by pulling instead.  That's complicated by the fact that circle insists on using SSH for pulls.  That is great for ensuring that they can pull private repos, but this workaround - which runs before the circle key is available - can't use that and the origin is configured poorly.