### PR TITLE
PRIORITY_UPDATE can be used for initial priority, split H3 frames into two types

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -357,18 +357,15 @@ frame header MUST be zero (0x0). Receiving a PRIORITY_UPDATE frame with a field
 of any other value MUST be treated as a connection error of type PROTOCOL_ERROR.
 
 ~~~ drawing
-HTTP/2 PRIORITY_UPDATE Frame {
-  Length (24),
-  Type (8) = 0x10,
-  Flags (8),
-  Reserved (1),
-  Stream Identifier (31) = 0,
-  R (1),
-  Prioritized Stream ID (31),
-  Priority Field Value (..),
-}
+  0                   1                   2                   3
+  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ +---------------------------------------------------------------+
+ |R|                        Stream ID (31)                       |
+ +---------------------------------------------------------------+
+ |                   Priority Field Value (*)                  ...
+ +---------------------------------------------------------------+
 ~~~
-{: #fig-h2-reprioritization-frame title="HTTP/2 PRIORITY_UPDATE Frame"}
+{: #fig-h2-reprioritization-frame title="HTTP/2 PRIORITY_UPDATE Frame Payload"}
 
 The PRIORITY_UPDATE frame payload has the following fields:
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -328,9 +328,9 @@ during the stream lifetime; see {{reprioritization}}.
 Unlike the Priority header field, the PRIORITY_UPDATE frame is a hop-by-hop
 signal. Clients that do not want to expose an end-to-end signal MAY omit the
 header field but send the PRIORITY_UPDATE frame at an early moment assuming that
-it will reach the server as early as the request message it applies to. An
-endpoint that receives both signals can process them in any way it chooses but
-MUST NOT treat this as error.
+it will reach the server as early as the request message it applies to. The
+signal carries by a PRIORITY_UPDATE frame overrides that carried by the header,
+even when the frame was received before the request headers.
 
 # Reprioritization
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -438,26 +438,31 @@ Prioritized Element ID:
 Priority Field Value:
 : The priority update value in ASCII text, encoded using Structured Headers.
 
-The PRIORITY_UPDATE frame MAY be sent before the request stream that it
-references has been created. The Stream ID MUST be within the client-initiated
-bidirectional stream limit. If a server receives a PRIORITY_UPDATE for a Stream
-ID that is beyond the stream limits, this SHOULD be treated as a connection error
-of type H3_ID_ERROR. PRIORITY_UPDATE frames received before the request or
-response has started SHOULD be buffered until the stream is opened and applied
-immediately after the request message has been processed. Holding
-PRIORITY_UPDATES consumes extra state on the peer, although the size of the
+The request-stream variant of PRIORITY_UPDATE (type=0x10) MUST reference a
+request stream. If a server receives a PRIORITY_UPDATE (type=0x10)for a Stream
+ID that is not a request stream, this MUST be treated as a connection error of
+type H3_ID_ERROR. PRIORITY_UPDATE (type=0x10) MAY be sent before the request
+stream that it references has been created. The Stream ID MUST be within the
+client-initiated bidirectional stream limit. If a server receives a
+PRIORITY_UPDATE (type=0x10) with a Stream ID that is beyond the stream limits,
+this SHOULD be treated as a connection error of type H3_ID_ERROR.
+
+Request-stream variant PRIORITY_UPDATEs (type=0x10) received before the request
+or response has started SHOULD be buffered until the stream is opened and
+applied immediately after the request message has been processed. Holding
+PRIORITY_UPDATEs consumes extra state on the peer, although the size of the
 state is bounded by bidirectional stream limits. There is no bound on the number
 of PRIORITY_UPDATEs that can be sent, so an endpoint SHOULD store only the most
 recently received frame.
 
-If a server receives a PRIORITY_UPDATE specifying a Push ID that has not been
-promised, it SHOULD be treated as a connection error of type H3_ID_ERROR.
+The push-stream variant PRIORITY_UPDATE (type=0x11) MUST reference a promised
+push stream. If a server receives a PRIORITY_UPDATE (type=0x11) with Push ID
+that is beyond the push limit or has not been promised, this MUST be treated as
+a connection error of type H3_ID_ERROR.
 
-If a server receives a PRIORITY_UPDATE for a Stream ID that is not a request
-stream, this MUST be treated as a connection error of type H3_ID_ERROR.
-
-If a client receives a PRIORITY_UPDATE frame, it MUST respond with a connection
-error of type H3_FRAME_UNEXPECTED.
+PRIORITY_UPDATEs of either type are only send by a client. If a client receives
+a PRIORITY_UPDATE frame, this MUST be treated as a connection error of type
+H3_FRAME_UNEXPECTED.
 
 
 # Merging Client- and Server-Driven Parameters {#merging}

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -340,11 +340,10 @@ PRIORITY_UPDATE frames to indicate both the initial priority and the updated
 priority.
 
 When a server receives a PRIORITY_UPDATE frame referring to a client-initiated
-request that has not yet been opened, the server buffers the priorities
-carried by the received frame and applies them once the request is being opened.
-The signal carried by a PRIORITY_UPDATE frame overrides that carried by the
-Priority header field, even when the frame was received before the request
-headers.
+request that has not yet been opened, the server buffers the priorities carried
+by the received frame and applies them once the request has been processed. The
+signal carried by a PRIORITY_UPDATE frame overrides that carried by the Priority
+header field, even when the frame was received before the request headers.
 
 ## HTTP/2 PRIORITY_UPDATE Frame {#h2-update-frame}
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -386,10 +386,10 @@ receives a PRIORITY_UPDATE for a Stream ID that is beyond the stream limits,
 this SHOULD be treated as a connection error of type PROTOCOL_ERROR.
 PRIORITY_UPDATE frames received before the request or response has started
 SHOULD be buffered until the stream is opened and applied immediately after the
-request message has been processed. Holding PRIORITY_UPDATES consumes extra
-state on the peer, although the size of the state is bounded by stream limits.
-There is no bound on the number of PRIORITY_UPDATEs that can be sent, so an
-endpoint SHOULD store only the most recently received frame.
+request message has been processed. Holding PRIORITY_UPDATE frames consumes
+extra state on the peer, although the size of the state is bounded by stream
+limits. There is no bound on the number of PRIORITY_UPDATE frames that can be
+sent, so an endpoint SHOULD store only the most recently received frame.
 
 If a PRIORITY_UPDATE frame is received with a Stream ID of 0x0, the recipient
 MUST respond with a connection error of type PROTOCOL_ERROR.
@@ -439,22 +439,22 @@ the client-initiated bidirectional stream limit. If a server receives a
 PRIORITY_UPDATE (type=0xF0700) with a Stream ID that is beyond the stream
 limits, this SHOULD be treated as a connection error of type H3_ID_ERROR.
 
-Request-stream variant PRIORITY_UPDATEs (type=0xF0700) received before the
+Request-stream variant PRIORITY_UPDATE frames (type=0xF0700) received before the
 request or response has started SHOULD be buffered until the stream is opened
 and applied immediately after the request message has been processed. Holding
-PRIORITY_UPDATEs consumes extra state on the peer, although the size of the
-state is bounded by bidirectional stream limits. There is no bound on the number
-of PRIORITY_UPDATEs that can be sent, so an endpoint SHOULD store only the most
-recently received frame.
+PRIORITY_UPDATE frames consumes extra state on the peer, although the size of
+the state is bounded by bidirectional stream limits. There is no bound on the
+number of PRIORITY_UPDATE frames that can be sent, so an endpoint SHOULD store
+only the most recently received frame.
 
 The push-stream variant PRIORITY_UPDATE (type=0xF0701) MUST reference a promised
 push stream. If a server receives a PRIORITY_UPDATE (type=0xF0701) with Push ID
 that is beyond the push limit or has not been promised, this MUST be treated as
 a connection error of type H3_ID_ERROR.
 
-PRIORITY_UPDATEs of either type are only sent by a client. If a client receives
-a PRIORITY_UPDATE frame, this MUST be treated as a connection error of type
-H3_FRAME_UNEXPECTED.
+PRIORITY_UPDATE frames of either type are only sent by a client. If a client
+receives a PRIORITY_UPDATE frame, this MUST be treated as a connection error of
+type H3_FRAME_UNEXPECTED.
 
 
 # Merging Client- and Server-Driven Parameters {#merging}

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -311,12 +311,11 @@ that control the caching behavior (e.g., Cache-Control, Vary).
 
 # Signalling Initial Priority in Frames
 
-Endpoints might prefer to signal the initial priority of a response using a
-frame rather than a header field. This document specifies a new PRIORITY_UPDATE
-frame for HTTP/2 ({{!RFC7540}}) and HTTP/3 ({{!I-D.ietf-quic-http}}). It carries
-priority parameters and references the target of the prioritization based on a
-version-specific identifier; in HTTP/2 this is the Stream ID, in HTTP/3 this is
-either the Stream ID or Push ID.
+This document specifies a new PRIORITY_UPDATE frame for HTTP/2 ({{!RFC7540}})
+and HTTP/3 ({{!I-D.ietf-quic-http}}). It carries priority parameters and
+references the target of the prioritization based on a version-specific
+identifier; in HTTP/2 this is the Stream ID, in HTTP/3 this is either the Stream
+ID or Push ID.
 
 In HTTP/2 the frame is sent on stream zero and in HTTP/3 it is sent on the client
 control stream ({{!I-D.ietf-quic-http}}, Section 6.2.1). This allows the
@@ -324,13 +323,12 @@ PRIORITY_UPDATE to be sent before the stream it references is created, and
 avoids having to extend the protocol semantics to support continued updates
 during the stream lifetime; see {{reprioritization}}.
 
-Unlike the header field, the PRIORITY_UPDATE frame is a hop-by-hop signal.
-
-Having two mechanisms to carry the initial priority signal brings the dilemma of
-choice. A sender can use either signal and sending both is not prohibited. An
+Unlike the Priority header field, the PRIORITY_UPDATE frame is a hop-by-hop
+signal. Clients that do not want to expose an end-to-end signal MAY omit the
+header field but send the PRIORITY_UPDATE frame at an early moment assuming that
+it will reach the server as early as the request message it applies to. An
 endpoint that receives both signals can process them in any way it chooses but
-MUST NOT treat this as error. Endpoints are advised that sending conflicting
-initial priority signals may lead to sub-optimal prioritization effects.
+MUST NOT treat this as error.
 
 # Reprioritization
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -325,17 +325,17 @@ set to `u=0`.
 This document specifies a new PRIORITY_UPDATE frame for HTTP/2 ({{!RFC7540}})
 and HTTP/3 ({{!I-D.ietf-quic-http}}). It carries priority parameters and
 references the target of the prioritization based on a version-specific
-identifier; in HTTP/2 this is the Stream ID, in HTTP/3 this is either the Stream
-ID or Push ID. Unlike the Priority header field, the PRIORITY_UPDATE frame is a
-hop-by-hop signal.
+identifier. In HTTP/2, this identifier is the Stream ID; in HTTP/3, the
+identifier is either the Stream ID or Push ID. Unlike the Priority header field,
+the PRIORITY_UPDATE frame is a hop-by-hop signal.
 
 PRIORITY_UPDATE frames are sent by clients on the control stream, and therefore
 can be sent even after the send-side of the request stream is being closed. This
-also allows the PRIORITY_UPDATE frame to be sent as early as the stream it
+also allows the PRIORITY_UPDATE frame to be sent as soon as the stream it
 references is created. Depending on the transmission logic of the endpoints and
 on the network condition in case of HTTP/3, servers might receive a
 PRIORITY_UPDATE frame that references a request stream that is yet to be opened.
-Furthermore, clients might omit the priority request header field, using
+Furthermore, clients might omit the Priority request header field, using
 PRIORITY_UPDATE frames to indicate both the initial priority and the updated
 priority.
 
@@ -343,14 +343,15 @@ When a server receives a PRIORITY_UPDATE frame referring to a client-initiated
 request that is yet to be opened, the server buffers the priorities being
 carried by the received frame and applies them once the request is being opened.
 The signal carried by a PRIORITY_UPDATE frame overrides that carried by the
-header field, even when the frame was received before the request headers.
+Priority header field, even when the frame was received before the request
+headers.
 
 ## HTTP/2 PRIORITY_UPDATE Frame {#h2-update-frame}
 
 The HTTP/2 PRIORITY_UPDATE frame (type=0x10) is used by clients to signal the
 initial priority of a response, or to reprioritize a response or push stream. It
 carries the stream ID of the response and the priority in ASCII text, using the
-same representation as that of the Priority header field value.
+same representation as the Priority header field value.
 
 The Stream Identifier field ({{!RFC7540}}, Section 4.1) in the PRIORITY_UPDATE
 frame header MUST be zero (0x0). Receiving a PRIORITY_UPDATE frame with a field
@@ -404,8 +405,8 @@ signal the initial priority of a response, or to reprioritize a response or push
 stream. It carries the identifer of the element that is being prioritized, and
 the updated priority in ASCII text, using the same representation as that of the
 Priority header field value. PRIORITY_UPDATE with a frame type of 0xF0700 is
-used for request streams, PRIORITY_UPDATE with a frame time of 0xF0701 is used
-for push streams.
+used for request streams, while PRIORITY_UPDATE with a frame type of 0xF0701 is
+used for push streams.
 
 The PRIORITY_UPDATE frame MUST be sent on the client control stream
 ({{!I-D.ietf-quic-http}}, Section 6.2.1). Receiving a PRIORITY_UPDATE frame on a
@@ -448,11 +449,11 @@ number of PRIORITY_UPDATE frames that can be sent, so an endpoint SHOULD store
 only the most recently received frame.
 
 The push-stream variant PRIORITY_UPDATE (type=0xF0701) MUST reference a promised
-push stream. If a server receives a PRIORITY_UPDATE (type=0xF0701) with Push ID
-that is beyond the push limit or has not been promised, this MUST be treated as
-a connection error of type H3_ID_ERROR.
+push stream. If a server receives a PRIORITY_UPDATE (type=0xF0701) with a Push ID
+that is greater than the maximum Push ID or which has not yet been promised, this
+MUST be treated as a connection error of type H3_ID_ERROR.
 
-PRIORITY_UPDATE frames of either type are only sent by a client. If a client
+PRIORITY_UPDATE frames of either type are only sent by clients. If a client
 receives a PRIORITY_UPDATE frame, this MUST be treated as a connection error of
 type H3_FRAME_UNEXPECTED.
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -391,8 +391,8 @@ state on the peer, although the size of the state is bounded by stream limits.
 There is no bound on the number of PRIORITY_UPDATEs that can be sent, so an
 endpoint SHOULD store only the most recently received frame.
 
-If a PRIORITY_UPDATE frame is received with a Prioritized Stream ID of 0x0, the
-recipient MUST respond with a connection error of type PROTOCOL_ERROR.
+If a PRIORITY_UPDATE frame is received with a Stream ID of 0x0, the recipient
+MUST respond with a connection error of type PROTOCOL_ERROR.
 
 If a client receives a PRIORITY_UPDATE frame, it MUST respond with a connection
 error of type PROTOCOL_ERROR.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -430,29 +430,30 @@ Prioritized Element ID:
 Priority Field Value:
 : The priority update value in ASCII text, encoded using Structured Headers.
 
-The request-stream variant of PRIORITY_UPDATE (type=0x10) MUST reference a
-request stream. If a server receives a PRIORITY_UPDATE (type=0x10)for a Stream
-ID that is not a request stream, this MUST be treated as a connection error of
-type H3_ID_ERROR. PRIORITY_UPDATE (type=0x10) MAY be sent before the request
-stream that it references has been created. The Stream ID MUST be within the
-client-initiated bidirectional stream limit. If a server receives a
-PRIORITY_UPDATE (type=0x10) with a Stream ID that is beyond the stream limits,
-this SHOULD be treated as a connection error of type H3_ID_ERROR.
+The request-stream variant of PRIORITY_UPDATE (type=0x1CCB8BBF1F0700) MUST
+reference a request stream. If a server receives a PRIORITY_UPDATE
+(type=0x1CCB8BBF1F0700) for a Stream ID that is not a request stream, this MUST
+be treated as a connection error of type H3_ID_ERROR. PRIORITY_UPDATE
+(type=0x1CCB8BBF1F0700) MAY be sent before the request stream that it references
+has been created. The Stream ID MUST be within the client-initiated
+bidirectional stream limit. If a server receives a PRIORITY_UPDATE
+(type=0x1CCB8BBF1F0700) with a Stream ID that is beyond the stream limits, this
+SHOULD be treated as a connection error of type H3_ID_ERROR.
 
-Request-stream variant PRIORITY_UPDATEs (type=0x10) received before the request
-or response has started SHOULD be buffered until the stream is opened and
-applied immediately after the request message has been processed. Holding
-PRIORITY_UPDATEs consumes extra state on the peer, although the size of the
-state is bounded by bidirectional stream limits. There is no bound on the number
-of PRIORITY_UPDATEs that can be sent, so an endpoint SHOULD store only the most
-recently received frame.
+Request-stream variant PRIORITY_UPDATEs (type=0x1CCB8BBF1F0700) received before
+the request or response has started SHOULD be buffered until the stream is
+opened and applied immediately after the request message has been processed.
+Holding PRIORITY_UPDATEs consumes extra state on the peer, although the size of
+the state is bounded by bidirectional stream limits. There is no bound on the
+number of PRIORITY_UPDATEs that can be sent, so an endpoint SHOULD store only
+the most recently received frame.
 
-The push-stream variant PRIORITY_UPDATE (type=0x11) MUST reference a promised
-push stream. If a server receives a PRIORITY_UPDATE (type=0x11) with Push ID
-that is beyond the push limit or has not been promised, this MUST be treated as
-a connection error of type H3_ID_ERROR.
+The push-stream variant PRIORITY_UPDATE (type=0x1CCB8BBF1F0701) MUST reference a
+promised push stream. If a server receives a PRIORITY_UPDATE
+(type=0x1CCB8BBF1F0701) with Push ID that is beyond the push limit or has not
+been promised, this MUST be treated as a connection error of type H3_ID_ERROR.
 
-PRIORITY_UPDATEs of either type are only send by a client. If a client receives
+PRIORITY_UPDATEs of either type are only sent by a client. If a client receives
 a PRIORITY_UPDATE frame, this MUST be treated as a connection error of type
 H3_FRAME_UNEXPECTED.
 
@@ -669,7 +670,7 @@ Frame Type:
 : PRIORITY_UPDATE
 
 Code:
-: 0x10 and 0x11
+: 0x1CCB8BBF1F0700 and 0x1CCB8BBF1F0701
 
 Specification:
 : This document

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -326,7 +326,7 @@ during the stream lifetime; see {{reprioritization}}.
 
 Unlike the header field, the PRIORITY_UPDATE frame is a hop-by-hop signal.
 
-Having two format to carry the initial priority signal brings the dilemma of
+Having two mechanisms to carry the initial priority signal brings the dilemma of
 choice. A sender can use either signal and sending both is not prohibited. An
 endpoint that receives both signals can process them in any way it chooses but
 MUST NOT treat this as error. Endpoints are advised that sending conflicting
@@ -358,8 +358,7 @@ same representation as that of the Priority header field value.
 
 The Stream Identifier field ({{!RFC7540}}, Section 4.1) in the PRIORITY_UPDATE
 frame header MUST be zero (0x0). Receiving a PRIORITY_UPDATE frame with a field
-of any other value MUST be treated as a connection error of type
-PROTOCOL_ERROR.
+of any other value MUST be treated as a connection error of type PROTOCOL_ERROR.
 
 ~~~ drawing
 HTTP/2 PRIORITY_UPDATE Frame {

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -101,6 +101,9 @@ Example HTTP requests and responses use the HTTP/2-style formatting from
 This document uses the variable-length integer encoding from
 {{!I-D.ietf-quic-transport}}.
 
+The term control stream is used to describe the HTTP/2 stream with identifier
+0x0, and HTTP/3 control stream; see {{!I-D.ietf-quic-http}}, Section 6.2.1.
+
 
 # Motivation for Replacing HTTP/2 Priorities {#motivation}
 
@@ -317,8 +320,7 @@ references the target of the prioritization based on a version-specific
 identifier; in HTTP/2 this is the Stream ID, in HTTP/3 this is either the Stream
 ID or Push ID.
 
-In HTTP/2 the frame is sent on stream zero and in HTTP/3 it is sent on the client
-control stream ({{!I-D.ietf-quic-http}}, Section 6.2.1). This allows the
+PRIORITY_UPDATE can be sent by clients on the control stream. This allows the
 PRIORITY_UPDATE to be sent before the stream it references is created, and
 avoids having to extend the protocol semantics to support continued updates
 during the stream lifetime; see {{reprioritization}}.
@@ -345,8 +347,8 @@ transitions to a state that prevents the client from sending additional frames
 on the stream. Therefore, a client cannot reprioritize a response by sending
 additional metadata (e.g., trailer fields) or a PRIORITY_UPDATE frame on the
 request stream. We avoid interoperability failure by restricting PRIORITY_UPDATE
-frames to stream zero or the control stream, with each such frame explicitly
-identifying the response to which the new priority applies.
+frames to the control stream, with each such frame explicitly identifying the
+response to which the new priority applies.
 
 ## HTTP/2 PRIORITY_UPDATE Frame {#h2-update-frame}
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -422,7 +422,7 @@ error of type H3_FRAME_UNEXPECTED.
 
 ~~~ drawing
 HTTP/3 PRIORITY_UPDATE Frame {
-  Type (i) = 0x0x1CCB8BBF1F0700..0x0x1CCB8BBF1F071,
+  Type (i) = 0x1CCB8BBF1F0700..0x1CCB8BBF1F071,
   Length (i),
   Prioritized Element ID (i),
   Priority Field Value (..),

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -352,7 +352,7 @@ response to which the new priority applies.
 
 ## HTTP/2 PRIORITY_UPDATE Frame {#h2-update-frame}
 
-The HTTP/2 PRIORITY_UPDATE frame (type=0xF) is used by clients to signal the
+The HTTP/2 PRIORITY_UPDATE frame (type=0x10) is used by clients to signal the
 initial priority of a response, or to reprioritize a response or push stream. It
 carries the stream ID of the response and the priority in ASCII text, using the
 same representation as that of the Priority header field value.
@@ -364,7 +364,7 @@ of any other value MUST be treated as a connection error of type PROTOCOL_ERROR.
 ~~~ drawing
 HTTP/2 PRIORITY_UPDATE Frame {
   Length (24),
-  Type (8) = 0xF,
+  Type (8) = 0x10,
   Flags (8),
   Reserved (1),
   Stream Identifier (31) = 0,
@@ -660,7 +660,7 @@ Frame Type:
 : PRIORITY_UPDATE
 
 Code:
-: 0xF
+: 0x10
 
 Specification:
 : This document
@@ -672,7 +672,7 @@ Frame Type:
 : PRIORITY_UPDATE
 
 Code:
-: 0xF and 0x10
+: 0x10 and 0x11
 
 Specification:
 : This document

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -422,7 +422,7 @@ error of type H3_FRAME_UNEXPECTED.
 
 ~~~ drawing
 HTTP/3 PRIORITY_UPDATE Frame {
-  Type (i) = 0x1CCB8BBF1F0700..0x1CCB8BBF1F071,
+  Type (i) = 0x1CCB8BBF1F0700..0x1CCB8BBF1F0701,
   Length (i),
   Prioritized Element ID (i),
   Priority Field Value (..),

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -407,13 +407,13 @@ error of type PROTOCOL_ERROR.
 
 ## HTTP/3 PRIORITY_UPDATE Frame {#h3-update-frame}
 
-The HTTP/3 PRIORITY_UPDATE frame (type=0xF or 0x10) is used by clients to
-signal the initial priority of a response, or to reprioritize a response or push
-stream. It carries the identifer of the element that is being prioritized, and
-the updated priority in ASCII text, using the same representation as that of the
-Priority header field value. PRIORITY_UPDATE with a frame type of 0xF is used
-for request streams, PRIORITY_UPDATE with a frame time of 0x11 is used for push
-streams.
+The HTTP/3 PRIORITY_UPDATE frame (type=0x1CCB8BBF1F0700 or 0x1CCB8BBF1F0701) is
+used by clients to signal the initial priority of a response, or to reprioritize
+a response or push stream. It carries the identifer of the element that is being
+prioritized, and the updated priority in ASCII text, using the same
+representation as that of the Priority header field value. PRIORITY_UPDATE with
+a frame type of 0x1CCB8BBF1F0700 is used for request streams, PRIORITY_UPDATE
+with a frame time of 0x1CCB8BBF1F0701 is used for push streams.
 
 The PRIORITY_UPDATE frame MUST be sent on the client control stream
 ({{!I-D.ietf-quic-http}}, Section 6.2.1). Receiving a PRIORITY_UPDATE frame on a
@@ -422,7 +422,7 @@ error of type H3_FRAME_UNEXPECTED.
 
 ~~~ drawing
 HTTP/3 PRIORITY_UPDATE Frame {
-  Type (i) = 0xF..0x10,
+  Type (i) = 0x0x1CCB8BBF1F0700..0x0x1CCB8BBF1F071,
   Length (i),
   Prioritized Element ID (i),
   Priority Field Value (..),

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -330,7 +330,7 @@ identifier is either the Stream ID or Push ID. Unlike the Priority header field,
 the PRIORITY_UPDATE frame is a hop-by-hop signal.
 
 PRIORITY_UPDATE frames are sent by clients on the control stream, and therefore
-can be sent even after the send-side of the request stream is being closed. This
+can be sent even after the sending part of the request stream is being closed. This
 also allows the PRIORITY_UPDATE frame to be sent as soon as the stream it
 references is created. Depending on the transmission logic of the endpoints and
 on the network condition in case of HTTP/3, servers might receive a
@@ -340,7 +340,7 @@ PRIORITY_UPDATE frames to indicate both the initial priority and the updated
 priority.
 
 When a server receives a PRIORITY_UPDATE frame referring to a client-initiated
-request that is yet to be opened, the server buffers the priorities being
+request that has not yet been opened, the server buffers the priorities
 carried by the received frame and applies them once the request is being opened.
 The signal carried by a PRIORITY_UPDATE frame overrides that carried by the
 Priority header field, even when the frame was received before the request

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -367,7 +367,7 @@ HTTP/2 PRIORITY_UPDATE Frame {
   Type (8) = 0xF,
   Flags (8),
   Reserved (1),
-  Stream Identifier (31),
+  Stream Identifier (31) = 0,
   R (1),
   Prioritized Stream ID (31),
   Priority Field Value (..),

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -361,7 +361,7 @@ of any other value MUST be treated as a connection error of type PROTOCOL_ERROR.
   0                   1                   2                   3
   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
  +---------------------------------------------------------------+
- |R|                        Stream ID (31)                       |
+ |R|                Prioritized Stream ID (31)                   |
  +---------------------------------------------------------------+
  |                   Priority Field Value (*)                  ...
  +---------------------------------------------------------------+
@@ -374,7 +374,7 @@ R:
 : A reserved 1-bit field. The semantics of this bit are undefined, and the bit
   MUST remain unset (0x0) when sending and MUST be ignored when receiving.
 
-Stream ID:
+Prioritized Stream ID:
 : A 31-bit stream identifier for the stream that is the target of the priority
   update.
 
@@ -382,18 +382,19 @@ Priority Field Value:
 : The priority update value in ASCII text, encoded using Structured Headers.
 
 The PRIORITY_UPDATE frame MAY be sent before the stream that it references has
-been created. The Stream ID MUST be within the stream limit. If a server
-receives a PRIORITY_UPDATE for a Stream ID that is beyond the stream limits,
-this SHOULD be treated as a connection error of type PROTOCOL_ERROR.
-PRIORITY_UPDATE frames received before the request or response has started
-SHOULD be buffered until the stream is opened and applied immediately after the
-request message has been processed. Holding PRIORITY_UPDATE frames consumes
-extra state on the peer, although the size of the state is bounded by stream
-limits. There is no bound on the number of PRIORITY_UPDATE frames that can be
-sent, so an endpoint SHOULD store only the most recently received frame.
+been created. The Prioritized Stream ID MUST be within the stream limit. If a
+server receives a PRIORITY_UPDATE with a Prioritized Stream ID that is beyond
+the stream limits, this SHOULD be treated as a connection error of type
+PROTOCOL_ERROR. PRIORITY_UPDATE frames received before the request or response
+has started SHOULD be buffered until the stream is opened and applied
+immediately after the request message has been processed. Holding
+PRIORITY_UPDATE frames consumes extra state on the peer, although the size of
+the state is bounded by stream limits. There is no bound on the number of
+PRIORITY_UPDATE frames that can be sent, so an endpoint SHOULD store only the
+most recently received frame.
 
-If a PRIORITY_UPDATE frame is received with a Stream ID of 0x0, the recipient
-MUST respond with a connection error of type PROTOCOL_ERROR.
+If a PRIORITY_UPDATE frame is received with a Prioritized Stream ID of 0x0, the
+recipient MUST respond with a connection error of type PROTOCOL_ERROR.
 
 If a client receives a PRIORITY_UPDATE frame, it MUST respond with a connection
 error of type PROTOCOL_ERROR.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -364,7 +364,7 @@ of any other value MUST be treated as a connection error of type PROTOCOL_ERROR.
 ~~~ drawing
 HTTP/2 PRIORITY_UPDATE Frame {
   Length (24),
-  Type (8) = 0x10,
+  Type (8) = 0xF,
   Flags (8),
   Reserved (1),
   Stream Identifier (31),

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -335,7 +335,7 @@ also allows the PRIORITY_UPDATE frame to be sent as early as the stream it
 references is created. Depending on the transmission logic of the endpoints and
 on the network condition in case of HTTP/3, servers might receive a
 PRIORITY_UPDATE frame that references a request stream that is yet to be opened.
-Furthermore, clients might omit the priority request header, using
+Furthermore, clients might omit the priority request header field, using
 PRIORITY_UPDATE frames to indicate both the initial priority and the updated
 priority.
 
@@ -343,7 +343,7 @@ When a server receives a PRIORITY_UPDATE frame referring to a client-initiated
 request that is yet to be opened, the server buffers the priorities being
 carried by the received frame and applies them once the request is being opened.
 The signal carried by a PRIORITY_UPDATE frame overrides that carried by the
-header, even when the frame was received before the request headers.
+header field, even when the frame was received before the request headers.
 
 ## HTTP/2 PRIORITY_UPDATE Frame {#h2-update-frame}
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -399,13 +399,13 @@ error of type PROTOCOL_ERROR.
 
 ## HTTP/3 PRIORITY_UPDATE Frame {#h3-update-frame}
 
-The HTTP/3 PRIORITY_UPDATE frame (type=0x1CCB8BBF1F0700 or 0x1CCB8BBF1F0701) is
-used by clients to signal the initial priority of a response, or to reprioritize
-a response or push stream. It carries the identifer of the element that is being
-prioritized, and the updated priority in ASCII text, using the same
-representation as that of the Priority header field value. PRIORITY_UPDATE with
-a frame type of 0x1CCB8BBF1F0700 is used for request streams, PRIORITY_UPDATE
-with a frame time of 0x1CCB8BBF1F0701 is used for push streams.
+The HTTP/3 PRIORITY_UPDATE frame (type=0xF0700 or 0xF0701) is used by clients to
+signal the initial priority of a response, or to reprioritize a response or push
+stream. It carries the identifer of the element that is being prioritized, and
+the updated priority in ASCII text, using the same representation as that of the
+Priority header field value. PRIORITY_UPDATE with a frame type of 0xF0700 is
+used for request streams, PRIORITY_UPDATE with a frame time of 0xF0701 is used
+for push streams.
 
 The PRIORITY_UPDATE frame MUST be sent on the client control stream
 ({{!I-D.ietf-quic-http}}, Section 6.2.1). Receiving a PRIORITY_UPDATE frame on a
@@ -414,7 +414,7 @@ error of type H3_FRAME_UNEXPECTED.
 
 ~~~ drawing
 HTTP/3 PRIORITY_UPDATE Frame {
-  Type (i) = 0x1CCB8BBF1F0700..0x1CCB8BBF1F0701,
+  Type (i) = 0xF0700..0xF0701,
   Length (i),
   Prioritized Element ID (i),
   Priority Field Value (..),
@@ -430,28 +430,27 @@ Prioritized Element ID:
 Priority Field Value:
 : The priority update value in ASCII text, encoded using Structured Headers.
 
-The request-stream variant of PRIORITY_UPDATE (type=0x1CCB8BBF1F0700) MUST
-reference a request stream. If a server receives a PRIORITY_UPDATE
-(type=0x1CCB8BBF1F0700) for a Stream ID that is not a request stream, this MUST
-be treated as a connection error of type H3_ID_ERROR. PRIORITY_UPDATE
-(type=0x1CCB8BBF1F0700) MAY be sent before the request stream that it references
-has been created. The Stream ID MUST be within the client-initiated
-bidirectional stream limit. If a server receives a PRIORITY_UPDATE
-(type=0x1CCB8BBF1F0700) with a Stream ID that is beyond the stream limits, this
-SHOULD be treated as a connection error of type H3_ID_ERROR.
+The request-stream variant of PRIORITY_UPDATE (type=0xF0700) MUST reference a
+request stream. If a server receives a PRIORITY_UPDATE (type=0xF0700) for a
+Stream ID that is not a request stream, this MUST be treated as a connection
+error of type H3_ID_ERROR. PRIORITY_UPDATE (type=0xF0700) MAY be sent before the
+request stream that it references has been created. The Stream ID MUST be within
+the client-initiated bidirectional stream limit. If a server receives a
+PRIORITY_UPDATE (type=0xF0700) with a Stream ID that is beyond the stream
+limits, this SHOULD be treated as a connection error of type H3_ID_ERROR.
 
-Request-stream variant PRIORITY_UPDATEs (type=0x1CCB8BBF1F0700) received before
-the request or response has started SHOULD be buffered until the stream is
-opened and applied immediately after the request message has been processed.
-Holding PRIORITY_UPDATEs consumes extra state on the peer, although the size of
-the state is bounded by bidirectional stream limits. There is no bound on the
-number of PRIORITY_UPDATEs that can be sent, so an endpoint SHOULD store only
-the most recently received frame.
+Request-stream variant PRIORITY_UPDATEs (type=0xF0700) received before the
+request or response has started SHOULD be buffered until the stream is opened
+and applied immediately after the request message has been processed. Holding
+PRIORITY_UPDATEs consumes extra state on the peer, although the size of the
+state is bounded by bidirectional stream limits. There is no bound on the number
+of PRIORITY_UPDATEs that can be sent, so an endpoint SHOULD store only the most
+recently received frame.
 
-The push-stream variant PRIORITY_UPDATE (type=0x1CCB8BBF1F0701) MUST reference a
-promised push stream. If a server receives a PRIORITY_UPDATE
-(type=0x1CCB8BBF1F0701) with Push ID that is beyond the push limit or has not
-been promised, this MUST be treated as a connection error of type H3_ID_ERROR.
+The push-stream variant PRIORITY_UPDATE (type=0xF0701) MUST reference a promised
+push stream. If a server receives a PRIORITY_UPDATE (type=0xF0701) with Push ID
+that is beyond the push limit or has not been promised, this MUST be treated as
+a connection error of type H3_ID_ERROR.
 
 PRIORITY_UPDATEs of either type are only sent by a client. If a client receives
 a PRIORITY_UPDATE frame, this MUST be treated as a connection error of type
@@ -670,7 +669,7 @@ Frame Type:
 : PRIORITY_UPDATE
 
 Code:
-: 0x1CCB8BBF1F0700 and 0x1CCB8BBF1F0701
+: 0xF0700 and 0xF0701
 
 Specification:
 : This document

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -391,7 +391,7 @@ Priority Field Value:
 The PRIORITY_UPDATE frame MAY be sent before the stream that it references has
 been created. The Stream ID MUST be within the stream limit. If a server
 receives a PRIORITY_UPDATE for a Stream ID that is beyond the stream limits,
-this MUST be treated as a connection error of type PROTOCOL_ERROR.
+this SHOULD be treated as a connection error of type PROTOCOL_ERROR.
 PRIORITY_UPDATE frames received before the request or response has started
 SHOULD be buffered until the stream is opened and applied immediately after the
 request message has been processed. Holding PRIORITY_UPDATES consumes extra
@@ -441,7 +441,7 @@ Priority Field Value:
 The PRIORITY_UPDATE frame MAY be sent before the request stream that it
 references has been created. The Stream ID MUST be within the client-initiated
 bidirectional stream limit. If a server receives a PRIORITY_UPDATE for a Stream
-ID that is beyond the stream limits, this MUST be treated as a connection error
+ID that is beyond the stream limits, this SHOULD be treated as a connection error
 of type H3_ID_ERROR. PRIORITY_UPDATE frames received before the request or
 response has started SHOULD be buffered until the stream is opened and applied
 immediately after the request message has been processed. Holding

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -343,11 +343,12 @@ browser would send a reprioritization frame with the priority field value
 set to `u=0`.
 
 In HTTP/2 and HTTP/3, after a request message is sent on a stream, the stream
-transitions to a state that prevents the client from sending additional
-frames on the stream. Therefore, a client cannot reprioritize a response by
-using the Priority header field.  Modifying this behavior would require a
-semantic change to the protocol, but this is avoided by restricting the
-stream on which a PRIORITY_UPDATE frame can be sent.
+transitions to a state that prevents the client from sending additional frames
+on the stream. Therefore, a client cannot reprioritize a response by sending
+additional metadata (e.g., trailer fields) or a PRIORITY_UPDATE frame on the
+request stream. We avoid interoperability failure by restricting PRIORITY_UPDATE
+frames to stream zero or the control stream, with each such frame explicitly
+identifying the response to which the new priority applies.
 
 ## HTTP/2 PRIORITY_UPDATE Frame {#h2-update-frame}
 


### PR DESCRIPTION
This attempts to address #1096 and #1079. It might help towards overcoming the headers vs frames debate.

I made the call to restrict the PRIORITY_UPDATE frame to only be sent by clients.

It replaces ASCII art with new QUIC-style frame definitions.