### PR TITLE
[6265bis] Refactor cookie retrieval algorithm to support non-HTTP APIs

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -89,6 +89,13 @@ normative:
       ins: D. Denicola
       name: Domenic Denicola
       organization: Google, Inc.
+  COOKIE-URL:
+    target: https://html.spec.whatwg.org/#cookie-url
+    title: HTML - Living Standard
+    date: 2021-05-04
+    author:
+    -
+      org: WHATWG
   SAMESITE:
     target: https://html.spec.whatwg.org/#same-site
     title: HTML - Living Standard
@@ -1539,9 +1546,11 @@ set to false.
 
 ## Retrieval Model {#retrieval-model}
 
-This section defines how cookies are retrieved from a cookie store in the form of
-a cookie-string. A cookie-string may be used to build a Cookie header for an HTTP
-request, or may be returned from a "non-HTTP" API that provides access to cookies.
+This section defines how cookies are retrieved from a cookie store in the form
+of a cookie-string. A "retrieval " is any event which requires generating a
+cookie-string. For example, a retrieval may occur in order to build a Cookie
+header for an HTTP request, or may be required in order to return a
+cookie-string from a call to a "non-HTTP" API that provides access to cookies.
 
 ### The Cookie Header {#cookie}
 
@@ -1555,29 +1564,35 @@ user agent might wish to block sending cookies during "third-party" requests
 from setting cookies (see {{third-party-cookies}}).
 
 If the user agent does attach a Cookie header field to an HTTP request, the
-user agent MUST send the cookie-string as the value of the
-header field. The cookie-string is computed as defined in {{retrieval-algorithm}},
-whereby the retrieval-uri is defined as the request-uri and the same-site status
-is computed for the HTTP request as defined in {{same-site-requests}}.
+user agent MUST compute the cookie-string following the algorithm defined in
+{{retrieval-algorithm)}, indicating that the retrieval is for an HTTP request.
+The retrieval-uri is defined as the request-uri and the same-site status of the
+retrieval is computed for the HTTP request as defined in
+{{same-site-requests}}.
 
 ### Non-HTTP APIs {#non-http}
 
 The user agent MAY implement "non-HTTP" APIs that can be used to access
 stored cookies.
 
-A user agent MAY return an empty cookie-string in certain contexts, such as when
-retrieval occurs within a third-party context (see {{third-party-cookies}}).
+A user agent MAY return an empty cookie-string in certain contexts, such as
+when a retrieval occurs within a third-party context (see
+{{third-party-cookies}}).
 
-If a user agent does return cookies for a given call to a "non-HTTP" API with an
-associated Document, then the user agent MUST compute the cookie-string following
-the algorithm defined in {{retrieval-algorithm)}, whereby the retrieval-uri is the
-associated Document's URL. The retrieval is same-site if the Document's "site for
-cookies" is same-site with the top-level origin as defined in {{document-requests}}.
+If a user agent does return cookies for a given call to a "non-HTTP" API with
+an associated Document, then the user agent MUST compute the cookie-string
+following the algorithm defined in {{retrieval-algorithm)}, indicating that the
+retrieval is from a "non-HTTP" API. The retrieval-uri is the associated
+Document's cookie URL {{COOKIE-URL}}, and the retrieval is same-site if the
+Document's "site for cookies" is same-site with the top-level origin as defined
+in {{document-requests}}.
 
 ### Retrieval Algorithm {#retrieval-algorithm}
 
-Given a cookie store, a retrieval-uri, and the same-site status of the
-retrieval-uri, the following algorithm returns a cookie-string.
+The following algorithm returns a cookie-string from a given cookie store.
+Callers of this algorithm MUST provide a retrieval-uri, indicate the same-site
+status of the retrieval, and indicate whether the retrieval is for an HTTP
+request or from a "non-HTTP" API.
 
 1. Let cookie-list be the set of cookies from the cookie store that meets all
    of the following requirements:
@@ -1604,7 +1619,7 @@ retrieval-uri, the following algorithm returns a cookie-string.
      protocol.
 
    * If the cookie's http-only-flag is true, then exclude the cookie if the
-     cookie-string is being generated for a "non-HTTP" API.
+     retrieval is for a "non-HTTP" API.
 
    * If the cookie's same-site-flag is not "None" and the retrieval's same-site
      status is "cross-site", then exclude the cookie unless all of the following

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -337,8 +337,8 @@ project at {{PSL}}.
 The term "request", as well as a request's "client", "current url", "method",
 "target browsing context", and "url list", are defined in {{FETCH}}.
 
