### PR TITLE
rough in server scheduling guidance

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -527,30 +527,27 @@ basic recommendations for implementations.
 Clients cannot depend on particular treatment based on priority signals. Servers
 can use other information to prioritize responses.
 
-It is RECOMMENDED that, when possible, servers respect urgency values, sending
-higher urgency responses before lower urgency responses.
+It is RECOMMENDED that, when possible, servers respect the urgency parameter
+({{urgency}}), sending higher urgency responses before lower urgency responses.
 
-It is RECOMMENDED that, when possible, servers respect incremental values.
-Sending non-incremental responses of the same urgency one-by-one, and sending
-incremental responses of the same urgency in round-robin manner.
+It is RECOMMENDED that, when possible, servers respect the incremental
+parameter ({{incremental}}). Non-incremental responses of the same urgency
+SHOULD be served one-by-one based on the Stream ID, that corersponds to the
+order in which clients make requests. Doing so ensures that clients can use
+request ordering to influence response order. Incremental responses of the same
+urgency SHOULD be served in round-robin manner.
 
-It is RECOMMENDED that a server considers request generation order as an input
-to prioritization. Prioritizing concurrent requests at the same urgency level
-based on the Stream ID, which corresponds to the order in which clients make
-requests, ensures that clients can use request ordering to influence response
-order.
-
-The incremental parameter ({{incremental}}) indicates how a client processes
-response bytes as they arrive. Non-incremental resources are only used when all
-of the response payload has been received. Incremental resources are used as
-parts, or chunks, of the response payload are received. Therefore, the timing of
-response data reception at the client, such as the time to early bytes or the
-time to receive the entire payload, plays an important role in perceived
-performance. Timings depend on resource size but this scheme provides no
-explicit guidance about how a server should use size as an input to
-prioritization. Instead, the following examples demonstrate how a server that
-strictly abides the scheduling guidance based on urgency and request generation
-order could find that early requests prevent serving of later requests.
+The incremental parameter indicates how a client processes response bytes as
+they arrive. Non-incremental resources are only used when all of the response
+payload has been received. Incremental resources are used as parts, or chunks,
+of the response payload are received. Therefore, the timing of response data
+reception at the client, such as the time to early bytes or the time to receive
+the entire payload, plays an important role in perceived performance. Timings
+depend on resource size but this scheme provides no explicit guidance about how
+a server should use size as an input to prioritization. Instead, the following
+examples demonstrate how a server that strictly abides the scheduling guidance
+based on urgency and request generation order could find that early requests
+prevent serving of later requests.
 
 1. At the same urgency level, a non-incremental request for a large resource
    followed by an incremental request for a small resource.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -536,13 +536,27 @@ based on the Stream ID, which corresponds to the order in which clients make
 requests, ensures that clients can use request ordering to influence response
 order.
 
-For non-incremental resources the total download time (time to first byte - time
-to last byte) is important. For incremental resources chunk download times are
-important, especially the first. A server that receives a mix of incremental and
-non-incremental at the same urgency is challenged to schedule two competing
-factors. An unbalanced scheduler might prefer one type over another, leading to
-sub-optimal loading and in the worst case starvation of one type. Servers are
-RECOMMENDED to avoid starvation but no specific method of doing so is prescribed.
+The incremental parameter ({{incremental}}) indicates how a client processes
+response bytes as they arrive. Non-incremental resources are only used when all
+of the response payload has been received. Incremental resources are used as
+parts, or chunks, of the response payload are received. Therefore, the timing of
+response data reception at the client, such as the time to early bytes or the
+time to receive the entire payload, plays an important role in perceived
+performance. Timings depend on resource size but this scheme provides no
+explicit guidance about how a server should use size as an input to
+prioritization. Instead, the follow examples demonstrate how a server that
+strictly abides the scheduling guidance based on urgency and request generation
+order could find that early requests prevent serving of later requests.
+
+1. At the same urgency level, a non-incremental request for a large resource
+   followed by an incremental request for a small resource.
+2. At the same urgency level, an incremental request of indeterminate length
+   followed by a non-incremental large resource.
+
+It is RECOMMENDED that servers avoid such starvation where possible. The method
+to do so is an implementation decision. For example, a server might
+pre-emptively send responses of a particular incremental type based on other
+information such as content size.
 
 An HTTP/2 server implementing the Extensible Priorities scheme instead of the
 HTTP/2 priority sends SETTINGS_DEPRECATE_HTTP2_PRIORITIES; see {{disabling}}. It

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -544,7 +544,7 @@ response data reception at the client, such as the time to early bytes or the
 time to receive the entire payload, plays an important role in perceived
 performance. Timings depend on resource size but this scheme provides no
 explicit guidance about how a server should use size as an input to
