### PR TITLE
fix some editorial hangovers

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -27,6 +27,12 @@ author:
 normative:
 
 informative:
+  CVE-2019-9513:
+    title: CVE-2019-9513
+    author:
+      org: Common Vulnerabilities and Exposures
+    date: 2019-03-01
+    target: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513
 
 --- abstract
 
@@ -109,20 +115,20 @@ combination of dependencies and weights, formed into an unbalanced tree. This
 scheme has suffered from poor deployment and interoperability.
 
 The rich flexibility of client-driven HTTP/2 prioritization tree building is
-rarely exercised; experience shows that clients either choose a single model
-optimized for a web use case (and don't vary it) or do nothing at all. But every
-client builds their prioritization tree in a different way, which makes it
-difficult for servers to understand their intent and act or intervene
-accordingly.
+rarely exercised. Experience has shown that clients tend to choose a single
+model optimized for a web use case and experiment within the model constraints,
+or do nothing at all. Furthermore, many clients build their prioritization tree
+in a unique way, which makes it difficult for servers to understand their intent
+and act or intervene accordingly.
 
 Many HTTP/2 server implementations do not include support for the priority
 scheme, some favoring instead bespoke server-driven schemes based on heuristics
-and other hints, like the content type of resources and the order in which
-requests arrive. For example, a server, with knowledge of the document
-structure, might want to prioritize the delivery of images that are critical to
-user experience above other images, but below the CSS files. Since client trees
-vary, it is impossible for the server to determine how such images should be
-prioritized against other responses.
+and other hints, like the content type of resources and the request generation
+order. For example, a server, with knowledge of the document structure, might
+want to prioritize the delivery of images that are critical to user experience
+above other images, but below the CSS files. Since client trees vary, it is
+impossible for the server to determine how such images should be prioritized
+against other responses.
 
 The HTTP/2 scheme allows intermediaries to coalesce multiple client trees into a
 single tree that is used for a single upstream HTTP/2 connection. However, most
@@ -134,7 +140,7 @@ priorities.
 HTTP/2 describes denial-of-service considerations for implementations. On
 2019-08-13 Netflix issued an advisory notice about the discovery of several
 resource exhaustion vectors affecting multiple HTTP/2 implementations. One
-attack, CVE-2019-9513 aka "Resource Loop", is based on manipulation of the
+attack, [CVE-2019-9513] aka "Resource Loop", is based on manipulation of the
 priority tree.
 
 The HTTP/2 scheme depends on in-order delivery of signals, leading to challenges
@@ -172,10 +178,11 @@ Until the client receives the SETTINGS frame from the server, the client SHOULD
 send both the priority signal defined in the HTTP/2 priority scheme and also
 that of this prioritization scheme. Once the client learns that the HTTP/2
 priority scheme is deprecated, it SHOULD stop sending the HTTP/2 priority
-signals. If the client learns that the HTTP/2 priority scheme is not
-deprecated, it SHOULD stop sending PRIORITY_UPDATE frames, but MAY continue
-sending the Priority header field, as it is an end-to-end signal that might be
-useful to nodes behind the server that the client is directly connected to.
+signals. If the client learns that the HTTP/2 priority scheme is not deprecated,
+it SHOULD stop sending PRIORITY_UPDATE frames ({{h2-update-frame}}), but MAY
+continue sending the Priority header field ({{header-field}}), as it is an
+end-to-end signal that might be useful to nodes behind the server that the
+client is directly connected to.
 
 The SETTINGS frame precedes any priority signal sent from a client in HTTP/2,
 so a server can determine if it should respect the HTTP/2 scheme before
@@ -186,12 +193,13 @@ building state.
 The priority information is a sequence of key-value pairs, providing room for
 future extensions. Each key-value pair represents a priority parameter.
 
-The Priority HTTP header field is an end-to-end way to transmit this set of
-parameters when a request or a response is issued. In order to reprioritize a
-request, HTTP-version-specific frames are used by clients to transmit the
-same information on a single hop.  If intermediaries want to specify
-prioritization on a multiplexed HTTP connection, it SHOULD use a
-PRIORITY_UPDATE frame and SHOULD NOT change the Priority header field.
+The Priority HTTP header field ({{header-field}}) is an end-to-end way to
+transmit this set of parameters when a request or a response is issued. In order
+to reprioritize a request, HTTP-version-specific frames ({{h2-update-frame}} and
+{{h3-update-frame}}) are used by clients to transmit the same information on a
+single hop.  If intermediaries want to specify prioritization on a multiplexed
+HTTP connection, they SHOULD use a PRIORITY_UPDATE frame and SHOULD NOT change
+the Priority header field.
 
 In both cases, the set of priority parameters is encoded as a Structured Headers
 Dictionary ({{!STRUCTURED-HEADERS}}).
@@ -251,11 +259,11 @@ responses that share the same urgency, hoping that providing those responses in
 parallel would be more helpful to the client than delivering the responses one
 by one.
 
-There is no benefit in providing multiple responses with their incremental
-parameters set to false in parallel, as the client is not going to process those
-responses incrementally. Serving non-incremental responses one by one, in the
-order in which those requests were generated is considered to be the best
-strategy.
+If a client makes concurrent requests with the incremental parameter set to
+false, there is no benefit serving responses in parallel because the client is
+not going to process those responses incrementally. Serving non-incremental
+responses one by one, in the order in which those requests were generated is
+considered to be the best strategy.
 
 The following example shows a request for a JPEG file with the urgency parameter
 set to `5` and the incremental parameter set to `true`.
@@ -283,7 +291,7 @@ Alternatively, the urgency can be augmented. For example, a graphical user agent
 could send a `visible` parameter to indicate if the resource being requested is
 within the viewport.
 
-# The Priority HTTP Header Field
+# The Priority HTTP Header Field {#header-field}
 
 The Priority HTTP header field can appear in requests and responses. A client
 uses it to specify the priority of the response. A server uses it to inform
@@ -309,7 +317,7 @@ a JavaScript file with the urgency parameter of the Priority request header
 field set to `u=7` (background). Then, when the user navigates to a page which
 references the new JavaScript file, while the prefetch is in progress, the
 browser would send a reprioritization frame with the priority field value
-set to `u=0` (prerequisite).
+set to `u=0`.
 
 In HTTP/2 and HTTP/3, after a request message is sent on a stream, the stream
 transitions to a state that prevents the client from sending additional
@@ -328,7 +336,7 @@ HTTP/2 this is the Stream ID, in HTTP/3 this is either the Stream ID or Push ID.
 
 Unlike the header field, the reprioritization frame is a hop-by-hop signal.
 
-## HTTP/2 PRIORITY_UPDATE Frame
+## HTTP/2 PRIORITY_UPDATE Frame {#h2-update-frame}
 
 The HTTP/2 PRIORITY_UPDATE frame (type=0xF) carries the stream ID of the
 response that is being reprioritized, and the updated priority in ASCII text,
@@ -368,7 +376,7 @@ it MAY be treated as a connection error of type PROTOCOL_ERROR.
 TODO: add more description of how to handle things like receiving
 PRIORITY_UPDATE on wrong stream, a PRIORITY_UPDATE with an invalid ID, etc.
 
-## HTTP/3 PRIORITY_UPDATE Frame
+## HTTP/3 PRIORITY_UPDATE Frame {#h3-update-frame}
 
 The HTTP/3 PRIORITY_UPDATE frame (type=0xF) carries the identifier of the
 element that is being reprioritized, and the updated priority in ASCII text,


### PR DESCRIPTION
A few editorial tweaks to improve readability, including some x-refs to the Header / frames.

The most contentious change is at L262, the sentence read a bit weird so I juggled it around to make the intent (as I understand it) clearer.