-The term "non-HTTP APIs" refers to non-HTTP methods used to set and retrieve
-cookies, such as a web browser API that exposes cookies to scripts.
+The term "non-HTTP APIs" refers to non-HTTP mechanisms used to set and retrieve cookies,
+such as a web browser API that exposes cookies to scripts.
 
 # Overview
 
@@ -1570,7 +1570,7 @@ retrieval occurs within a third-party context (see {{third-party-cookies}}).
 
 If a user agent does return cookies for a given call to a "non-HTTP" API with an
 associated Document, then the user agent MUST compute the cookie-string following
-the algorithm defined in {{retrieval-algorithm}, whereby the retrieval-uri is the
+the algorithm defined in {{retrieval-algorithm)}, whereby the retrieval-uri is the
 associated Document's URL. The retrieval is same-site if the Document's "site for
 cookies" is same-site with the top-level origin as defined in {{document-requests}}.
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -876,7 +876,7 @@ found-year) are initially "not set".
     the minute-value, and the second-value, respectively. If no such date
     exists, abort these steps and fail to parse the cookie-date.
 
-7. Return the parsed-cookie-date as the result of this algorithm.
+7.  Return the parsed-cookie-date as the result of this algorithm.
 
 ### Canonicalized Host Names
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1576,9 +1576,8 @@ cookies" is same-site with the top-level origin as defined in {{document-request
 
 ### Retrieval Algorithm {#retrieval-algorithm}
 
-The user agent MUST use an algorithm equivalent to the following algorithm to
-compute the cookie-string from a cookie store, a retrieval-uri, and the retrieval's
-same-site status.
+Given a cookie store, a retrieval-uri, and the same-site status of the
+retrieval-uri, the following algorithm returns a cookie-string.
 
 1. Let cookie-list be the set of cookies from the cookie store that meets all
    of the following requirements:
@@ -1612,7 +1611,8 @@ same-site status.
      conditions are met:
 
      * The retrieval is for a Cookie header in the HTTP request associated with
-       the retrieval-uri The same-site-flag is "Lax" or "Default".
+       the retrieval-uri.
+     * The same-site-flag is "Lax" or "Default".
      * The HTTP request's method is "safe".
      * The HTTP request's target browsing context is a top-level browsing context.
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1562,7 +1562,7 @@ is computed for the HTTP request as defined in {{same-site-requests}}.
 
 ### Non-HTTP APIs {#non-http}
 
-The user agent may implement "non-HTTP" APIs that can be used to access 
+The user agent may implement "non-HTTP" APIs that can be used to access
 stored cookies.
 
 A user agent MAY return an empty cookie-string in certain contexts, such as when

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1539,6 +1539,43 @@ set to false.
 
 ## Retrieval Model {#retrieval-model}
 