-prioritization. Instead, the follow examples demonstrate how a server that
+prioritization. Instead, the following examples demonstrate how a server that
 strictly abides the scheduling guidance based on urgency and request generation
 order could find that early requests prevent serving of later requests.
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -187,9 +187,14 @@ continue sending the Priority header field ({{header-field}}), as it is an
 end-to-end signal that might be useful to nodes behind the server that the
 client is directly connected to.
 
-The SETTINGS frame precedes any priority signal sent from a client in HTTP/2,
-so a server can determine if it should respect the HTTP/2 scheme before
-building state.
+The SETTINGS frame precedes any priority signal sent from a client in HTTP/2, so
+a server can determine if it should respect the HTTP/2 scheme before building
+state. A server that receives SETTINGS_DEPRECATE_HTTP2_PRIORITIES MUST ignore
+HTTP/2 priority signals.
+
+Where both endpoints disable HTTP/2 priorities, the client is expected to send
+this scheme's priority signal. Handling of omitted signals is described in
+{{parameters}}.
 
 # Priority Parameters {#parameters}
 
@@ -212,7 +217,6 @@ receiving an HTTP request that does not carry these priority parameters, a
 server SHOULD act as if their default values were specified. Note that handling
 of omitted parameters is different when processing an HTTP response; see
 {{merging}}.
-
 
 Unknown parameters, parameters with out-of-range values or values of unexpected
 types MUST be ignored.
@@ -558,12 +562,6 @@ to do so is an implementation decision. For example, a server might
 pre-emptively send responses of a particular incremental type based on other
 information such as content size.
 
-HTTP/2 endpoints can advertise that they are using the Extensible Priorities scheme
-instead of the HTTP/2 priority scheme by sending
-SETTINGS_DEPRECATE_HTTP2_PRIORITIES; see {{disabling}}. A server that sends or
-receives this setting SHOULD NOT act on priority signals belonging to the HTTP/2
-scheme. The absence of a client Extensible Priority signal SHOULD be treated
-as though default urgency and incremental parameters were sent.
 
 
 # Fairness {#fairness}

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -520,9 +520,8 @@ given connection is likely to have many dynamic permutations. For these reasons,
 there is no unilateral perfect scheduler and this document only provides some
 basic recommendations for implementations. 
 
-Clients can expect servers will make prioritization decisions, including
-ignoring all signals. And they should expect that decisions might be based on
-metadata or information beyond the scope of extensible priorities. 
+Clients cannot depend on particular treatment based on priority signals. Servers
+can use other information to prioritize responses.
 
 It is RECOMMENDED that, when possible, servers respect urgency values. Sending
 higher urgency responses before lower urgency responses.
@@ -532,11 +531,10 @@ Sending non-incremental responses of the same urgency one-by-one, and sending
 incremental responses of the same urgency in round-robin manner.
 
 It is RECOMMENDED that a server considers request generation order as an input
-to prioritization. This can be determined from the Stream ID. A server that
-receives concurrent requests at the same urgency level might serve the responses
-one-by-one but it needs to pick an order. Serving the lowest Stream ID in a
-given urgency level can align well with clients usage of HTTP; such as user
-agents that load document trees where ordering is important.
+to prioritization. Prioritizing concurrent requests at the same urgency level
+based on the Stream ID, which corresponds to the order in which clients make
+requests, ensures that clients can use request ordering to influence response
+order.
 
 For non-incremental resources the total download time (time to first byte - time
 to last byte) is important. For incremental resources chunk download times are

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -513,7 +513,7 @@ other response. An endpoint cannot force a peer to process concurrent request in
 a particular order using priority. Expressing priority is therefore only a
 suggestion.
 
