### PR TITLE
Fix: 1208. Intermediaries altering content/transfer-coding or content…

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -281,7 +281,6 @@ A recipient MAY ignore any or all of the representation-data-digests in a Digest
 field. This allows the recipient to choose which digest-algorithm(s) to use for
 validation instead of verifying every received representation-data-digest.
 
-An intermediary MUST NOT alter the value of a received `Digest` field.
 
 A sender MAY send a representation-data-digest using a digest-algorithm without
 knowing whether the recipient supports the digest-algorithm, or even knowing
@@ -1532,4 +1531,3 @@ _RFC Editor: Please remove this section before publication._
 * Use when acting on resources (POST, PATCH) #853
 * Added Relationship with SRI, draft Use Cases #868, #971
 * Warn about the implications of `Content-Location`
-

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1013,7 +1013,7 @@ multiple hops, as it just covers the `representation data` and not the
 `representation metadata`.
 
 Besides, it allows to protect `representation data` from buggy manipulation,
- etc.
+undesired "transforming proxies" (see Section 6.5 of {{SEMANTICS}}), etc.
 
 Moreover identity digest-algorithms (eg. "id-sha-256" and "id-sha-512") allow
 piecing together a resource from different sources (e.g. different servers that

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -281,6 +281,7 @@ A recipient MAY ignore any or all of the representation-data-digests in a Digest
 field. This allows the recipient to choose which digest-algorithm(s) to use for
 validation instead of verifying every received representation-data-digest.
 
+An intermediary MUST NOT alter the value of a received `Digest` field.
 
 A sender MAY send a representation-data-digest using a digest-algorithm without
 knowing whether the recipient supports the digest-algorithm, or even knowing

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -117,7 +117,7 @@ integrity protection; for instance TCP checksums or TLS records [RFC2818].
 
 However, there are cases where relying on this alone is insufficient. An
 HTTP-level integrity mechanism that operates independent of transfer can be used
-to detect programming errors and/or corruption of data at rest, be used across
+to detect programming errors and/or corruption of data in flight or at rest, be used across
 multiple hops in order to provide end-to-end integrity guarantees, aid fault
 diagnosis across hops and system boundaries, and can be used to validate
 integrity when reconstructing a resource fetched using different HTTP
@@ -1013,7 +1013,7 @@ multiple hops, as it just covers the `representation data` and not the
 `representation metadata`.
 
 Besides, it allows to protect `representation data` from buggy manipulation,
-buggy compression, etc.
+ etc.
 
 Moreover identity digest-algorithms (eg. "id-sha-256" and "id-sha-512") allow
 piecing together a resource from different sources (e.g. different servers that


### PR DESCRIPTION
## This PR

- [x] avoid ambiguous statement on digest protecting from compressed content-coding https://github.com/httpwg/http-extensions/issues/1208#issuecomment-634351643
- i[x] t can protect from intermediaries altering representation metadata (content-type, content-coding)

