### PR TITLE
digest-headers: remove non-ASCII characters from prose

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1201,10 +1201,10 @@ and method impacts on the message and payload body. When the payload body
 contains non-printable characters (eg. when it is compressed) it is shown as
 base64-encoded string.
 
-A request with a json object without any content coding
-￼
+A request with a json object without any content coding.
+
 Request:
-￼
+
 ~~~
 PUT /entries/1234 HTTP/1.1
 Content-Type: application/json
@@ -1212,9 +1212,9 @@ Content-Encoding: identity
 
 {"hello": "world"}
 ~~~
-￼
+
 Here is a gzip-compressed json object
-using a content coding
+using a content coding.
 
 Request:
 


### PR DESCRIPTION
(inserted with https://github.com/httpwg/http-extensions/commit/4178324c374fd1e75acda09df6d7b2afb232de07)