-A server can use Priority signals along with other inputs to make scheduling
+A server can use priority signals along with other inputs to make scheduling
 decisions. No guidance is provided about how this can or should be done. Factors
 such as implementation choices or deployment environment also play a role. Any
 given connection is likely to have many dynamic permutations. For these reasons,

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -546,7 +546,6 @@ factors. An unbalanced scheduler might prefer one type over another, leading to
 sub-optimal loading and in the worst case starvation of one type. Servers are
 RECOMMENDED to avoid starvation but no specific method of doing so is prescribed.
 
-
 An HTTP/2 server that sends SETTINGS_DEPRECATE_HTTP2_PRIORITIES ({{disabling}})
 SHOULD NOT act on HTTP/2 priority signals.
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -158,7 +158,7 @@ multiple experiments from independent research have shown that simpler schemes
 can reach at least equivalent performance characteristics compared to the more
 complex HTTP/2 setups seen in practice, at least for the web use case.
 
-## Disabling HTTP/2 Priorities
+## Disabling HTTP/2 Priorities {#disabling}
 
 The problems and insights set out above are motivation for allowing endpoints to
 opt out of using the HTTP/2 priority scheme, in favor of using an alternative
@@ -501,8 +501,54 @@ not specify the incremental(`i`) parameter.
 
 # Client Scheduling
 
-A client MAY use priority values to make local scheduling choices about the
-requests it initiates.
+A client MAY use priority values to make local processing or scheduling choices
+about the requests it initiates.
+
+
+# Server Scheduling
+
+Priority signals are input to a prioritization process. They do not guarantee
+any particular processing or transmission order for one response relative to any
+other response. An endpoint cannot force a peer to process concurrent request in
+a particular order using priority. Expressing priority is therefore only a
+suggestion.
+
+A server can use Priority signals along with other inputs to make scheduling
+decisions. No guidance is provided about how this can or should be done. Factors
+such as implementation choices or deployment environment also play a role. Any
+given connection is likely to have many dynamic permutations. For these reasons,
+there is no unilateral perfect scheduler and this document only provides some
+basic recommendations for implementations. 
+
+Clients can expect servers will make prioritization decisions, including
+ignoring all signals. And they should expect that decisions might be based on
+metadata or information beyond the scope of extensible priorities. 
+
+It is RECOMMENDED that, when possible, servers respect urgency values. Sending
+higher urgency responses before lower urgency responses.
+
+It is RECOMMENDED that, when possible, servers respect incremental values.
+Sending non-incremental responses of the same urgency one-by-one, and sending
+incremental responses of the same urgency in round-robin manner.
+
+It is RECOMMENDED that a server considers request generation order as an input
+to prioritization. This can be determined from the Stream ID. A server that
+receives concurrent requests at the same urgency level might serve the responses
+one-by-one but it needs to pick an order. Serving the lowest Stream ID in a
+given urgency level can align well with clients usage of HTTP; such as user
+agents that load document trees where ordering is important.
+
+For non-incremental resources the total download time (time to first byte - time
+to last byte) is important. For incremental resources chunk download times are
+important, especially the first. A server that receives a mix of incremental and
+non-incremental at the same urgency is challenged to schedule two competing
+factors. An unbalanced scheduler might prefer one type over another, leading to
+sub-optimal loading and in the worst case starvation of one type. Servers are
+RECOMMENDED to avoid starvation but no specific method of doing so is prescribed.
+
+
+An HTTP/2 server that sends SETTINGS_DEPRECATE_HTTP2_PRIORITIES ({{disabling}})
+SHOULD NOT act on HTTP/2 priority signals.
 
 
 # Fairness {#fairness}

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -558,7 +558,7 @@ to do so is an implementation decision. For example, a server might
 pre-emptively send responses of a particular incremental type based on other
 information such as content size.
 
