### PR TITLE
Improve POST and PATCH section. See #1366.

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -466,12 +466,6 @@ In PATCH requests, the representation digest MUST be computed on the patch docum
 because the representation metadata refers to the patch document and not
 to the target resource (see Section 2 of {{?PATCH=RFC5789}}).
 
-In PATCH responses, the representation digest MUST be computed on the selected
-representation of the patched resource.
-
-`Digest` usage with PATCH is thus very similar to POST, but with the
-resource's own semantic partly implied by the method and by the patch document.
-
 # Deprecate Negotiation of Content-MD5 {#deprecate-contentMD5}
 
 This RFC deprecates the negotiation of Content-MD5 as it has been obsoleted by

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -436,9 +436,8 @@ character sets used for the encoding.
 
 # Use of Digest when acting on resources {#acting-on-resources}
 
-POST and PATCH requests can appear to convey partial representations but are
-semantically acting on resources. The enclosed representation, including its
-metadata, refers to that action.
+In POST and PATCH requests, the representation data and metadata
+describe an action on a resource.
 
 In these requests the representation digest MUST be computed on the
 representation-data of that action.
@@ -456,7 +455,7 @@ In responses,
    even if that is different from the target resource.
    That might or might not result in computing `Digest` on the enclosed representation.
 
-The latter case might be done according to the HTTP semantics of the given
+The latter case is done according to the HTTP semantics of the given
 method, for example using the `Content-Location` header field.
 In contrast, the `Location` header field does not affect `Digest` because
 it is not representation metadata.


### PR DESCRIPTION
## This PR

improves POST and PATCH section considering some of the hints provided in #1366 

- the fact that PATCH responses require digest to be computed on the representation-data of the patched document is implied by the rest of the document;
