### PR TITLE
We forgot to align this part with the SHA-1 deprecation.

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1169,8 +1169,8 @@ registry:
 The status of "MD5" has been updated to "deprecated", and its description states
 that this algorithm MUST NOT be used.
 
-The status of "SHA" has been updated to "obsoleted", and its description states
-that this algorithm is NOT RECOMMENDED.
+The status of "SHA" has been updated to "deprecated", and its description states
+that this algorithm MUST NOT be used.
 
 The status for "CRC32c" has been updated to "standard".
 


### PR DESCRIPTION
## This PR

Aligns a part of the doc with the SHA-1 deprecation we decided in #1020 

## Note

We correctly deprecated SHA-1 but in this part we left it as NOT RECOMMENDED.