### PR TITLE
Install SF validator only when not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ http-lint: $(drafts_xml) http-lint-install
 
 .PHONY: http-lint-install
 http-lint-install:
-	@hash rfc-http-validate 2>/dev/null || pip3 install rfc-http-validate
+	@hash rfc-http-validate.py 2>/dev/null || pip3 install rfc-http-validate


### PR DESCRIPTION
That .py suffix is a curse.