### PR TITLE
clean up editorial notes and issues list

### DIFF
--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -71,6 +71,14 @@ informative:
 
 This document describes a mechanism for creating, encoding, and verifying digital signatures or message authentication codes over content within an HTTP message.  This mechanism supports use cases where the full HTTP message may not be known to the signer, and where the message may be transformed (e.g., by intermediaries) before reaching the verifier.
 
+--- note_Note_to_Readers
+
+*RFC EDITOR: please remove this section before publication*
+
+Discussion of this draft takes place on the HTTP working group mailing list (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
+
+Working Group information can be found at <https://httpwg.org/>; source code and issues list for this draft can be found at <https://github.com/httpwg/http-extensions/labels/signatures>.
+
 --- middle
 
 # Introduction {#intro}


### PR DESCRIPTION
This removes the in-document "issues" list and background introduction note paragraph, in line with the document's status as a working group draft backed with an issue tracker.

All removed items should have corresponding issues tagged with `signatures` in this repository's issue tracker (some have already been closed), so keeping them in the document was redundant and artificially inflated the page count.