### PR TITLE
SHOULD check DNS for secondary if you would have for primary

### DIFF
--- a/draft-ietf-httpbis-http2-secondary-certs.md
+++ b/draft-ietf-httpbis-http2-secondary-certs.md
@@ -825,9 +825,13 @@ vulnerability in the TLS handshake.
 This mechanism could increase the impact of a key compromise. Rather than
 needing to subvert DNS or IP routing in order to use a compromised certificate,
 a malicious server now only needs a client to connect to *some* HTTPS site under
-its control in order to present the compromised certificate. As recommended in
-{{?RFC8336}}, clients opting not to consult DNS ought to employ some alternative
-means to increase confidence that the certificate is legitimate.
+its control in order to present the compromised certificate. Clients SHOULD
+consult DNS for hostnames presented in secondary certificates if they would have
+done so for the same hostname if it were present in the primary certificate.
+
+As recommended in {{?RFC8336}}, clients opting not to consult DNS ought to
+employ some alternative means to increase confidence that the certificate is
+legitimate.
 
 One such means is the Required Domain certificate extension defined in
 {extension}. Clients MUST require that server certificates presented via this


### PR DESCRIPTION
Fixes #869.  The intent here is to say that your requirements for trusting a secondary certificate should be at least as strict as for trusting additional names in the primary certificate.