### PR TITLE
[RFC6265bis, Editorial] Consistently use 'last-access-time'.

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1537,7 +1537,7 @@ agent MUST evict cookies in the following priority order:
 4.  All cookies.
 
 If two cookies have the same removal priority, the user agent MUST evict the
-cookie with the earliest last-access date first.
+cookie with the earliest last-access-time first.
 
 When "the current session is over" (as defined by the user agent), the user
 agent MUST remove from the cookie store all cookies with the persistent-flag


### PR DESCRIPTION
Closes #1032.

@johnwilander @bagder, mind taking a look? John, in particular, you noted "But we should also have an explicit reference in my opinion.", which I didn't really understand. Do you want more than this patch?