### PR TITLE
Fix: #980. Clarify binary payload is b64 encoded

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -234,7 +234,7 @@ the intermediaries may apply.
 The following examples show how representation metadata, payload transformations and method
 impacts on the message and payload body.
 When the payload body contains non-printable characters (eg. when it is compressed)
-it is shown as base64 encoded.
+it is shown as base64-encoded string.
 
 Here is a gzip-compressed json object
 
@@ -720,6 +720,9 @@ The response includes a `Content-Encoding: br` that indicates
 the selected representation is brotli encoded.
 The `Digest` field-value is therefore different compared to the request.
 
+The response body is displayed as a base64-encoded string
+because it contains non-printable characters.
+
 Request:
 
 ~~~
@@ -741,8 +744,6 @@ Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=
 
 iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 ~~~
-
-The above payload body contains non-printable characters and it is shown as base64 encoded.
 
 
 ## Client Provides Full Representation Data, Server Provides No Representation Data
@@ -784,6 +785,8 @@ The response contains two digest values:
   matches the unencoded digest-value sent in the request;
 - one taking into account the `Content-Encoding`.
 
+As the response body contains non-printable characters, it is displayed as a base64-encoded string.
+
 Request:
 
 ~~~
@@ -807,7 +810,6 @@ Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=, id-sha-256=X48E9qO
 iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 ~~~
 
-The above payload body contains non-printable characters and it is shown as base64 encoded.
 
 ## POST Response does not Reference the Request URI {#post-not-request-uri}
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -233,6 +233,8 @@ the intermediaries may apply.
 
 The following examples show how representation metadata, payload transformations and method
 impacts on the message and payload body.
+When the payload body contains non-printable characters (eg. when it is compressed)
+it is shown as base64 encoded.
 
 Here is a gzip-compressed json object
 
@@ -740,6 +742,8 @@ Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=
 iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 ~~~
 
+The above payload body contains non-printable characters and it is shown as base64 encoded.
+
 
 ## Client Provides Full Representation Data, Server Provides No Representation Data
 
@@ -802,6 +806,8 @@ Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=, id-sha-256=X48E9qO
 
 iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 ~~~
+
+The above payload body contains non-printable characters and it is shown as base64 encoded.
 
 ## POST Response does not Reference the Request URI {#post-not-request-uri}
 


### PR DESCRIPTION
## This PR

clarify editorial rendering of binary payloads