### PR TITLE
[client-hints] Move Variants reference to the Variants draft

### DIFF
--- a/draft-ietf-httpbis-client-hints.md
+++ b/draft-ietf-httpbis-client-hints.md
@@ -262,13 +262,6 @@ This document defines the "Accept-CH" HTTP response header field, and registers 
 - Specification document(s): {{accept-ch}} of this document
 - Related information: for Client Hints
 
---- back
-
-# Interaction with Variants Response Header Field
-
-Client Hints might be combined with Variants response header field {{?VARIANTS=I-D.ietf-httpbis-variants}} to enable fine-grained control of the cache key for improved cache efficiency.
-Features that define Client Hints will need to specify the related variants algorithms as described in Section 6 of {{?VARIANTS}}.
-
 # Changes
 
 ## Since -00

--- a/draft-ietf-httpbis-variants.md
+++ b/draft-ietf-httpbis-variants.md
@@ -676,7 +676,10 @@ Variant-Key: (gold europe)
 Vary: Cookie
 ~~~
 
+## Client Hints {#client-hints}
 
+Client Hints {{CLIENT-HINTS}} might be combined with Variants response header field to enable fine-grained control of the cache key for improved cache efficiency.
+Features that define Client Hints will need to specify the related variants algorithms as described in Section 6.
 
 # Acknowledgements
 {:numbered="false"}


### PR DESCRIPTION
This is moving the Variants-Client Hints interaction section from the Client Hints draft to the Variants one, as [requested](https://lists.w3.org/Archives/Public/ietf-http-wg/2020JanMar/0158.html)