### PR TITLE
Replace validator -> validator fields

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -214,7 +214,7 @@ The definitions "representation", "selected representation", "representation
 data", "representation metadata", and "payload body" in this document are to be
 interpreted as described in [I-D.ietf-httpbis-semantics].
 
-The definition "validator" in this document is to be interpreted as described in
+The definition "validator fields" in this document is to be interpreted as described in
 Section 10.2 of [I-D.ietf-httpbis-semantics].
 
 # Representation Digest {#representation-digest}
@@ -261,7 +261,7 @@ response.
    Digest = "Digest" ":" OWS 1#representation-data-digest
 ~~~
 
-The resource is specified by the effective request URI and any `validator`
+The resource is specified by the effective request URI and any `validator field`
 contained in the message.
 
 The relationship between Content-Location (see Section 6.2.5 of


### PR DESCRIPTION
## This PR


"validator" refers to validator fields used in preconditions. The term validator fields seems more faithful to the original cache-validators in RFC3230.

## See

https://github.com/httpwg/http-core/blob/master/draft-ietf-httpbis-semantics-latest.xml#L9288

and


https://tools.ietf.org/html/draft-ietf-httpbis-semantics-07#section-10.2