### PR TITLE
Validate Structured Fields, with adjustments

### DIFF
--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -157,6 +157,7 @@ Verifier:
 
 This document contains non-normative examples of partial and complete HTTP messages.  To improve readability, header fields may be split into multiple lines, using the `obs-fold` syntax.  This syntax is deprecated in [RFC7230], and senders MUST NOT generate messages that include it.
 
+Additionally, some examples use '\\' line wrapping for long values that contain no whitespace, as per {{!RFC8792}}.
 
 # Identifying and Canonicalizing Content {#content-identifiers}
 
@@ -507,29 +508,33 @@ The `Signature` HTTP header field is a Dictionary Structured Header {{Structured
 The following is a non-normative example of `Signature-Input` and `Signature` HTTP header fields representing the signature in {{example-sig-value}}:
 
 ~~~ http-message
+# NOTE: '\' line wrapping per RFC 8792
+
 Signature-Input: sig1=(*request-target *created host date
     cache-control x-empty-header x-example); keyid="test-key-a";
     alg=hs2019; created=1402170695; expires=1402170995
-Signature: sig1=:K2qGT5srn2OGbOIDzQ6kYT+ruaycnDAAUpKv+ePFfD0RAxn/1BUe
-    Zx/Kdrq32DrfakQ6bPsvB9aqZqognNT6be4olHROIkeV879RrsrObury8L9SCEibe
-    oHyqU/yCjphSmEdd7WD+zrchK57quskKwRefy2iEC5S2uAH0EPyOZKWlvbKmKu5q4
-    CaB8X/I5/+HLZLGvDiezqi6/7p2Gngf5hwZ0lSdy39vyNMaaAT0tKo6nuVw0S1MVg
-    1Q7MpWYZs0soHjttq0uLIA3DIbQfLiIvK6/l0BdWTU7+2uQj7lBkQAsFZHoA96ZZg
+Signature: sig1=:K2qGT5srn2OGbOIDzQ6kYT+ruaycnDAAUpKv+ePFfD0RAxn/1BUe\
+    Zx/Kdrq32DrfakQ6bPsvB9aqZqognNT6be4olHROIkeV879RrsrObury8L9SCEibe\
+    oHyqU/yCjphSmEdd7WD+zrchK57quskKwRefy2iEC5S2uAH0EPyOZKWlvbKmKu5q4\
+    CaB8X/I5/+HLZLGvDiezqi6/7p2Gngf5hwZ0lSdy39vyNMaaAT0tKo6nuVw0S1MVg\
+    1Q7MpWYZs0soHjttq0uLIA3DIbQfLiIvK6/l0BdWTU7+2uQj7lBkQAsFZHoA96ZZg\
     FquQrXRlmYOh+Hx5D9fJkXcXe5tmAg==:
 ~~~
 
 Since `Signature-Input` and `Signature` are both defined as Dictionary Structured Headers, they can be used to easily include multiple signatures within the same HTTP message. For example, a signer may include multiple signatures signing the same content with different keys and/or algorithms to support verifiers with different capabilities, or a reverse proxy may include information about the client in header fields when forwarding the request to a service host, and may also include a signature over those fields and the client's signature. The following is a non-normative example of header fields a reverse proxy might add to a forwarded request that contains the signature in the above example:
 
 ~~~ http-message
+# NOTE: '\' line wrapping per RFC 8792
+
 X-Forwarded-For: 192.0.2.123
 Signature-Input: reverse_proxy_sig=(*created host date
     signature:sig1 x-forwarded-for); keyid="test-key-a";
     alg=hs2019; created=1402170695; expires=1402170695.25
-Signature: reverse_proxy_sig=:ON3HsnvuoTlX41xfcGWaOEVo1M3bJDRBOp0Pc/O
-    jAOWKQn0VMY0SvMMWXS7xG+xYVa152rRVAo6nMV7FS3rv0rR5MzXL8FCQ2A35DCEN
-    LOhEgj/S1IstEAEFsKmE9Bs7McBsCtJwQ3hMqdtFenkDffSoHOZOInkTYGafkoy78
-    l1VZvmb3Y4yf7McJwAvk2R3gwKRWiiRCw448Nt7JTWzhvEwbh7bN2swc/v3NJbg/w
-    JYyYVbelZx4IywuZnYFxgPl/qvqbAjeEVvaLKLgSMr11y+uzxCHoMnDUnTYhMrmOT
+Signature: reverse_proxy_sig=:ON3HsnvuoTlX41xfcGWaOEVo1M3bJDRBOp0Pc/O\
+    jAOWKQn0VMY0SvMMWXS7xG+xYVa152rRVAo6nMV7FS3rv0rR5MzXL8FCQ2A35DCEN\
+    LOhEgj/S1IstEAEFsKmE9Bs7McBsCtJwQ3hMqdtFenkDffSoHOZOInkTYGafkoy78\
+    l1VZvmb3Y4yf7McJwAvk2R3gwKRWiiRCw448Nt7JTWzhvEwbh7bN2swc/v3NJbg/w\
+    JYyYVbelZx4IywuZnYFxgPl/qvqbAjeEVvaLKLgSMr11y+uzxCHoMnDUnTYhMrmOT\
     4O8lBLfRFOcoJPKBdoKg9U0a96U2mUug1bFOozEVYFg==:
 ~~~
 
@@ -754,13 +759,15 @@ vtzidyBYFtAUoYhRWO8+ntqA1q2OK4LMjM2XgDScSVWvGdVd459A0wI9lRlnPap3zg==
 A possible `Signature-Input` and `Signature` header containing this signature is:
 
 ~~~ http-message
+# NOTE: '\' line wrapping per RFC 8792
+
 Signature-Input: sig1=(*created *request-target);
     keyid="test-key-a"; created=1402170695
-Signature: sig1=:QaVaWYfF2da6tG66Xtd0GrVFChJ0fOWUe/C6kaYESPiYYwnMH9eg
-    OgyKqgLLY9NQJFk7bQY834sHEUwjS5ByEBaO3QNwIvqEY1qAAU/2MX14tc9Yn7ELB
-    naaNHaHkV3xVO9KIuLT7V6e4OUuGb1axfbXpMgPEql6CEFrn6K95CLuuKP5/gOEcB
-    tmJp5L58gN4VvZrk2OVA6U971YiEDNuDa4CwMcQMvcGssbc/L3OULTUffD/1VcPtd
-    GImP2uvVQntpT8b2lBeBpfh8MuaV2vtzidyBYFtAUoYhRWO8+ntqA1q2OK4LMjM2X
+Signature: sig1=:QaVaWYfF2da6tG66Xtd0GrVFChJ0fOWUe/C6kaYESPiYYwnMH9eg\
+    OgyKqgLLY9NQJFk7bQY834sHEUwjS5ByEBaO3QNwIvqEY1qAAU/2MX14tc9Yn7ELB\
+    naaNHaHkV3xVO9KIuLT7V6e4OUuGb1axfbXpMgPEql6CEFrn6K95CLuuKP5/gOEcB\
+    tmJp5L58gN4VvZrk2OVA6U971YiEDNuDa4CwMcQMvcGssbc/L3OULTUffD/1VcPtd\
+    GImP2uvVQntpT8b2lBeBpfh8MuaV2vtzidyBYFtAUoYhRWO8+ntqA1q2OK4LMjM2X\
     gDScSVWvGdVd459A0wI9lRlnPap3zg==:
 ~~~
 
@@ -801,14 +808,16 @@ PxzQ5nwrLD+mUVPZ9rDs1En6fmOX9xfkZTblG/5D+s1fHHs9dDXCOVkT5dLS8DjdIA==
 A possible `Signature-Input` and `Signature` header containing this signature is:
 
 ~~~ http-message
+# NOTE: '\' line wrapping per RFC 8792
+
 Signature-Input: sig1=(*request-target *created host date
         content-type digest content-length); keyid="test-key-a";
     alg=hs2019; created=1402170695
-Signature: sig1=:B24UG4FaiE2kSXBNKV4DA91J+mElAhS3mncrgyteAye1GKMpmzt8
-    jkHNjoudtqw3GngGY3n0mmwjdfn1eA6nAjgeHwl0WXced5tONcCPNzLswqPOiobGe
-    A5y4WE8iBveel30OKYVel0lZ1OnXOmN5TIEIIPo9LrE+LzZis6A0HA1FRMtKgKGhT
-    3N965pkqfhKbq/V48kpJKT8+cZs0TOn4HFMG+OIy6c9ofSBrXD68yxP6QYTz6xH0G
-    MWawLyPLYR52j3I05fK1ylAb6K0oxPxzQ5nwrLD+mUVPZ9rDs1En6fmOX9xfkZTbl
+Signature: sig1=:B24UG4FaiE2kSXBNKV4DA91J+mElAhS3mncrgyteAye1GKMpmzt8\
+    jkHNjoudtqw3GngGY3n0mmwjdfn1eA6nAjgeHwl0WXced5tONcCPNzLswqPOiobGe\
+    A5y4WE8iBveel30OKYVel0lZ1OnXOmN5TIEIIPo9LrE+LzZis6A0HA1FRMtKgKGhT\
+    3N965pkqfhKbq/V48kpJKT8+cZs0TOn4HFMG+OIy6c9ofSBrXD68yxP6QYTz6xH0G\
+    MWawLyPLYR52j3I05fK1ylAb6K0oxPxzQ5nwrLD+mUVPZ9rDs1En6fmOX9xfkZTbl\
     G/5D+s1fHHs9dDXCOVkT5dLS8DjdIA==:
 ~~~
 
@@ -819,12 +828,14 @@ Signature: sig1=:B24UG4FaiE2kSXBNKV4DA91J+mElAhS3mncrgyteAye1GKMpmzt8
 This presents a `Signature-Input` and `Signature` header containing only the minimal required parameters:
 
 ~~~ http-message
+# NOTE: '\' line wrapping per RFC 8792
+
 Signature-Input: sig1=(); keyid="test-key-a"; created=1402170695
-Signature: sig1=:cxieW5ZKV9R9A70+Ua1A/1FCvVayuE6Z77wDGNVFSiluSzR9TYFV
-    vwUjeU6CTYUdbOByGMCee5q1eWWUOM8BIH04Si6VndEHjQVdHqshAtNJk2Quzs6WC
-    2DkV0vysOhBSvFZuLZvtCmXRQfYGTGhZqGwq/AAmFbt5WNLQtDrEe0ErveEKBfaz+
-    IJ35zhaj+dun71YZ82b/CRfO6fSSt8VXeJuvdqUuVPWqjgJD4n9mgZpZFGBaDdPiw
-    pfbVZHzcHrumFJeFHWXH64a+c5GN+TWlP8NPg2zFdEc/joMymBiRelq236WGm5VvV
+Signature: sig1=:cxieW5ZKV9R9A70+Ua1A/1FCvVayuE6Z77wDGNVFSiluSzR9TYFV\
+    vwUjeU6CTYUdbOByGMCee5q1eWWUOM8BIH04Si6VndEHjQVdHqshAtNJk2Quzs6WC\
+    2DkV0vysOhBSvFZuLZvtCmXRQfYGTGhZqGwq/AAmFbt5WNLQtDrEe0ErveEKBfaz+\
+    IJ35zhaj+dun71YZ82b/CRfO6fSSt8VXeJuvdqUuVPWqjgJD4n9mgZpZFGBaDdPiw\
+    pfbVZHzcHrumFJeFHWXH64a+c5GN+TWlP8NPg2zFdEc/joMymBiRelq236WGm5VvV\
     9a22RW2/yLmaU/uwf9v40yGR/I1NRA==:
 ~~~
 
@@ -849,13 +860,15 @@ The corresponding Signature Input is:
 This presents a `Signature-Input` and `Signature` header containing only the minimal required and recommended parameters:
 
 ~~~ http-message
+# NOTE: '\' line wrapping per RFC 8792
+
 Signature-Input: sig1=(); alg=hs2019; keyid="test-key-a";
     created=1402170695
-Signature: sig1=:cxieW5ZKV9R9A70+Ua1A/1FCvVayuE6Z77wDGNVFSiluSzR9TYFV
-    vwUjeU6CTYUdbOByGMCee5q1eWWUOM8BIH04Si6VndEHjQVdHqshAtNJk2Quzs6WC
-    2DkV0vysOhBSvFZuLZvtCmXRQfYGTGhZqGwq/AAmFbt5WNLQtDrEe0ErveEKBfaz+
-    IJ35zhaj+dun71YZ82b/CRfO6fSSt8VXeJuvdqUuVPWqjgJD4n9mgZpZFGBaDdPiw
-    pfbVZHzcHrumFJeFHWXH64a+c5GN+TWlP8NPg2zFdEc/joMymBiRelq236WGm5VvV
+Signature: sig1=:cxieW5ZKV9R9A70+Ua1A/1FCvVayuE6Z77wDGNVFSiluSzR9TYFV\
+    vwUjeU6CTYUdbOByGMCee5q1eWWUOM8BIH04Si6VndEHjQVdHqshAtNJk2Quzs6WC\
+    2DkV0vysOhBSvFZuLZvtCmXRQfYGTGhZqGwq/AAmFbt5WNLQtDrEe0ErveEKBfaz+\
+    IJ35zhaj+dun71YZ82b/CRfO6fSSt8VXeJuvdqUuVPWqjgJD4n9mgZpZFGBaDdPiw\
+    pfbVZHzcHrumFJeFHWXH64a+c5GN+TWlP8NPg2zFdEc/joMymBiRelq236WGm5VvV\
     9a22RW2/yLmaU/uwf9v40yGR/I1NRA==:
 ~~~
 
@@ -880,12 +893,14 @@ The corresponding Signature Input is:
 This presents a minimal `Signature-Input` and `Signature` header for a signature using the `rsa-sha256` algorithm:
 
 ~~~ http-message
+# NOTE: '\' line wrapping per RFC 8792
+
 Signature: sig1=(date); alg=rsa-sha256; keyid="test-key-b"
-Signature: sig1=:HtXycCl97RBVkZi66ADKnC9c5eSSlb57GnQ4KFqNZplOpNfxqk62
-    JzZ484jXgLvoOTRaKfR4hwyxlcyb+BWkVasApQovBSdit9Ml/YmN2IvJDPncrlhPD
-    VDv36Z9/DiSO+RNHD7iLXugdXo1+MGRimW1RmYdenl/ITeb7rjfLZ4b9VNnLFtVWw
-    rjhAiwIqeLjodVImzVc5srrk19HMZNuUejK6I3/MyN3+3U8tIRW4LWzx6ZgGZUaEE
-    P0aBlBkt7Fj0Tt5/P5HNW/Sa/m8smxbOHnwzAJDa10PyjzdIbywlnWIIWtZKPPsoV
+Signature: sig1=:HtXycCl97RBVkZi66ADKnC9c5eSSlb57GnQ4KFqNZplOpNfxqk62\
+    JzZ484jXgLvoOTRaKfR4hwyxlcyb+BWkVasApQovBSdit9Ml/YmN2IvJDPncrlhPD\
+    VDv36Z9/DiSO+RNHD7iLXugdXo1+MGRimW1RmYdenl/ITeb7rjfLZ4b9VNnLFtVWw\
+    rjhAiwIqeLjodVImzVc5srrk19HMZNuUejK6I3/MyN3+3U8tIRW4LWzx6ZgGZUaEE\
+    P0aBlBkt7Fj0Tt5/P5HNW/Sa/m8smxbOHnwzAJDa10PyjzdIbywlnWIIWtZKPPsoV\
     oKVopUWEU3TNhpWmaVhFrUL/O6SN3w==:
 ~~~
 

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -143,19 +143,19 @@ For brevity, the term "signature" on its own is used in this document to refer t
 In addition to those listed above, this document uses the following terms:
 
 Decimal String
-: 
+:
 : An Integer String optionally concatenated with a period "." followed by a second Integer String, representing a positive real number expressed in base 10.  The first Integer String represents the integral portion of the number, while the optional second Integer String represents the fractional portion of the number.  (( Editor's note: There's got to be a definition for this that we can reference. ))
 
 Integer String
-: 
+:
 : A US-ASCII string of one or more digits "0-9", representing a positive integer in base 10. (( Editor's note: There's got to be a definition for this that we can reference. ))
 
 Signer
-: 
+:
 : The entity that is generating or has generated an HTTP Message Signature.
 
 Verifier
-: 
+:
 : An entity that is verifying or has verified an HTTP Message Signature against an HTTP Message.  Note that an HTTP Message Signature may be verified multiple times, potentially by different entities.
 
 This document contains non-normative examples of partial and complete HTTP messages.  To improve readability, header fields may be split into multiple lines, using the `obs-fold` syntax.  This syntax is deprecated in [RFC7230], and senders MUST NOT generate messages that include it.
@@ -187,10 +187,10 @@ This section contains non-normative examples of canonicalized values for header 
 HTTP/1.1 200 OK
 Server: www.example.com
 Date: Tue, 07 Jun 2014 20:51:35 GMT
-X-OWS-Header:   Leading and trailing whitespace.   
-X-Obs-Fold-Header: Obsolete  
+X-OWS-Header:   Leading and trailing whitespace.
+X-Obs-Fold-Header: Obsolete
     line folding.
-X-Empty-Header: 
+X-Empty-Header:
 Cache-Control: max-age=60
 Cache-Control:    must-revalidate
 ~~~
@@ -334,23 +334,23 @@ An HTTP Message Signature is a signature over a string generated from a subset o
 HTTP Message Signatures have metadata properties that provide information regarding the signature's generation and/or verification.  The following metadata properties are defined:
 
 Algorithm
-: 
+:
 : An HTTP Signature Algorithm defined in the HTTP Signature Algorithms Registry defined in this document. It describes the signing and verification algorithms for the signature.
 
 Creation Time
-: 
+:
 : A timestamp representing the point in time that the signature was generated. Sub-second precision is not supported. A signature's Creation Time MAY be undefined, indicating that it is unknown.
 
 Covered Content
-: 
+:
 : An ordered list of content identifiers (Section 2) that indicates the metadata and message content that is covered by the signature. The order of identifiers in this list affects signature generation and verification, and therefore MUST be preserved.
 
 Expiration Time
-: 
+:
 : A timestamp representing the point in time at which the signature expires. An expired signature always fails verification. A signature's Expiration Time MAY be undefined, indicating that the signature does not expire.
 
 Verification Key Material
-: 
+:
 : The key material required to verify the signature.
 
 
@@ -465,7 +465,7 @@ In order to verify a signature, a verifier MUST:
 3. Use the signature's Algorithm and Verification Key Material with the recreated Signing Input to verify the signature value.
 
 
-A signature with a Creation Time that is in the future or an Expiration Time that is in the past MUST NOT be processed.  
+A signature with a Creation Time that is in the future or an Expiration Time that is in the past MUST NOT be processed.
 
 The verifier MUST ensure that a signature's Algorithm is appropriate for the key material the verifier will use to verify the signature.  If the Algorithm is not appropriate for the key material (for example, if it is the wrong size, or in the wrong format), the signature MUST NOT be processed.
 
@@ -494,19 +494,19 @@ The `Signature-Input` HTTP header field is a Dictionary Structured Header {{Stru
 The parameters on each `Signature-Input` member value contain metadata about the signature. Each parameter name MUST be a parameter name registered in the IANA HTTP Signatures Metadata Parameters Registry defined in {{param-registry}} of this document. This document defines the following parameters, and registers them as the initial contents of the registry:
 
 alg
-: 
+:
 : RECOMMENDED. The `alg` parameter is a Token containing the name of the signature's Algorithm, as registered in the HTTP Signature Algorithms Registry defined by this document. Verifiers MUST determine the signature's Algorithm from the `keyId` parameter rather than from `alg`. If `alg` is provided and differs from or is incompatible with the algorithm or key material identified by `keyId` (for example, `alg` has a value of `rsa-sha256` but `keyId` identifies an EdDSA key), then implementations MUST produce an error.
 
 created
-: 
+:
 : RECOMMENDED. The `created` parameter is a Decimal containing the signature's Creation Time, expressed as the canonicalized value of the `*created` content identifier, as defined in Section 2.  If not specified, the signature's Creation Time is undefined.  This parameter is useful when signers are not capable of controlling the Date HTTP Header such as when operating in certain web browser environments.
 
 expires
-: 
+:
 : OPTIONAL. The `expires` parameter is a Decimal containing the signature's Expiration Time, expressed as the canonicalized value of the `*expires` content identifier, as defined in Section 2.  If the signature does not have an Expiration Time, this parameter MUST be omitted.  If not specified, the signature's Expiration Time is undefined.
 
 keyId
-: 
+:
 : REQUIRED. The `keyId` parameter is a String whose value can be used by a verifier to identify and/or obtain the signature's Verification Key Material. Further format and semantics of this value are out of scope for this document.
 
 ## The 'Signature' HTTP Header
@@ -552,15 +552,15 @@ This document defines HTTP Signature Algorithms, for which IANA is asked to crea
 ### Registration Template {#iana-hsa-template}
 
 Algorithm Name
-: 
+:
 : An identifier for the HTTP Signature Algorithm. The name MUST be an ASCII string consisting only of lower-case characters (`"a"` - `"z"`), digits (`"0"` - `"9"`), and hyphens (`"-"`), and SHOULD NOT exceed 20 characters in length.  The identifier MUST be unique within the context of the registry.
 
 Status
-: 
+:
 : A brief text description of the status of the algorithm.  The description MUST begin with one of "Active" or "Deprecated", and MAY provide further context or explanation as to the reason for the status.
 
 Description
-: 
+:
 : A description of the algorithm used to sign the signing string when generating an HTTP Message Signature, or instructions on how to determine that algorithm.  When the description specifies an algorithm, it MUST include a reference to the document or documents that define the algorithm.
 
 ### Initial Contents {#iana-hsa-contents}
@@ -570,15 +570,15 @@ Description
 #### hs2019
 
 Algorithm Name
-: 
+:
 : `hs2019`
 
 Status
-: 
+:
 : active
 
 Description
-: 
+:
 : Derived from metadata associated with keyId. Recommend support for:
 :    - RSASSA-PSS [RFC8017] using SHA-512 [RFC6234]
 :    - HMAC [RFC2104] using SHA-512 [RFC6234]
@@ -588,54 +588,54 @@ Description
 
 #### rsa-sha1
 Algorithm Name
-: 
+:
 : `rsa-sha1`
 
 Status
-: 
-: Deprecated; SHA-1 not secure. 
+:
+: Deprecated; SHA-1 not secure.
 
 Description
-: 
+:
 : RSASSA-PKCS1-v1_5 [RFC8017] using SHA-1 [RFC6234]
 
 #### rsa-sha256
 Algorithm Name
-: 
+:
 : `rsa-sha256`
 
 Status
-: 
+:
 : Deprecated; specifying signature algorithm enables attack vector.
 
 Description
-: 
+:
 : RSASSA-PKCS1-v1_5 [RFC8017] using SHA-256 [RFC6234]
 
 #### hmac-sha256
 Algorithm Name
-: 
+:
 : `hmac-sha256`
 
 Status
-: 
+:
 : Deprecated; specifying signature algorithm enables attack vector.
 
 Description
-: 
+:
 : HMAC [RFC2104] using SHA-256 [RFC6234]
 
 #### ecdsa-sha256
 Algorithm Name
-: 
+:
 : `ecdsa-sha256`
 
 Status
-: 
+:
 : Deprecated; specifying signature algorithm enables attack vector.
 
 Description
-: 
+:
 : ECDSA using curve P-256 DSS {{FIPS186-4}} and SHA-256 [RFC6234]
 
 ## HTTP Signature Metadata Parameters Registry {#param-registry}
@@ -821,7 +821,7 @@ A possible `Signature-Input` and `Signature` header containing this signature is
 ~~~
 Signature-Input: sig1=(*request-target, *created, host, date,
         content-type, digest, content-length); keyId="test-key-a";
-    alg=hs2019; created=1402170695 
+    alg=hs2019; created=1402170695
 Signature: sig1=:B24UG4FaiE2kSXBNKV4DA91J+mElAhS3mncrgyteAye1GKMpmzt8
     jkHNjoudtqw3GngGY3n0mmwjdfn1eA6nAjgeHwl0WXced5tONcCPNzLswqPOiobGe
     A5y4WE8iBveel30OKYVel0lZ1OnXOmN5TIEIIPo9LrE+LzZis6A0HA1FRMtKgKGhT
@@ -938,7 +938,7 @@ The current draft encourages determining the Algorithm metadata property from th
 
 Punting algorithm identification into `keyId` hurts interoperability, since we aren't defining the syntax or semantics of `keyId`.  It actually goes against that claim, as we are dictating that the signing algorithm must be specified by `keyId` or derivable from it.  It also renders the algorithm registry essentially useless.  Instead of this approach, we can protect against manipulation of the Signature header field by adding support for (and possibly mandating) including Signature metadata within the Signature Input.
 
-### Lack of definition of keyId hurts interoperability 
+### Lack of definition of keyId hurts interoperability
 
 The current text leaves the format and semantics of `keyId` completely up to the implementation.  This is primarily due to the fact that most implementers of Cavage have extensive investment in key distribution and management, and just need to plug an identifier into the header.  We should support those cases, but we also need to provide guidance for the developer that doesn't have that and just wants to know how to identify a key.  It may be enough to punt this to profiling specs, but this needs to be explored more.
 
@@ -959,7 +959,7 @@ The initial entries in this document reflect those in Cavage.  The ones that are
 
 See: [issue #26](https://github.com/w3c-dvcg/http-signatures/issues/26)
 
-The canonicalization rules for `*request-target` do not perform handle minor, semantically meaningless differences in percent-encoding, such that verification could fail if an intermediary normalizes the effective request URI prior to forwarding the message.  
+The canonicalization rules for `*request-target` do not perform handle minor, semantically meaningless differences in percent-encoding, such that verification could fail if an intermediary normalizes the effective request URI prior to forwarding the message.
 
 At a minimum, they should be case and percent-encoding normalized as described in sections 6.2.2.1 and 6.2.2.2 of {{?RFC3986}}.
 
@@ -1132,7 +1132,7 @@ Jeffrey Yasskin
 
   - -00
      * Initialized from draft-richanna-http-message-signatures-00, following adoption by the working group.
-     
+
 - draft-richanna-http-message-signatures
   - -00
      * Converted to xml2rfc v3 and reformatted to comply with RFC style guides.

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -289,35 +289,35 @@ The following table contains non-normative example HTTP messages and their canon
     </thead>
     <tbody>
         <tr>
-            <td><sourcecode>
+            <td><sourcecode type="http-message">
 POST /?param=value HTTP/1.1
 Host: www.example.com</sourcecode></td>
             <td><tt>post /?param=value</tt></td>
         </tr>
         <tr>
-            <td><sourcecode>
+            <td><sourcecode type="http-message">
 POST /a/b HTTP/1.1
 Host: www.example.com</sourcecode></td>
             <td><tt>post /a/b</tt></td>
         </tr>
         <tr>
-            <td><sourcecode>
+            <td><sourcecode type="http-message">
 GET http://www.example.com/a/ HTTP/1.1</sourcecode></td>
             <td><tt>get /a/</tt></td>
         </tr>
         <tr>
-            <td><sourcecode>
+            <td><sourcecode type="http-message">
 GET http://www.example.com HTTP/1.1</sourcecode></td>
             <td><tt>get /</tt></td>
         </tr>
         <tr>
-            <td><sourcecode>
+            <td><sourcecode type="http-message">
 CONNECT server.example.com:80 HTTP/1.1
 Host: server.example.com</sourcecode></td>
             <td><tt>connect /</tt></td>
         </tr>
         <tr>
-            <td><sourcecode>
+            <td><sourcecode type="http-message">
 OPTIONS * HTTP/1.1
 Host: server.example.com</sourcecode></td>
             <td><tt>options *</tt></td>

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -183,7 +183,7 @@ An HTTP header field value is canonicalized as follows:
 
 This section contains non-normative examples of canonicalized values for header fields, given the following example HTTP message:
 
-~~~
+~~~ http-message
 HTTP/1.1 200 OK
 Server: www.example.com
 Date: Tue, 07 Jun 2014 20:51:35 GMT
@@ -215,7 +215,7 @@ An individual member in the value of a Dictionary Structured Field is identified
 
 This section contains non-normative examples of canonicalized values for Dictionary Structured Field Members given the following example header field, whose value is assumed to be a Dictionary:
 
-~~~
+~~~ http-message
 X-Dictionary:  a=1, b=2;x=1;y=2, c=(a, b, c)
 ~~~
 
@@ -237,7 +237,7 @@ A prefix of a List Structured Field consisting of the first N members in the fie
 
 This section contains non-normative examples of canonicalized values for list prefixes given the following example header fields, whose values are assumed to be Dictionaries:
 
-~~~
+~~~ http-message
 X-List-A: (a, b, c, d, e, f)
 X-List-B: ()
 ~~~
@@ -384,7 +384,7 @@ The following sections describe each of these steps in detail.
 
 For example, given the following HTTP message:
 
-~~~
+~~~ http-message
 GET /foo HTTP/1.1
 Host: example.org
 Date: Sat, 07 Jun 2014 20:51:35 GMT
@@ -516,7 +516,7 @@ The `Signature` HTTP header field is a Dictionary Structured Header {{Structured
 
 The following is a non-normative example of `Signature-Input` and `Signature` HTTP header fields representing the signature in {{example-sig-value}}:
 
-~~~
+~~~ http-message
 Signature-Input: sig1=(*request-target, *created, host, date,
     cache-control, x-empty-header, x-example); keyId="test-key-a";
     alg=hs2019; created=1402170695; expires=1402170995
@@ -530,7 +530,7 @@ Signature: sig1=:K2qGT5srn2OGbOIDzQ6kYT+ruaycnDAAUpKv+ePFfD0RAxn/1BUe
 
 Since `Signature-Input` and `Signature` are both defined as Dictionary Structured Headers, they can be used to easily include multiple signatures within the same HTTP message. For example, a signer may include multiple signatures signing the same content with different keys and/or algorithms to support verifiers with different capabilities, or a reverse proxy may include information about the client in header fields when forwarding the request to a service host, and may also include a signature over those fields and the client's signature. The following is a non-normative example of header fields a reverse proxy might add to a forwarded request that contains the signature in the above example:
 
-~~~
+~~~ http-message
 X-Forwarded-For: 192.0.2.123
 Signature-Input: reverse_proxy_sig=(*created, host, date,
     signature:sig1, x-forwarded-for); keyId="test-key-a";
@@ -727,7 +727,7 @@ The table below maps example `keyId` values to associated algorithms and/or keys
 
 This section provides non-normative examples that may be used as test cases to validate implementation correctness.  These examples are based on the following HTTP message:
 
-~~~
+~~~ http-message
 POST /foo?param=value&pet=dog HTTP/1.1
 Host: example.com
 Date: Tue, 07 Jun 2014 20:51:35 GMT
@@ -771,7 +771,7 @@ vtzidyBYFtAUoYhRWO8+ntqA1q2OK4LMjM2XgDScSVWvGdVd459A0wI9lRlnPap3zg==
 
 A possible `Signature-Input` and `Signature` header containing this signature is:
 
-~~~
+~~~ http-message
 Signature-Input: sig1=(*created, *request-target);
     keyId="test-key-a"; created=1402170695
 Signature: sig1=:QaVaWYfF2da6tG66Xtd0GrVFChJ0fOWUe/C6kaYESPiYYwnMH9eg
@@ -818,7 +818,7 @@ PxzQ5nwrLD+mUVPZ9rDs1En6fmOX9xfkZTblG/5D+s1fHHs9dDXCOVkT5dLS8DjdIA==
 
 A possible `Signature-Input` and `Signature` header containing this signature is:
 
-~~~
+~~~ http-message
 Signature-Input: sig1=(*request-target, *created, host, date,
         content-type, digest, content-length); keyId="test-key-a";
     alg=hs2019; created=1402170695
@@ -836,7 +836,7 @@ Signature: sig1=:B24UG4FaiE2kSXBNKV4DA91J+mElAhS3mncrgyteAye1GKMpmzt8
 
 This presents a `Signature-Input` and `Signature` header containing only the minimal required parameters:
 
-~~~
+~~~ http-message
 Signature-Input: sig1=(); keyId="test-key-a"; created=1402170695
 Signature: sig1=:cxieW5ZKV9R9A70+Ua1A/1FCvVayuE6Z77wDGNVFSiluSzR9TYFV
     vwUjeU6CTYUdbOByGMCee5q1eWWUOM8BIH04Si6VndEHjQVdHqshAtNJk2Quzs6WC
@@ -866,7 +866,7 @@ The corresponding Signature Input is:
 
 This presents a `Signature-Input` and `Signature` header containing only the minimal required and recommended parameters:
 
-~~~
+~~~ http-message
 Signature-Input: sig1=(); alg=hs2019; keyId="test-key-a";
     created=1402170695
 Signature: sig1=:cxieW5ZKV9R9A70+Ua1A/1FCvVayuE6Z77wDGNVFSiluSzR9TYFV
@@ -897,7 +897,7 @@ The corresponding Signature Input is:
 
 This presents a minimal `Signature-Input` and `Signature` header for a signature using the `rsa-sha256` algorithm:
 
-~~~
+~~~ http-message
 Signature: sig1=(date); alg=rsa-sha256; keyId="test-key-b"
 Signature: sig1=:HtXycCl97RBVkZi66ADKnC9c5eSSlb57GnQ4KFqNZplOpNfxqk62
     JzZ484jXgLvoOTRaKfR4hwyxlcyb+BWkVasApQovBSdit9Ml/YmN2IvJDPncrlhPD

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -142,20 +142,17 @@ For brevity, the term "signature" on its own is used in this document to refer t
 
 In addition to those listed above, this document uses the following terms:
 
-Decimal String
-:
+{: vspace="0"}
+Decimal String:
 : An Integer String optionally concatenated with a period "." followed by a second Integer String, representing a positive real number expressed in base 10.  The first Integer String represents the integral portion of the number, while the optional second Integer String represents the fractional portion of the number.  (( Editor's note: There's got to be a definition for this that we can reference. ))
 
-Integer String
-:
+Integer String:
 : A US-ASCII string of one or more digits "0-9", representing a positive integer in base 10. (( Editor's note: There's got to be a definition for this that we can reference. ))
 
-Signer
-:
+Signer:
 : The entity that is generating or has generated an HTTP Message Signature.
 
-Verifier
-:
+Verifier:
 : An entity that is verifying or has verified an HTTP Message Signature against an HTTP Message.  Note that an HTTP Message Signature may be verified multiple times, potentially by different entities.
 
 This document contains non-normative examples of partial and complete HTTP messages.  To improve readability, header fields may be split into multiple lines, using the `obs-fold` syntax.  This syntax is deprecated in [RFC7230], and senders MUST NOT generate messages that include it.
@@ -333,24 +330,20 @@ An HTTP Message Signature is a signature over a string generated from a subset o
 
 HTTP Message Signatures have metadata properties that provide information regarding the signature's generation and/or verification.  The following metadata properties are defined:
 
-Algorithm
-:
+{: vspace="0"}
+Algorithm:
 : An HTTP Signature Algorithm defined in the HTTP Signature Algorithms Registry defined in this document. It describes the signing and verification algorithms for the signature.
 
-Creation Time
-:
+Creation Time:
 : A timestamp representing the point in time that the signature was generated. Sub-second precision is not supported. A signature's Creation Time MAY be undefined, indicating that it is unknown.
 
-Covered Content
-:
+Covered Content:
 : An ordered list of content identifiers (Section 2) that indicates the metadata and message content that is covered by the signature. The order of identifiers in this list affects signature generation and verification, and therefore MUST be preserved.
 
-Expiration Time
-:
+Expiration Time:
 : A timestamp representing the point in time at which the signature expires. An expired signature always fails verification. A signature's Expiration Time MAY be undefined, indicating that the signature does not expire.
 
-Verification Key Material
-:
+Verification Key Material:
 : The key material required to verify the signature.
 
 
@@ -493,20 +486,17 @@ The `Signature-Input` HTTP header field is a Dictionary Structured Header {{Stru
 ### Metadata Parameters {#params}
 The parameters on each `Signature-Input` member value contain metadata about the signature. Each parameter name MUST be a parameter name registered in the IANA HTTP Signatures Metadata Parameters Registry defined in {{param-registry}} of this document. This document defines the following parameters, and registers them as the initial contents of the registry:
 
-alg
-:
+{: vspace="0"}
+alg:
 : RECOMMENDED. The `alg` parameter is a Token containing the name of the signature's Algorithm, as registered in the HTTP Signature Algorithms Registry defined by this document. Verifiers MUST determine the signature's Algorithm from the `keyid` parameter rather than from `alg`. If `alg` is provided and differs from or is incompatible with the algorithm or key material identified by `keyid` (for example, `alg` has a value of `rsa-sha256` but `keyid` identifies an EdDSA key), then implementations MUST produce an error.
 
-created
-:
+created:
 : RECOMMENDED. The `created` parameter is a Decimal containing the signature's Creation Time, expressed as the canonicalized value of the `*created` content identifier, as defined in Section 2.  If not specified, the signature's Creation Time is undefined.  This parameter is useful when signers are not capable of controlling the Date HTTP Header such as when operating in certain web browser environments.
 
-expires
-:
+expires:
 : OPTIONAL. The `expires` parameter is a Decimal containing the signature's Expiration Time, expressed as the canonicalized value of the `*expires` content identifier, as defined in Section 2.  If the signature does not have an Expiration Time, this parameter MUST be omitted.  If not specified, the signature's Expiration Time is undefined.
 
-keyid
-:
+keyid:
 : REQUIRED. The `keyid` parameter is a String whose value can be used by a verifier to identify and/or obtain the signature's Verification Key Material. Further format and semantics of this value are out of scope for this document.
 
 ## The 'Signature' HTTP Header
@@ -551,16 +541,14 @@ This document defines HTTP Signature Algorithms, for which IANA is asked to crea
 
 ### Registration Template {#iana-hsa-template}
 
-Algorithm Name
-:
+{: vspace="0"}
+Algorithm Name:
 : An identifier for the HTTP Signature Algorithm. The name MUST be an ASCII string consisting only of lower-case characters (`"a"` - `"z"`), digits (`"0"` - `"9"`), and hyphens (`"-"`), and SHOULD NOT exceed 20 characters in length.  The identifier MUST be unique within the context of the registry.
 
-Status
-:
+Status:
 : A brief text description of the status of the algorithm.  The description MUST begin with one of "Active" or "Deprecated", and MAY provide further context or explanation as to the reason for the status.
 
-Description
-:
+Description:
 : A description of the algorithm used to sign the signing string when generating an HTTP Message Signature, or instructions on how to determine that algorithm.  When the description specifies an algorithm, it MUST include a reference to the document or documents that define the algorithm.
 
 ### Initial Contents {#iana-hsa-contents}
@@ -569,16 +557,14 @@ Description
 
 #### hs2019
 
-Algorithm Name
-:
+{: vspace="0"}
+Algorithm Name:
 : `hs2019`
 
-Status
-:
+Status:
 : active
 
-Description
-:
+Description:
 : Derived from metadata associated with keyid. Recommend support for:
 :    - RSASSA-PSS [RFC8017] using SHA-512 [RFC6234]
 :    - HMAC [RFC2104] using SHA-512 [RFC6234]
@@ -587,21 +573,21 @@ Description
 
 
 #### rsa-sha1
-Algorithm Name
-:
+
+{: vspace="0"}
+Algorithm Name:
 : `rsa-sha1`
 
-Status
-:
+Status:
 : Deprecated; SHA-1 not secure.
 
-Description
-:
+Description:
 : RSASSA-PKCS1-v1_5 [RFC8017] using SHA-1 [RFC6234]
 
 #### rsa-sha256
-Algorithm Name
-:
+
+{: vspace="0"}
+Algorithm Name:
 : `rsa-sha256`
 
 Status
@@ -613,29 +599,27 @@ Description
 : RSASSA-PKCS1-v1_5 [RFC8017] using SHA-256 [RFC6234]
 
 #### hmac-sha256
-Algorithm Name
-:
+
+{: vspace="0"}
+Algorithm Name:
 : `hmac-sha256`
 
-Status
-:
+Status:
 : Deprecated; specifying signature algorithm enables attack vector.
 
-Description
-:
+Description:
 : HMAC [RFC2104] using SHA-256 [RFC6234]
 
 #### ecdsa-sha256
-Algorithm Name
-:
+
+{: vspace="0"}
+Algorithm Name:
 : `ecdsa-sha256`
 
-Status
-:
+Status:
 : Deprecated; specifying signature algorithm enables attack vector.
 
-Description
-:
+Description:
 : ECDSA using curve P-256 DSS {{FIPS186-4}} and SHA-256 [RFC6234]
 
 ## HTTP Signature Metadata Parameters Registry {#param-registry}

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -216,7 +216,7 @@ An individual member in the value of a Dictionary Structured Field is identified
 This section contains non-normative examples of canonicalized values for Dictionary Structured Field Members given the following example header field, whose value is assumed to be a Dictionary:
 
 ~~~ http-message
-X-Dictionary:  a=1, b=2;x=1;y=2, c=(a, b, c)
+X-Dictionary:  a=1, b=2;x=1;y=2, c=(a b c)
 ~~~
 
 The following table shows example canonicalized values for different content identifiers, given that field:
@@ -238,7 +238,7 @@ A prefix of a List Structured Field consisting of the first N members in the fie
 This section contains non-normative examples of canonicalized values for list prefixes given the following example header fields, whose values are assumed to be Dictionaries:
 
 ~~~ http-message
-X-List-A: (a, b, c, d, e, f)
+X-List-A: (a b c d e f)
 X-List-B: ()
 ~~~
 
@@ -392,7 +392,7 @@ X-Example: Example header
         with some whitespace.
 X-EmptyHeader:
 X-Dictionary: a=1, b=2
-X-List: (a, b, c, d)
+X-List: (a b c d)
 Cache-Control: max-age=60
 Cache-Control: must-revalidate
 ~~~
@@ -517,8 +517,8 @@ The `Signature` HTTP header field is a Dictionary Structured Header {{Structured
 The following is a non-normative example of `Signature-Input` and `Signature` HTTP header fields representing the signature in {{example-sig-value}}:
 
 ~~~ http-message
-Signature-Input: sig1=(*request-target, *created, host, date,
-    cache-control, x-empty-header, x-example); keyId="test-key-a";
+Signature-Input: sig1=(*request-target *created host date
+    cache-control x-empty-header x-example); keyId="test-key-a";
     alg=hs2019; created=1402170695; expires=1402170995
 Signature: sig1=:K2qGT5srn2OGbOIDzQ6kYT+ruaycnDAAUpKv+ePFfD0RAxn/1BUe
     Zx/Kdrq32DrfakQ6bPsvB9aqZqognNT6be4olHROIkeV879RrsrObury8L9SCEibe
@@ -532,8 +532,8 @@ Since `Signature-Input` and `Signature` are both defined as Dictionary Structure
 
 ~~~ http-message
 X-Forwarded-For: 192.0.2.123
-Signature-Input: reverse_proxy_sig=(*created, host, date,
-    signature:sig1, x-forwarded-for); keyId="test-key-a";
+Signature-Input: reverse_proxy_sig=(*created host date
+    signature:sig1 x-forwarded-for); keyId="test-key-a";
     alg=hs2019; created=1402170695; expires=1402170695.25
 Signature: reverse_proxy_sig=:ON3HsnvuoTlX41xfcGWaOEVo1M3bJDRBOp0Pc/O
     jAOWKQn0VMY0SvMMWXS7xG+xYVa152rRVAo6nMV7FS3rv0rR5MzXL8FCQ2A35DCEN
@@ -772,7 +772,7 @@ vtzidyBYFtAUoYhRWO8+ntqA1q2OK4LMjM2XgDScSVWvGdVd459A0wI9lRlnPap3zg==
 A possible `Signature-Input` and `Signature` header containing this signature is:
 
 ~~~ http-message
-Signature-Input: sig1=(*created, *request-target);
+Signature-Input: sig1=(*created *request-target);
     keyId="test-key-a"; created=1402170695
 Signature: sig1=:QaVaWYfF2da6tG66Xtd0GrVFChJ0fOWUe/C6kaYESPiYYwnMH9eg
     OgyKqgLLY9NQJFk7bQY834sHEUwjS5ByEBaO3QNwIvqEY1qAAU/2MX14tc9Yn7ELB
@@ -819,8 +819,8 @@ PxzQ5nwrLD+mUVPZ9rDs1En6fmOX9xfkZTblG/5D+s1fHHs9dDXCOVkT5dLS8DjdIA==
 A possible `Signature-Input` and `Signature` header containing this signature is:
 
 ~~~ http-message
-Signature-Input: sig1=(*request-target, *created, host, date,
-        content-type, digest, content-length); keyId="test-key-a";
+Signature-Input: sig1=(*request-target *created host date
+        content-type digest content-length); keyId="test-key-a";
     alg=hs2019; created=1402170695
 Signature: sig1=:B24UG4FaiE2kSXBNKV4DA91J+mElAhS3mncrgyteAye1GKMpmzt8
     jkHNjoudtqw3GngGY3n0mmwjdfn1eA6nAjgeHwl0WXced5tONcCPNzLswqPOiobGe

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -189,7 +189,7 @@ This section contains non-normative examples of canonicalized values for header 
 HTTP/1.1 200 OK
 Server: www.example.com
 Date: Tue, 07 Jun 2014 20:51:35 GMT
-X-OWS-Header:   Leading and trailing whitespace.
+X-OWS-Header:   Leading and trailing whitespace.    
 X-Obs-Fold-Header: Obsolete
     line folding.
 X-Empty-Header:

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -590,12 +590,10 @@ Description:
 Algorithm Name:
 : `rsa-sha256`
 
-Status
-:
+Status:
 : Deprecated; specifying signature algorithm enables attack vector.
 
-Description
-:
+Description:
 : RSASSA-PKCS1-v1_5 [RFC8017] using SHA-256 [RFC6234]
 
 #### hmac-sha256

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -405,7 +405,7 @@ The following table presents a non-normative example of metadata values that a s
 |Covered Content|`*request-target`, `*created`, `host`, `date`, `cache-contol`, `x-emptyheader`, `x-example`, `x-dictionary:b`, `x-dictionary:a`, `x-list:3`|
 |Creation Time|`1402174295`|
 |Expiration Time|`1402174595`|
-|Verification Key Material|The public key provided in {{example-key-rsa-test}} and identified by the `keyId` value "test-key-a".|
+|Verification Key Material|The public key provided in {{example-key-rsa-test}} and identified by the `keyid` value "test-key-a".|
 {: title="Non-normative example metadata values" #example-metadata}
 
 
@@ -495,7 +495,7 @@ The parameters on each `Signature-Input` member value contain metadata about the
 
 alg
 :
-: RECOMMENDED. The `alg` parameter is a Token containing the name of the signature's Algorithm, as registered in the HTTP Signature Algorithms Registry defined by this document. Verifiers MUST determine the signature's Algorithm from the `keyId` parameter rather than from `alg`. If `alg` is provided and differs from or is incompatible with the algorithm or key material identified by `keyId` (for example, `alg` has a value of `rsa-sha256` but `keyId` identifies an EdDSA key), then implementations MUST produce an error.
+: RECOMMENDED. The `alg` parameter is a Token containing the name of the signature's Algorithm, as registered in the HTTP Signature Algorithms Registry defined by this document. Verifiers MUST determine the signature's Algorithm from the `keyid` parameter rather than from `alg`. If `alg` is provided and differs from or is incompatible with the algorithm or key material identified by `keyid` (for example, `alg` has a value of `rsa-sha256` but `keyid` identifies an EdDSA key), then implementations MUST produce an error.
 
 created
 :
@@ -505,9 +505,9 @@ expires
 :
 : OPTIONAL. The `expires` parameter is a Decimal containing the signature's Expiration Time, expressed as the canonicalized value of the `*expires` content identifier, as defined in Section 2.  If the signature does not have an Expiration Time, this parameter MUST be omitted.  If not specified, the signature's Expiration Time is undefined.
 
-keyId
+keyid
 :
-: REQUIRED. The `keyId` parameter is a String whose value can be used by a verifier to identify and/or obtain the signature's Verification Key Material. Further format and semantics of this value are out of scope for this document.
+: REQUIRED. The `keyid` parameter is a String whose value can be used by a verifier to identify and/or obtain the signature's Verification Key Material. Further format and semantics of this value are out of scope for this document.
 
 ## The 'Signature' HTTP Header
 The `Signature` HTTP header field is a Dictionary Structured Header {{StructuredFields}} containing zero or more message signatures generated from content within the HTTP message. Each member's name is a signature identifier that is present as a member name in the `Signature-Input` Structured Header within the HTTP message. Each member's value is a Byte Sequence containing the signature value for the message signature identified by the member name. Any member in the `Signature` HTTP header field that does not have a corresponding member in the HTTP message's `Signature-Input` HTTP header field MUST be ignored.
@@ -518,7 +518,7 @@ The following is a non-normative example of `Signature-Input` and `Signature` HT
 
 ~~~ http-message
 Signature-Input: sig1=(*request-target *created host date
-    cache-control x-empty-header x-example); keyId="test-key-a";
+    cache-control x-empty-header x-example); keyid="test-key-a";
     alg=hs2019; created=1402170695; expires=1402170995
 Signature: sig1=:K2qGT5srn2OGbOIDzQ6kYT+ruaycnDAAUpKv+ePFfD0RAxn/1BUe
     Zx/Kdrq32DrfakQ6bPsvB9aqZqognNT6be4olHROIkeV879RrsrObury8L9SCEibe
@@ -533,7 +533,7 @@ Since `Signature-Input` and `Signature` are both defined as Dictionary Structure
 ~~~ http-message
 X-Forwarded-For: 192.0.2.123
 Signature-Input: reverse_proxy_sig=(*created host date
-    signature:sig1 x-forwarded-for); keyId="test-key-a";
+    signature:sig1 x-forwarded-for); keyid="test-key-a";
     alg=hs2019; created=1402170695; expires=1402170695.25
 Signature: reverse_proxy_sig=:ON3HsnvuoTlX41xfcGWaOEVo1M3bJDRBOp0Pc/O
     jAOWKQn0VMY0SvMMWXS7xG+xYVa152rRVAo6nMV7FS3rv0rR5MzXL8FCQ2A35DCEN
@@ -579,7 +579,7 @@ Status
 
 Description
 :
-: Derived from metadata associated with keyId. Recommend support for:
+: Derived from metadata associated with keyid. Recommend support for:
 :    - RSASSA-PSS [RFC8017] using SHA-512 [RFC6234]
 :    - HMAC [RFC2104] using SHA-512 [RFC6234]
 :    - ECDSA using curve P-256 DSS {{FIPS186-4}} and SHA-512 [RFC6234]
@@ -653,7 +653,7 @@ The table below contains the initial contents of the HTTP Signature Metadata Par
 |`alg`|Active | {{params}} of this document|
 |`created`|Active   | {{params}} of this document|
 |`expires`|Active   | {{params}} of this document|
-|`keyId`|Active     | {{params}} of this document|
+|`keyid`|Active     | {{params}} of this document|
 {: title="Initial contents of the HTTP Signature Metadata Parameters Registry." }
 
 # Security Considerations {#security}
@@ -714,11 +714,11 @@ EQeNC8fHGg4UXU8mhHnSBt3EA10qQJfRDs15M38eG2cYwB1PZpDHScDnDA0=
 -----END RSA PRIVATE KEY-----
 ~~~
 
-## Example keyId Values
+## Example keyid Values
 
-The table below maps example `keyId` values to associated algorithms and/or keys.  These are example mappings that are valid only within the context of examples in examples within this and future documents that reference this section.  Unless otherwise specified, within the context of examples it should be assumed that the signer and verifier understand these `keyId` mappings.  These `keyId` values are not reserved, and deployments are free to use them, with these associations or others.
+The table below maps example `keyid` values to associated algorithms and/or keys.  These are example mappings that are valid only within the context of examples in examples within this and future documents that reference this section.  Unless otherwise specified, within the context of examples it should be assumed that the signer and verifier understand these `keyid` mappings.  These `keyid` values are not reserved, and deployments are free to use them, with these associations or others.
 
-|keyId|Algorithm|Verification Key|
+|keyid|Algorithm|Verification Key|
 |--- |--- |---|
 |`test-key-a`|`hs2019`, using RSASSA-PSS [RFC8017] and SHA-512 [RFC6234]|The public key specified in {{example-key-rsa-test}}|
 |`test-key-b`|`rsa-sha256`|The public key specified in {{example-key-rsa-test}}|
@@ -773,7 +773,7 @@ A possible `Signature-Input` and `Signature` header containing this signature is
 
 ~~~ http-message
 Signature-Input: sig1=(*created *request-target);
-    keyId="test-key-a"; created=1402170695
+    keyid="test-key-a"; created=1402170695
 Signature: sig1=:QaVaWYfF2da6tG66Xtd0GrVFChJ0fOWUe/C6kaYESPiYYwnMH9eg
     OgyKqgLLY9NQJFk7bQY834sHEUwjS5ByEBaO3QNwIvqEY1qAAU/2MX14tc9Yn7ELB
     naaNHaHkV3xVO9KIuLT7V6e4OUuGb1axfbXpMgPEql6CEFrn6K95CLuuKP5/gOEcB
@@ -820,7 +820,7 @@ A possible `Signature-Input` and `Signature` header containing this signature is
 
 ~~~ http-message
 Signature-Input: sig1=(*request-target *created host date
-        content-type digest content-length); keyId="test-key-a";
+        content-type digest content-length); keyid="test-key-a";
     alg=hs2019; created=1402170695
 Signature: sig1=:B24UG4FaiE2kSXBNKV4DA91J+mElAhS3mncrgyteAye1GKMpmzt8
     jkHNjoudtqw3GngGY3n0mmwjdfn1eA6nAjgeHwl0WXced5tONcCPNzLswqPOiobGe
@@ -837,7 +837,7 @@ Signature: sig1=:B24UG4FaiE2kSXBNKV4DA91J+mElAhS3mncrgyteAye1GKMpmzt8
 This presents a `Signature-Input` and `Signature` header containing only the minimal required parameters:
 
 ~~~ http-message
-Signature-Input: sig1=(); keyId="test-key-a"; created=1402170695
+Signature-Input: sig1=(); keyid="test-key-a"; created=1402170695
 Signature: sig1=:cxieW5ZKV9R9A70+Ua1A/1FCvVayuE6Z77wDGNVFSiluSzR9TYFV
     vwUjeU6CTYUdbOByGMCee5q1eWWUOM8BIH04Si6VndEHjQVdHqshAtNJk2Quzs6WC
     2DkV0vysOhBSvFZuLZvtCmXRQfYGTGhZqGwq/AAmFbt5WNLQtDrEe0ErveEKBfaz+
@@ -867,7 +867,7 @@ The corresponding Signature Input is:
 This presents a `Signature-Input` and `Signature` header containing only the minimal required and recommended parameters:
 
 ~~~ http-message
-Signature-Input: sig1=(); alg=hs2019; keyId="test-key-a";
+Signature-Input: sig1=(); alg=hs2019; keyid="test-key-a";
     created=1402170695
 Signature: sig1=:cxieW5ZKV9R9A70+Ua1A/1FCvVayuE6Z77wDGNVFSiluSzR9TYFV
     vwUjeU6CTYUdbOByGMCee5q1eWWUOM8BIH04Si6VndEHjQVdHqshAtNJk2Quzs6WC
@@ -898,7 +898,7 @@ The corresponding Signature Input is:
 This presents a minimal `Signature-Input` and `Signature` header for a signature using the `rsa-sha256` algorithm:
 
 ~~~ http-message
-Signature: sig1=(date); alg=rsa-sha256; keyId="test-key-b"
+Signature: sig1=(date); alg=rsa-sha256; keyid="test-key-b"
 Signature: sig1=:HtXycCl97RBVkZi66ADKnC9c5eSSlb57GnQ4KFqNZplOpNfxqk62
     JzZ484jXgLvoOTRaKfR4hwyxlcyb+BWkVasApQovBSdit9Ml/YmN2IvJDPncrlhPD
     VDv36Z9/DiSO+RNHD7iLXugdXo1+MGRimW1RmYdenl/ITeb7rjfLZ4b9VNnLFtVWw
@@ -934,13 +934,13 @@ The goal of this draft document is to provide a starting point at feature parity
 
 ### Confusing guidance on algorithm and key identification {#issue-alg-keyid}
 
-The current draft encourages determining the Algorithm metadata property from the `keyId` field, both in the guidance for the use of `algorithm` and `keyId`, and the definition for the `hs2019` algorithm and deprecation of the other algorithms in the registry.  The current state arose from concern that a malicious party could change the value of the `algorithm` parameter, potentially tricking the verifier into accepting a signature that would not have been verified under the actual parameter.
+The current draft encourages determining the Algorithm metadata property from the `keyid` field, both in the guidance for the use of `algorithm` and `keyid`, and the definition for the `hs2019` algorithm and deprecation of the other algorithms in the registry.  The current state arose from concern that a malicious party could change the value of the `algorithm` parameter, potentially tricking the verifier into accepting a signature that would not have been verified under the actual parameter.
 
-Punting algorithm identification into `keyId` hurts interoperability, since we aren't defining the syntax or semantics of `keyId`.  It actually goes against that claim, as we are dictating that the signing algorithm must be specified by `keyId` or derivable from it.  It also renders the algorithm registry essentially useless.  Instead of this approach, we can protect against manipulation of the Signature header field by adding support for (and possibly mandating) including Signature metadata within the Signature Input.
+Punting algorithm identification into `keyid` hurts interoperability, since we aren't defining the syntax or semantics of `keyid`.  It actually goes against that claim, as we are dictating that the signing algorithm must be specified by `keyid` or derivable from it.  It also renders the algorithm registry essentially useless.  Instead of this approach, we can protect against manipulation of the Signature header field by adding support for (and possibly mandating) including Signature metadata within the Signature Input.
 
-### Lack of definition of keyId hurts interoperability
+### Lack of definition of keyid hurts interoperability
 
-The current text leaves the format and semantics of `keyId` completely up to the implementation.  This is primarily due to the fact that most implementers of Cavage have extensive investment in key distribution and management, and just need to plug an identifier into the header.  We should support those cases, but we also need to provide guidance for the developer that doesn't have that and just wants to know how to identify a key.  It may be enough to punt this to profiling specs, but this needs to be explored more.
+The current text leaves the format and semantics of `keyid` completely up to the implementation.  This is primarily due to the fact that most implementers of Cavage have extensive investment in key distribution and management, and just need to plug an identifier into the header.  We should support those cases, but we also need to provide guidance for the developer that doesn't have that and just wants to know how to identify a key.  It may be enough to punt this to profiling specs, but this needs to be explored more.
 
 ### Algorithm Registry duplicates work of JWA
 
@@ -985,15 +985,15 @@ The Algorithm should be part of the Signature Input, to protect against maliciou
 
 ### Verification key identifier is not signed
 
-The Verification key identifier (e.g., the value used for the `keyId` parameter) should be part of the Signature Input, to protect against malicious changes.
+The Verification key identifier (e.g., the value used for the `keyid` parameter) should be part of the Signature Input, to protect against malicious changes.
 
 ### Max values, precision for Integer String and Decimal String not defined
 
 The definitions for Integer String and Decimal String do not specify a maximum value.  The definition for Decimal String (used to provide sub-second precision for Expiration Time) does not define minimum or maximum precision requirements.  It should set a sane requirement here (e.g., MUST support up to 3 decimal places and no more).
 
-### keyId parameter value could break list syntax
+### keyid parameter value could break list syntax
 
-The `keyId` parameter value needs to be constrained so as to not break list syntax (e.g., by containing a comma).
+The `keyid` parameter value needs to be constrained so as to not break list syntax (e.g., by containing a comma).
 
 ### Creation Time and Expiration Time do not allow for clock skew
 
@@ -1039,7 +1039,7 @@ It should be possible to independently include the following content and metadat
 
 - The signature's Algorithm
 - The signature's Covered Content
-- The value used for the `keyId` parameter
+- The value used for the `keyid` parameter
 - Request method
 - Individual components of the effective request URI: scheme, authority, path, query
 - Status code

--- a/sf.json
+++ b/sf.json
@@ -2,5 +2,11 @@
     "cache-status": "list",
     "proxy-status": "list",
     "variant-key": "list",
-    "variants": "dict"
+    "variants": "dict",
+    "signature": "dict",
+    "signature-input": "dict",
+    "x-dictionary": "dict",
+    "x-list": "list",
+    "x-list-a": "list",
+    "x-list-b": "list"
 }

--- a/sf.json
+++ b/sf.json
@@ -8,7 +8,7 @@
     "x-dictionary": "dict",
     "x-list": "list",
     "x-list-a": "list",
-    "x-list-b": "list"
+    "x-list-b": "list",
     "accept-ch": "list",
     "example-list": "list",
     "example-dict": "dict",


### PR DESCRIPTION
This annotates examples with `http-message` so they can be validated; I corrected the errors I saw.

One outstanding issue is that you're wrapping long binary content across multiple lines, and HTTP line folding rules means that doing so inserts whitespace, which isn't allowed in structured binary content.

Two possible solutions:

1. Make a note near the top that it's wrapping these long lines for illustrative purposes only, and that they're not valid; I can adjust the tooling to make it validate properly despite that
2. Change structured binary content's definition to allow whitespace

(2) is unlikely, because that document is in the RFC Editor queue, but not impossible.
