### PR TITLE
Fix "is can be" (header structure)

### DIFF
--- a/draft-ietf-httpbis-header-structure.md
+++ b/draft-ietf-httpbis-header-structure.md
@@ -359,7 +359,7 @@ Parsers MUST support dictionaries containing at least 1024 name/value pairs, and
 
 ## Items {#item}
 
-An item is can be a integer ({{integer}}), decimal ({{decimal}}), string ({{string}}), token ({{token}}), byte sequence ({{binary}}), or Boolean ({{boolean}}). It can have associated parameters ({{param}}).
+An item can be a integer ({{integer}}), decimal ({{decimal}}), string ({{string}}), token ({{token}}), byte sequence ({{binary}}), or Boolean ({{boolean}}). It can have associated parameters ({{param}}).
 
 The ABNF for items in HTTP headers is:
 


### PR DESCRIPTION
Small editorial fix.

I'm also not comfortable with "a integer", maybe remove "a"? Anyway that's a nitpick.