### PR TITLE
fix the error type when PRIORITY_UPDATE is bogus

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -349,7 +349,8 @@ initial priority of a response instead of the Priority header field.
 A PRIORITY_UPDATE frame communicates a complete set of all parameters in the
 Priority Field Value field. Omitting a parameter is a signal to use the
 parameter's default value. Failure to parse the Priority Field Value MUST be
-treated as a connection error of type FRAME_ENCODING_ERROR.
+treated as a connection error. In HTTP/2 the error is of type PROTOCOL_ERROR; in
+HTTP/3 the error is of type H3_FRAME_ERROR.
 
 A client MAY send a PRIORITY_UPDATE frame before the stream that it references
 is open. Furthermore, HTTP/3 offers no guaranteed ordering across streams, which


### PR DESCRIPTION
Fixes #1277 

@dtikhonov correctly pointed out that the draft contained a made up error code. On inspection, we need to define specific error codes for both H2 and H3. This change does that.