### PR TITLE
Describe frame/header dichotomy and error handling for SFV failures

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -312,8 +312,8 @@ properties of an HTTP request it receives, the server is expected to control the
 cacheability or the applicability of the cached response, by using header fields
 that control the caching behavior (e.g., Cache-Control, Vary).
 
-An endpoint that fails to parse the Priority header SHOULD use default parameter
-values.
+An endpoint that fails to parse the Priority header field SHOULD use default
+parameter values.
 
 
 # Reprioritization
@@ -340,7 +340,7 @@ the PRIORITY_UPDATE frame is a hop-by-hop signal.
 PRIORITY_UPDATE frames are sent by clients on the control stream, allowing them
 to be sent independent from the stream that carries the response. This means
 they can be used to reprioritize a response or a push stream; or signal the
-initial priority of a response instead of the Priority header.
+initial priority of a response instead of the Priority header field.
 
 A PRIORITY_UPDATE frame communicates a complete set of all parameters in the
 Priority Field Value field. Omitting a parameter is a signal to use the

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -345,7 +345,7 @@ initial priority of a response instead of the Priority header field.
 A PRIORITY_UPDATE frame communicates a complete set of all parameters in the
 Priority Field Value field. Omitting a parameter is a signal to use the
 parameter's default value. Failure to parse the Priority Field Value MUST be
-treat as a connection error of type FRAME_ENCODING_ERROR.
+treated as a connection error of type FRAME_ENCODING_ERROR.
 
 A client MAY send a PRIORITY_UPDATE frame before the stream that it references
 is open. Furthermore, HTTP/3 offers no guaranteed ordering across streams, which

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -312,6 +312,9 @@ properties of an HTTP request it receives, the server is expected to control the
 cacheability or the applicability of the cached response, by using header fields
 that control the caching behavior (e.g., Cache-Control, Vary).
 
+An endpoint that fails to parse the Priority header SHOULD use default parameter
+values.
+
 
 # Reprioritization
 
@@ -338,6 +341,11 @@ PRIORITY_UPDATE frames are sent by clients on the control stream, allowing them
 to be sent independent from the stream that carries the response. This means
 they can be used to reprioritize a response or a push stream; or signal the
 initial priority of a response instead of the Priority header.
+
+A PRIORITY_UPDATE frame communicates a complete set of all parameters in the
+Priority Field Value field. Omitting a parameter is a signal to use the
+parameter's default value. Failure to parse the Priority Field Value MUST be
+treat as a connection error of type FRAME_ENCODING_ERROR.
 
 A client MAY send a PRIORITY_UPDATE frame before the stream that it references
 is open. Furthermore, HTTP/3 offers no guaranteed ordering across streams, which


### PR DESCRIPTION
As noted in the discussion on #1267, there is some asymmetry between the Priority header and PRIORITY_UPDATE frame. This PR addresses the dichotomy by localized description of the frame. I've avoided great exposition of the dichotomy because I feel it could be wordy and distracting; others might disagree.

The changes dovetail nicely with the discussion #1268 about how to handle parsing failures. So adding that at the same time.

Closes #1267 and #1268 

cc: @martinthomson @dtikhonov @kazuho 
