### PR TITLE
make serialise decimal algo round early, fail fast

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -621,17 +621,18 @@ Given an integer as input_integer, return an ASCII string suitable for use in a 
 
 ### Serializing a Decimal {#ser-decimal}
 
-Given a decimal_number as input_decimal, return an ASCII string suitable for use in a HTTP header value.
+Given a decimal number as input_decimal, return an ASCII string suitable for use in a HTTP header value.
 
-1. Let output be an empty string.
-2. If input_decimal is less than (but not equal to) 0, append "-" to output.
-3. Append input_decimal's integer component represented in base 10 (using only decimal digits) to output; if it is zero, append "0".
-4. If the number of characters appended in the previous step is greater than 12, fail serialisation.
-5. Append "." to output.
-6. If input_decimal's fractional component is zero, append "0" to output.
-7. Else if input_decimal's fractional component has up to three digits, append them represented in base 10 (using only decimal digits) to output.
-8. Otherwise, append the first three digits of input_decimal's fractional component (represented in base 10, using only decimal digits) to output, rounding the final digit to the nearest value, or to the even value if it is equidistant.
-9. Return output.
+1. If input_decimal is not a decimal number, fail serialisation.
+2. If input_decimal has more than three significant digits to the right of the decimal point, round it to three decimal places, rounding the final digit to the nearest value, or to the even value if it is equidistant.
+3. If input_decimal has more than 12 significant digits to the left of the decimal point after rounding, fail serialisation.
+4. Let output be an empty string.
+5. If input_decimal is less than (but not equal to) 0, append "-" to output.
+6. Append input_decimal's integer component represented in base 10 (using only decimal digits) to output; if it is zero, append "0".
+7. Append "." to output.
+8. If input_decimal's fractional component is zero, append "0" to output.
+9. Otherwise, append the significant digits of input_decimal's fractional component represented in base 10 (using only decimal digits) to output.
+10. Return output.
 
 
 ### Serializing a String {#ser-string}


### PR DESCRIPTION
Round to three decimal places first, then check the domain, then do all the actual serialising.

It's potentially not very l13n-friendly; feel free to change "decimal point" or "to the left" etc., if something is more appropriate.

Fixes #1043