+This section defines how cookies are retrieved from a cookie store in the form of
+a cookie-string. A cookie-string may be used to build a Cookie header for an HTTP
+request, or may be returned from a "non-HTTP" API that provides access to cookies.
+
+### The Cookie Header {#cookie}
+
+The user agent includes stored cookies in the Cookie HTTP request header.
+
+When the user agent generates an HTTP request, the user agent MUST NOT attach
+more than one Cookie header field.
+
+A user agent MAY omit the Cookie header in its entirety.  For example, the
+user agent might wish to block sending cookies during "third-party" requests
+from setting cookies (see {{third-party-cookies}}).
+
+If the user agent does attach a Cookie header field to an HTTP request, the
+user agent MUST send the cookie-string as the value of the
+header field. The cookie-string is computed as defined in {{retrieval-algorithm}},
+whereby the retrieval-uri is defined as the request-uri and the same-site status
+is computed for the HTTP request as defined in {{same-site-requests}}.
+
+### Non-HTTP APIs {#non-http}
+
+The user agent may implement "non-HTTP" APIs that can be used to access 
+stored cookies.
+
+A user agent MAY return an empty cookie-string in certain contexts, such as when
+retrieval occurs within a third-party context (see {{third-party-cookies}}).
+
+If a user agent does return cookies for a given call to a "non-HTTP" API with an
+associated Document, then the user agent MUST compute the cookie-string following
+the algorithm defined in {{retrieval-algorithm}, whereby the retrieval-uri is the
+associated Document's URL. The retrieval is same-site if the Document's "site for
+cookies" is same-site with the top-level origin as defined in {{document-requests}}.
+
+### Retrieval Algorithm {#retrieval-algorithm}
+
 The user agent MUST use an algorithm equivalent to the following algorithm to
 compute the cookie-string from a cookie store, a retrieval-uri, and the retrieval's
 same-site status.
@@ -1612,30 +1649,7 @@ the user agent might wish to try using the UTF-8 character encoding {{RFC3629}}
 to decode the octet sequence. This decoding might fail, however, because not
 every sequence of octets is valid UTF-8.
 
-### The Cookie Header {#cookie}
 
-The user agent includes stored cookies in the Cookie HTTP request header.
-
-When the user agent generates an HTTP request, the user agent MUST NOT attach
-more than one Cookie header field.
-
-A user agent MAY omit the Cookie header in its entirety.  For example, the
-user agent might wish to block sending cookies during "third-party" requests
-from setting cookies (see {{third-party-cookies}}).
-
-If the user agent does attach a Cookie header field to an HTTP request, the
-user agent MUST send the cookie-string as the value of the
-header field. The cookie-string is computed as defined in {{retrieval-model}},
-whereby the retrieval-uri is defined as the request-uri and the same-site status
-is computed for the HTTP request as defined in {{same-site-requests}}.
-
-### Non-HTTP APIs {#non-http}
-
-When a cookie-string is retrieved by a "non-HTTP" API with an associated
-Document, the user agent MUST compute the cookie-string following the algorithm
-defined in {{retrieval-model}}, whereby the retrieval-uri is the associated
-Document's URL. The retrieval is same-site if the Document's "site for cookies"
-is same-site with the top-level origin as defined in {{document-requests}}.
 
 # Implementation Considerations
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1565,7 +1565,7 @@ from setting cookies (see {{third-party-cookies}}).
 
 If the user agent does attach a Cookie header field to an HTTP request, the
 user agent MUST compute the cookie-string following the algorithm defined in
-{{retrieval-algorithm)}, indicating that the retrieval is for an HTTP request.
+{{retrieval-algorithm}}, indicating that the retrieval is for an HTTP request.
 The retrieval-uri is defined as the request-uri and the same-site status of the
 retrieval is computed for the HTTP request as defined in
 {{same-site-requests}}.
@@ -1581,7 +1581,7 @@ when a retrieval occurs within a third-party context (see
 
 If a user agent does return cookies for a given call to a "non-HTTP" API with
 an associated Document, then the user agent MUST compute the cookie-string
-following the algorithm defined in {{retrieval-algorithm)}, indicating that the
+following the algorithm defined in {{retrieval-algorithm}}, indicating that the
 retrieval is from a "non-HTTP" API. The retrieval-uri is the associated
 Document's cookie URL {{COOKIE-URL}}, and the retrieval is same-site if the
 Document's "site for cookies" is same-site with the top-level origin as defined

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1562,7 +1562,7 @@ is computed for the HTTP request as defined in {{same-site-requests}}.
 
 ### Non-HTTP APIs {#non-http}
 
-The user agent may implement "non-HTTP" APIs that can be used to access
+The user agent MAY implement "non-HTTP" APIs that can be used to access
 stored cookies.
 
 A user agent MAY return an empty cookie-string in certain contexts, such as when


### PR DESCRIPTION
This PR refactors the cookie retrieval algorithm that formerly lived in `The Cookie Header` section to a new `Retrieval Model` section that mirrors the more generic `Storage Model` section for cookie setting.

This didn't require too much legwork in the end. Of note, I've moved us over from working with a [request-target](https://tools.ietf.org/html/rfc7230#section-5.3) to [target URI](https://tools.ietf.org/html/rfc7230#section-5.1). A request target may not be a full URI (i.e., the "origin form" is a path + query), but we want a full URI so we can call the retrieval algorithm with a Document's URI for non-HTTP APIs. This was mostly a drop-in replacement in the rest of the doc, but I did remove one section that elaborated on extracting a path from the different forms of a request target.

I'm wondering whether we want to keep the `non-HTTP API` section at all. This only specifies one type of non-HTTP API (i.e., those with an associated Document); I'm not sure if there are any other non-HTTP APIs that user agents implement? And that functionality is already specified in more detail in HTML [here](https://html.spec.whatwg.org/#dom-document-cookie). I wonder whether it's better to just update HTML with a reference to the new Retrieval Algorithm once we release a new version of the draft. cc/ @annevk for input.

Addresses #1233, #769, and #1163.