### PR TITLE
priority: HTTP/2 doesn't have stream limits

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -402,14 +402,27 @@ Prioritized Stream ID:
 Priority Field Value:
 : The priority update value in ASCII text, encoded using Structured Fields.
 
-The Prioritized Stream ID SHOULD be a value within the limit of concurrent
-active streams, which is determined by the SETTINGS_MAX_CONCURRENT_STREAMS
-parameter and streams in the "open" or "half-closed" state; see Section 5.1.2 of
-{{RFC7540}}. A server SHOULD NOT treat a Prioritized Stream ID beyond this limit
-as an error because it can buffer PRIORITY_UPDATE frames; see {{frame}}.
-However, since servers can restrict the amount of buffering, PRIORITY_UPDATE
-frames for streams too far beyond the limit could be ignored, resulting in
-default priority values being used when the stream is eventually opened.
+When the PRIORITY_UPDATE frame applies to a request stream, a client SHOULD
+provide a Prioritized Stream ID that refers to a stream in the "open",
+"half-closed (local)", or "idle" state. Frames where the Prioritized Stream ID
+refers to a stream in the "half-closed (remote)" or "closed" state can be
+discarded by the server upon receipt. The number of streams which have been
+prioritized but remain in the "idle" state plus the number of active streams
+(those in the "open" or "half-closed" states; see section 5.1.2 of RFC 7540)
+MUST NOT exceed the value of the SETTINGS_MAX_CONCURRENT_STREAMS parameter. A
+server that receives such a PRIORITY_UPDATE MUST respond with a connection error
+of type PROTOCOL_ERROR.
+
+When the PRIORITY_UPDATE frame applies to a push stream, a client SHOULD provide
+a Prioritized Stream ID that refers to a stream in the "reserved (remote)",
+"half-closed (local)", or "idle" state. Frames where the Prioritized Stream ID
+refers to a stream in the "half-closed (remote)" or "closed" state can be
+discarded by the server upon receipt. The number of streams which have been
+prioritized but remain in the "idle" state plus the number of active streams
+(those in the "reserved" or "half-closed" states; see section 5.1.2 of RFC 7540)
+MUST NOT exceed the value of the SETTINGS_MAX_CONCURRENT_STREAMS parameter. A
+server that receives such a PRIORITY_UPDATE MUST respond with a connection error
+of type PROTOCOL_ERROR.
 
 If a PRIORITY_UPDATE frame is received with a Prioritized Stream ID of 0x0, the
 recipient MUST respond with a connection error of type PROTOCOL_ERROR.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -402,22 +402,24 @@ Prioritized Stream ID:
 Priority Field Value:
 : The priority update value in ASCII text, encoded using Structured Fields.
 
-When the PRIORITY_UPDATE frame applies to a request stream, a client SHOULD
+When the PRIORITY_UPDATE frame applies to a request stream, clients SHOULD
 provide a Prioritized Stream ID that refers to a stream in the "open",
-"half-closed (local)", or "idle" state. The server can discard frames where the
-Prioritized Stream ID refers to a stream in the "half-closed (local)" or "closed"
-state can be discarded upon receipt. The number of streams which have been
-prioritized but remain in the "idle" state plus the number of active streams
-(those in the "open" or either "half-closed" state; see section 5.1.2 of RFC 7540)
-MUST NOT exceed the value of the SETTINGS_MAX_CONCURRENT_STREAMS parameter. A
-server that receives such a PRIORITY_UPDATE MUST respond with a connection error
-of type PROTOCOL_ERROR.
+"half-closed (local)", or "idle" state. Servers can discard frames where the
+Prioritized Stream ID refers to a stream in the "half-closed (local)" or
+"closed" state. The number of streams which have been prioritized but remain in
+the "idle" state plus the number of active streams (those in the "open" or
+either "half-closed" state; see section 5.1.2 of {{RFC7540}}) MUST NOT exceed
+the value of the SETTINGS_MAX_CONCURRENT_STREAMS parameter. Servers that receive
+such a PRIORITY_UPDATE MUST respond with a connection error of type
+PROTOCOL_ERROR.
 
