### PR TITLE
Mark's review on section 3.

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -228,11 +228,7 @@ The representation digest is an integrity mechanism for HTTP resources
 which uses a checksum  that is calculated independently of the content
 (see Section 6.4 of {{SEMANTICS}}).
 It uses the representation data (see Section 8.1 of {{SEMANTICS}}),
-that can be fully or partially contained in the content, or not contained at all:
-
-~~~
-   representation-data := Content-Encoding( Content-Type( bits ) )
-~~~
+that can be fully or partially contained in the content, or not contained at all.
 
 This takes into account the effect of the HTTP semantics on the messages;
 for example, the content can be affected by Range Requests or methods such as HEAD,
@@ -258,12 +254,6 @@ computing the representation digest on an empty string
 
 The checksum is computed using one of the digest-algorithms listed in {{algorithms}}
 and then encoded in the associated format.
-
-The example below shows the  "sha-256" digest-algorithm that uses base64 encoding.
-
-~~~ example
-   sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-~~~
 
 # The Digest Field {#digest}
 


### PR DESCRIPTION
## This PR

- [x] * 3. It's probably worth mentioning that they're comma-separated in prose.
- [ ] * 3. I'm uncomfortable with relying on examples to specify how this spec works normatively; by their nature, examples are not 'comprehensive.' While this spec shouldn't re-specify HTTP, the header's definition should be clear enough that a reader doesn't have to dig around in the examples and other specs to understand what's going on.
- [x] * 3. Disagreeing plurals in 'an incremental digest-algorithms'.
- [x] * 4. Is Want-Digest a request field, a response field, or both? In either or both cases, what's the scope of the assertion?
- [x] * 4. A reference to SEMANTICS 12.4.2 is necessary.
