### PR TITLE
Fix: #1392. Reference RFC 6515 and 6194 for deprecating md5 and sha1.

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -349,10 +349,13 @@ The Internet Assigned Numbers Authority (IANA) acts as a registry for
 digest-algorithm values.
 The registry contains the tokens listed below.
 
-Some digest-algorithms, although registered, rely on vulnerable algorithms:
-the "md5" digest-algorithm MUST NOT be used due to collision attacks [CMU-836068]
-and the "sha" digest-algorithm MUST NOT be used due
-to collision attacks [IACR-2020-014].
+Some digest-algorithms, although registered, rely on vulnerable algorithms
+and MUST not be used:
+
+- "md5", see [CMU-836068] and {{?NO-MD5=RFC6151}};
+- "sha", see [IACR-2020-014] and {{?NO-SHA1=RFC6194}}.
+
+See the references above for further information.
 
 
   {: vspace="0"}
@@ -373,7 +376,7 @@ to collision attacks [IACR-2020-014].
       The output of this algorithm is encoded using the
       base64 encoding  [RFC4648].
       This digest-algorithm MUST NOT be used as it's now vulnerable
-      to collision attacks [CMU-836068].
+      to collision attacks. See {{NO-MD5}} and [CMU-836068].
     * Reference: [RFC1321], [RFC4648], this document.
     * Status: deprecated
 
@@ -381,7 +384,7 @@ to collision attacks [IACR-2020-014].
   : * Description:  The SHA-1 algorithm [RFC3174].  The output of this
       algorithm is encoded using the base64 encoding  [RFC4648].
       This digest-algorithm MUST NOT be used as it's now vulnerable
-      to collision attacks [IACR-2020-014].
+      to collision attacks. See {{NO-SHA1}} and [IACR-2020-014].
     * Reference: [RFC3174], [RFC6234], [RFC4648], this document.
     * Status: deprecated
 


### PR DESCRIPTION
## This PR

- references RFC6515 and 6194 for deprecating md5 and sha1

## Note

Since there are RFCs, we could even skip explaining that those algorithms are vulnerable to collisions.