-When the PRIORITY_UPDATE frame applies to a push stream, a client SHOULD provide
+When the PRIORITY_UPDATE frame applies to a push stream, clients SHOULD provide
 a Prioritized Stream ID that refers to a stream in the "reserved (remote)" or
-"half-closed (local)" state. Frames where the Prioritized Stream ID
-refers to a stream in the "half-closed (remote)" or "closed" state can be
-discarded by the server upon receipt.
+"half-closed (local)" state. Servers can discard frames where the Prioritized
+Stream ID refers to a stream in the "half-closed (remote)" or "closed" state.
+Client MUST NOT provide a Prioritized Stream ID that refers to a stream in the
+"idle" state. Servers that receive such a PRIORITY_UPDATE MUST respond with a
+connection error of type PROTOCOL_ERROR.
 
 If a PRIORITY_UPDATE frame is received with a Prioritized Stream ID of 0x0, the
 recipient MUST respond with a connection error of type PROTOCOL_ERROR.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -364,7 +364,7 @@ Servers SHOULD buffer the most recently received PRIORITY_UPDATE frame and apply
 it once the referenced stream is opened. Holding PRIORITY_UPDATE frames for each
 stream requires server resources, which can can be bound by local implementation
 policy. (TODO: consider resolving #1261, and adding more text about bounds).
-Although there is no limit to the number PRIORITY_UPDATES that can be sent,
+Although there is no limit to the number of PRIORITY_UPDATES that can be sent,
 storing only the most recently received frame limits resource commitment.
 
 ## HTTP/2 PRIORITY_UPDATE Frame {#h2-update-frame}
@@ -402,10 +402,13 @@ Prioritized Stream ID:
 Priority Field Value:
 : The priority update value in ASCII text, encoded using Structured Fields.
 
-The Prioritized Stream ID MUST be within the stream limit. If a
-server receives a PRIORITY_UPDATE with a Prioritized Stream ID that is beyond
-the stream limits, this SHOULD be treated as a connection error of type
-PROTOCOL_ERROR.
+The Prioritized Stream ID SHOULD be a value within the stream concurrency
+window. A server SHOULD NOT treat a Prioritized Stream ID beyond this window as
+an error because it can buffer PRIORITY_UPDATE frames; see {{frame}}. However,
+servers can limit the amount of buffering beyond the limit imposed by the
+concurrency window. Therefore, sending PRIORITY_UPDATE frames for streams too
+far beyond the limit could result in them being in ignored and the application
+of default priority when the stream is eventually opened.
 
 If a PRIORITY_UPDATE frame is received with a Prioritized Stream ID of 0x0, the
 recipient MUST respond with a connection error of type PROTOCOL_ERROR.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -402,13 +402,14 @@ Prioritized Stream ID:
 Priority Field Value:
 : The priority update value in ASCII text, encoded using Structured Fields.
 
-The Prioritized Stream ID SHOULD be a value within the stream concurrency
-window. A server SHOULD NOT treat a Prioritized Stream ID beyond this window as
-an error because it can buffer PRIORITY_UPDATE frames; see {{frame}}. However,
-servers can limit the amount of buffering beyond the limit imposed by the
-concurrency window. Therefore, sending PRIORITY_UPDATE frames for streams too
-far beyond the limit could result in them being in ignored and the application
-of default priority when the stream is eventually opened.
+The Prioritized Stream ID SHOULD be a value within the limit of concurrent
+active streams, which is determined by the SETTINGS_MAX_CONCURRENT_STREAMS
+paramater and streams in the "open" or "half-closed" state; see Section 5.1.2 of
+{{RFC7540}}. A server SHOULD NOT treat a Prioritized Stream ID beyond this limit
+as an error because it can buffer PRIORITY_UPDATE frames; see {{frame}}.
+However, since servers can restrict the amount of buffering, PRIORITY_UPDATE
+frames for streams too far beyond the limit could be ignored, resulting in
+default priority values being used when the stream is eventually opened.
 
 If a PRIORITY_UPDATE frame is received with a Prioritized Stream ID of 0x0, the
 recipient MUST respond with a connection error of type PROTOCOL_ERROR.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -354,15 +354,16 @@ treated as a connection error. In HTTP/2 the error is of type PROTOCOL_ERROR; in
 HTTP/3 the error is of type H3_FRAME_ERROR.
 
 A client MAY send a PRIORITY_UPDATE frame before the stream that it references
-is open. Furthermore, HTTP/3 offers no guaranteed ordering across streams, which
-could cause the frame to be received earlier than intended. Either case leads to
-a race condition where a server receives a PRIORITY_UPDATE frame that references
-a request stream that is yet to be opened. To solve this condition, for the
-purposes of scheduling, the most recently received PRIORITY_UPDATE frame can be
-considered as the most up-to-date information that overrides any other signal.
-Servers SHOULD buffer the most recently received PRIORITY_UPDATE frame and apply
-it once the referenced stream is opened. Holding PRIORITY_UPDATE frames for each
-stream requires server resources, which can can be bound by local implementation
+is open (except for HTTP/2 push streams; see {{h2-update-frame}}. Furthermore,
+HTTP/3 offers no guaranteed ordering across streams, which could cause the frame
+to be received earlier than intended. Either case leads to a race condition
+where a server receives a PRIORITY_UPDATE frame that references a request stream
+that is yet to be opened. To solve this condition, for the purposes of
+scheduling, the most recently received PRIORITY_UPDATE frame can be considered
+as the most up-to-date information that overrides any other signal. Servers
+SHOULD buffer the most recently received PRIORITY_UPDATE frame and apply it once
+the referenced stream is opened. Holding PRIORITY_UPDATE frames for each stream
+requires server resources, which can can be bound by local implementation
 policy. (TODO: consider resolving #1261, and adding more text about bounds).
 Although there is no limit to the number of PRIORITY_UPDATES that can be sent,
 storing only the most recently received frame limits resource commitment.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -404,25 +404,20 @@ Priority Field Value:
 
 When the PRIORITY_UPDATE frame applies to a request stream, a client SHOULD
 provide a Prioritized Stream ID that refers to a stream in the "open",
-"half-closed (local)", or "idle" state. Frames where the Prioritized Stream ID
-refers to a stream in the "half-closed (remote)" or "closed" state can be
-discarded by the server upon receipt. The number of streams which have been
+"half-closed (local)", or "idle" state. The server can discard frames where the
+Prioritized Stream ID refers to a stream in the "half-closed (local)" or "closed"
+state can be discarded upon receipt. The number of streams which have been
 prioritized but remain in the "idle" state plus the number of active streams
-(those in the "open" or "half-closed" states; see section 5.1.2 of RFC 7540)
+(those in the "open" or either "half-closed" state; see section 5.1.2 of RFC 7540)
 MUST NOT exceed the value of the SETTINGS_MAX_CONCURRENT_STREAMS parameter. A
 server that receives such a PRIORITY_UPDATE MUST respond with a connection error
 of type PROTOCOL_ERROR.
 
 When the PRIORITY_UPDATE frame applies to a push stream, a client SHOULD provide
-a Prioritized Stream ID that refers to a stream in the "reserved (remote)",
-"half-closed (local)", or "idle" state. Frames where the Prioritized Stream ID
+a Prioritized Stream ID that refers to a stream in the "reserved (remote)" or
+"half-closed (local)" state. Frames where the Prioritized Stream ID
 refers to a stream in the "half-closed (remote)" or "closed" state can be
-discarded by the server upon receipt. The number of streams which have been
-prioritized but remain in the "idle" state plus the number of active streams
-(those in the "reserved" or "half-closed" states; see section 5.1.2 of RFC 7540)
-MUST NOT exceed the value of the SETTINGS_MAX_CONCURRENT_STREAMS parameter. A
-server that receives such a PRIORITY_UPDATE MUST respond with a connection error
-of type PROTOCOL_ERROR.
+discarded by the server upon receipt.
 
 If a PRIORITY_UPDATE frame is received with a Prioritized Stream ID of 0x0, the
 recipient MUST respond with a connection error of type PROTOCOL_ERROR.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -404,7 +404,7 @@ Priority Field Value:
 
 The Prioritized Stream ID SHOULD be a value within the limit of concurrent
 active streams, which is determined by the SETTINGS_MAX_CONCURRENT_STREAMS
-paramater and streams in the "open" or "half-closed" state; see Section 5.1.2 of
+parameter and streams in the "open" or "half-closed" state; see Section 5.1.2 of
 {{RFC7540}}. A server SHOULD NOT treat a Prioritized Stream ID beyond this limit
 as an error because it can buffer PRIORITY_UPDATE frames; see {{frame}}.
 However, since servers can restrict the amount of buffering, PRIORITY_UPDATE

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -354,7 +354,7 @@ treated as a connection error. In HTTP/2 the error is of type PROTOCOL_ERROR; in
 HTTP/3 the error is of type H3_FRAME_ERROR.
 
 A client MAY send a PRIORITY_UPDATE frame before the stream that it references
-is open (except for HTTP/2 push streams; see {{h2-update-frame}}. Furthermore,
+is open (except for HTTP/2 push streams; see {{h2-update-frame}}). Furthermore,
 HTTP/3 offers no guaranteed ordering across streams, which could cause the frame
 to be received earlier than intended. Either case leads to a race condition
 where a server receives a PRIORITY_UPDATE frame that references a request stream
@@ -417,9 +417,9 @@ When the PRIORITY_UPDATE frame applies to a push stream, clients SHOULD provide
 a Prioritized Stream ID that refers to a stream in the "reserved (remote)" or
 "half-closed (local)" state. Servers can discard frames where the Prioritized
 Stream ID refers to a stream in the "half-closed (remote)" or "closed" state.
-Client MUST NOT provide a Prioritized Stream ID that refers to a stream in the
-"idle" state. Servers that receive such a PRIORITY_UPDATE MUST respond with a
-connection error of type PROTOCOL_ERROR.
+Clients MUST NOT provide a Prioritized Stream ID that refers to a stream in the
+"idle" state. Servers that receive a PRIORITY_UPDATE for a stream in the "idle" state MUST
+respond with a connection error of type PROTOCOL_ERROR.
 
 If a PRIORITY_UPDATE frame is received with a Prioritized Stream ID of 0x0, the
 recipient MUST respond with a connection error of type PROTOCOL_ERROR.

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -416,9 +416,9 @@ PROTOCOL_ERROR.
 When the PRIORITY_UPDATE frame applies to a push stream, clients SHOULD provide
 a Prioritized Stream ID that refers to a stream in the "reserved (remote)" or
 "half-closed (local)" state. Servers can discard frames where the Prioritized
-Stream ID refers to a stream in the "half-closed (remote)" or "closed" state.
-Clients MUST NOT provide a Prioritized Stream ID that refers to a stream in the
-"idle" state. Servers that receive a PRIORITY_UPDATE for a stream in the "idle" state MUST
+Stream ID refers to a stream in the "closed" state.
+Clients MUST NOT provide a Prioritized Stream ID that refers to a push stream in the
+"idle" state. Servers that receive a PRIORITY_UPDATE for a push stream in the "idle" state MUST
 respond with a connection error of type PROTOCOL_ERROR.
 
 If a PRIORITY_UPDATE frame is received with a Prioritized Stream ID of 0x0, the

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -364,9 +364,8 @@ as the most up-to-date information that overrides any other signal. Servers
 SHOULD buffer the most recently received PRIORITY_UPDATE frame and apply it once
 the referenced stream is opened. Holding PRIORITY_UPDATE frames for each stream
 requires server resources, which can can be bound by local implementation
-policy. (TODO: consider resolving #1261, and adding more text about bounds).
-Although there is no limit to the number of PRIORITY_UPDATES that can be sent,
-storing only the most recently received frame limits resource commitment.
+policy. Although there is no limit to the number of PRIORITY_UPDATES that can be
+sent, storing only the most recently received frame limits resource commitment.
 
 ## HTTP/2 PRIORITY_UPDATE Frame {#h2-update-frame}
 


### PR DESCRIPTION
Fixes #1261.

When the ID discusses PRIORITY_UPDATE frame element ID for HTTP/2,
@MikeBishop rightly pointed out that HTTP/2 doesn't have HTTP/3's 
notion of stream limits. So this text tries to reframe things in
terms of the concurrency window.

I might have gone too far here. Given the guidance we give about
buffering PRIORITY_UPDATE, and the fuziness of concurrency window and
upper limts to idle but openable streams, I don't think its right
to recommend that servers treat it as a conenction error. 

Interested to see what others think of the PR/