-HTTP/2 endpoints can advertise that they using the Extensible Priorities scheme
+HTTP/2 endpoints can advertise that they are using the Extensible Priorities scheme
 instead of the HTTP/2 priority scheme by sending
 SETTINGS_DEPRECATE_HTTP2_PRIORITIES; see {{disabling}}. A server that sends or
 receives this setting SHOULD NOT act on priority signals belonging to the HTTP/2

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -546,8 +546,11 @@ factors. An unbalanced scheduler might prefer one type over another, leading to
 sub-optimal loading and in the worst case starvation of one type. Servers are
 RECOMMENDED to avoid starvation but no specific method of doing so is prescribed.
 
-An HTTP/2 server that sends SETTINGS_DEPRECATE_HTTP2_PRIORITIES ({{disabling}})
-SHOULD NOT act on HTTP/2 priority signals.
+An HTTP/2 server implementing the Extensible Priorities scheme instead of the
+HTTP/2 priority sends SETTINGS_DEPRECATE_HTTP2_PRIORITIES; see {{disabling}}. It
+SHOULD NOT act on priority signals belonging to the HTTP/2 scheme. The absence
+of a client Extensible Priority signal for SHOULD be treated as though default
+urgency and incremental parameters were sent.
 
 
 # Fairness {#fairness}

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -523,7 +523,7 @@ basic recommendations for implementations.
 Clients cannot depend on particular treatment based on priority signals. Servers
 can use other information to prioritize responses.
 
-It is RECOMMENDED that, when possible, servers respect urgency values. Sending
+It is RECOMMENDED that, when possible, servers respect urgency values, sending
 higher urgency responses before lower urgency responses.
 
 It is RECOMMENDED that, when possible, servers respect incremental values.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -558,11 +558,12 @@ to do so is an implementation decision. For example, a server might
 pre-emptively send responses of a particular incremental type based on other
 information such as content size.
 
-An HTTP/2 server implementing the Extensible Priorities scheme instead of the
-HTTP/2 priority sends SETTINGS_DEPRECATE_HTTP2_PRIORITIES; see {{disabling}}. It
-SHOULD NOT act on priority signals belonging to the HTTP/2 scheme. The absence
-of a client Extensible Priority signal for SHOULD be treated as though default
-urgency and incremental parameters were sent.
+HTTP/2 endpoints can advertise that they using the Extensible Priorities scheme
+instead of the HTTP/2 priority scheme by sending
+SETTINGS_DEPRECATE_HTTP2_PRIORITIES; see {{disabling}}. A server that sends or
+receives this setting SHOULD NOT act on priority signals belonging to the HTTP/2
+scheme. The absence of a client Extensible Priority signal SHOULD be treated
+as though default urgency and incremental parameters were sent.
 
 
 # Fairness {#fairness}

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -532,7 +532,7 @@ It is RECOMMENDED that, when possible, servers respect the urgency parameter
 
 It is RECOMMENDED that, when possible, servers respect the incremental
 parameter ({{incremental}}). Non-incremental responses of the same urgency
-SHOULD be served one-by-one based on the Stream ID, that corersponds to the
+SHOULD be served one-by-one based on the Stream ID, which corresponds to the
 order in which clients make requests. Doing so ensures that clients can use
 request ordering to influence response order. Incremental responses of the same
 urgency SHOULD be served in round-robin manner.


### PR DESCRIPTION
This tries to address two sets of comments on "what signals are subsumed by priority hints" and "how should a server implement things". 

One aspect of this is setting client expectations straight; they should have a vague idea what will happen if a server plays ball but also expect that servers can and will do whatever they want.

The other aspect of this is describing what signals servers have at their disposal, and presenting some of the gotchas or tradeoffs that might happen if the extensible priority scheme is implemented too matter-of-fact. Some people would like to see more explicit guidance for servers, that's a fine request. However, I don't see how any single scheduling algorithm would work for the range of vendors and deployments that have shown an interest Priorities, so I've focused on the common criteria.

While adding this section, the thought did cross my mind to move the sections on scheduling. We can always do that as a followup.

Closes #1216 and #1232.

cc @ekinnear, @guoye-zhang, @martinthomson 