### PR TITLE
Remove TODOs

### DIFF
--- a/draft-ietf-httpbis-client-cert-field.md
+++ b/draft-ietf-httpbis-client-cert-field.md
@@ -115,15 +115,6 @@ requires that the client send the Certificate and CertificateVerify messages
 during the handshake and for the server to verify the CertificateVerify and
 Finished messages.
 
-> TODO: HTTP2 forbids TLS renegotiation and post-handshake authentication but it's
-possible with HTTP1.1 and maybe needs to be discussed explicitly here or
-somewhere in this document? Naively I'd say that the `Client-Cert` header will
-be sent with the data of the most recent client cert anytime after renegotiation
-or post-handshake auth. And only for requests that are fully covered by the cert
-but that in practice making the determination of where exactly in the
-application data the cert messages arrived is hard to impossible so it'll be a
-best effort kind of thing.
-
 
 # HTTP Header Field and Processing Rules
 
@@ -241,8 +232,7 @@ Other deployments that meet the requirements set forth herein are also possible.
 
 # IANA Considerations
 
-> TODO: register the `Client-Cert` HTTP header field in the registry defined by
-http-core.
+The `Client-Cert` HTTP header field will be added to the registry defined by http-core.
 
 --- back
 
@@ -368,28 +358,6 @@ responsibility of certificate validation falling on the TTRP, only the
 end-entity certificate is passed to the backend - the root Certificate Authority
 is not included nor are any intermediates.
 
-> TODO: It has been suggested that more information about the certificate chain
-might be needed/wanted by the backend application (to independently evaluate the
-cert chain, for example, although that seems like it would be terribly
-inefficient) and that any intermediates as well as the root should also be
-somehow conveyed, which is an area for further discussion should this draft
-progress. One potential approach suggested by a few folks is to allow some
-configurability in what is sent along with maybe a prefix token to indicate
-what's being sent - something like `Client-Cert: FULL \<cert> \<intermediate>
-\<anchor>` or `Client-Cert: EE \<cert>` as the strawman. Or a perhaps a
-parameter or other construct of {{?RFC8941}} to indicate what's being sent. It's
-also been suggested that the end-entity certificate by itself might sometimes be
-too big (esp. e.g., with some post-quantum signature schemes). Hard to account
-for it both being too much data and not enough data at the same time. But
-potentially opening up configuration options to send only specific attribute(s)
-from the client certificate is a possibility for that. In the author's humble
-opinion the end-entity certificate by itself strikes a good balance for the vast
-majority of needs and avoids optionality. But, again, this is an area for
-further discussion should this draft progress.
-
-> TODO: It has also been suggested that maybe considerations for {{?RFC7250}} Raw
-Public Keys is maybe worth considering. This too is this is an area for further
-discussion and consideration should this draft progress.
 
 # Acknowledgements
 


### PR DESCRIPTION
I've opened issues for the things that were previously TODO comments in the draft; this removes them from the draft itself.