### PR TITLE
Detail encryption quirks

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1059,7 +1059,7 @@ in conjunction with the encrypted content-coding {{?RFC8188}}.
 
 The representation-data-digest of an encrypted payload can change between different messages
 depending on the encryption algorithm used; in those cases its value could not be used to provide
-a proof of integrity "at rest" unless the whole (eg. encoded) payload body is persisted.
+a proof of integrity "at rest" unless the whole (e.g. encoded) payload body is persisted.
 
 ## Algorithm Agility
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1055,7 +1055,11 @@ the whole payload before sending a message (eg. see {{?I-D.thomson-http-mice}}).
 `Digest` may expose information details of encrypted payload when the checksum
 is computed on the unencrypted data.
 An example of that is the use of the "id-sha-256" digest-algorithm
-in conjuction with the encrypted content-coding {{?RFC8188}}.
+in conjunction with the encrypted content-coding {{?RFC8188}}.
+
+The representation-data-digest of an encrypted payload can change between different messages
+depending on the encryption algorithm used: in those cases its value could not be used to provide
+a proof of integrity "at rest" unless the whole (eg. encoded) payload body is persisted.
 
 ## Algorithm Agility
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1058,7 +1058,7 @@ An example of that is the use of the "id-sha-256" digest-algorithm
 in conjunction with the encrypted content-coding {{?RFC8188}}.
 
 The representation-data-digest of an encrypted payload can change between different messages
-depending on the encryption algorithm used: in those cases its value could not be used to provide
+depending on the encryption algorithm used; in those cases its value could not be used to provide
 a proof of integrity "at rest" unless the whole (eg. encoded) payload body is persisted.
 
 ## Algorithm Agility


### PR DESCRIPTION
## This PR

details encryption quirks:

- encryption functions may produce different results with the same data
- this means that if I GET an encrypted resource twice, I could get two different digest values
- so the digest value is just good to validate the ongoing message and not for further processing of the data at rest, unless I store the encrypted data or use an `id-` algorithm which in turn might disclose information.

This  