### PR TITLE
added new specialty content fields, fix request-target

### DIFF
--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -446,9 +446,13 @@ If used in a response message, the `@scheme` identifier refers to the associated
 
 The `@request-target` identifier refers to the full request target of the HTTP request message,
 as defined in {{SEMANTICS}} Section 7.1. The value of the request target can take different forms,
-depending on the type of request. For HTTP 1.1, the value is equivalent to the request target
-portion of the request line.
+depending on the type of request, as described below.
 If used, the `@request-target` identifier MUST occur only once in the signature input.
+
+For HTTP 1.1, the value is equivalent to the request target
+portion of the request line. However, this value is more difficult to reliably construct in
+other versions of HTTP. Therefore, it is NOT RECOMMENDED that this identifier be used
+when versions of HTTP other than 1.1 might be in use.
 
 The origin form value is combination of the absolute path and query components of the request URL. For example, the following request message:
 

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -1016,7 +1016,7 @@ This document defines a method for canonicalizing HTTP message content, includin
 The table below contains the initial contents of the HTTP Signature Specialty Content Identifiers Registry.
 
 |Name|Status|Target|Reference|
-|--- |--- |--- |
+|--- |--- |--- |--- |
 |`@signature-params`|Active   | Request, Response | {{signature-params}} of this document|
 |`@method`| Active | Request, Related-Response | {{content-request-method}} of this document|
 |`@authority`| Active | Request, Related-Response | {{content-request-authority}} of this document|

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -1015,17 +1015,17 @@ This document defines a method for canonicalizing HTTP message content, includin
 
 The table below contains the initial contents of the HTTP Signature Specialty Content Identifiers Registry.
 
-|Name|Status|Reference|
+|Name|Status|Target|Reference|
 |--- |--- |--- |
-|`@signature-params`|Active   | {{signature-params}} of this document|
-|`@method`| Active | {{content-request-method}} of this document|
-|`@authority`| Active | {{content-request-authority}} of this document|
-|`@scheme`| Active | {{content-request-scheme}} of this document|
-|`@target-uri`| Active | {{content-target-uri}} of this document|
-|`@request-target`| Active | {{content-request-target}} of this document|
-|`@path`| Active | {{content-request-path}} of this document|
-|`@query-param`| Active | {{content-request-query}} of this document|
-|`@status-code`| Active | {{content-status-code}} of this document|
+|`@signature-params`|Active   | Request, Response | {{signature-params}} of this document|
+|`@method`| Active | Request, Related-Response | {{content-request-method}} of this document|
+|`@authority`| Active | Request, Related-Response | {{content-request-authority}} of this document|
+|`@scheme`| Active | Request, Related-Response | {{content-request-scheme}} of this document|
+|`@target-uri`| Active | Request, Related-Response | {{content-target-uri}} of this document|
+|`@request-target`| Active | Request, Related-Response | {{content-request-target}} of this document|
+|`@path`| Active | Request, Related-Response | {{content-request-path}} of this document|
+|`@query-param`| Active | Request, Related-Response | {{content-request-query}} of this document|
+|`@status-code`| Active | Response | {{content-status-code}} of this document|
 {: title="Initial contents of the HTTP Signature Specialty Content Identifiers Registry." }
 
 # Security Considerations {#security}

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -525,6 +525,8 @@ Would result in the following `@path` value:
 "@path": /path
 ~~~
 
+If used in a response message, the `@path` identifier refers to the associated value of the request that triggered the response message being signed.
+
 ### Query {#content-request-query}
 
 The `@query` identifier refers to the query component of the HTTP request message. The value is the entire normalized query string defined by {{RFC3986}}, including the leading `?` character. The value is normalized according to the rules in {{SEMANTICS}} Section 4.2.3. Namely, percent-encoded octets are decoded.
@@ -555,6 +557,8 @@ Would result in the following `@query` value:
 ~~~
 "@query": ?queryString
 ~~~
+
+If used in a response message, the `@query` identifier refers to the associated value of the request that triggered the response message being signed.
 
 ### Query Parameters {#content-request-query-params}
 

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -954,10 +954,16 @@ This document defines a method for canonicalizing HTTP message content, includin
 
 The table below contains the initial contents of the HTTP Signature Specialty Content Identifiers Registry.
 
-|Name|Status|Reference(s)|
+|Name|Status|Reference|
 |--- |--- |--- |
-|`@request-target`|Active   | {{content-request-target}} of this document|
 |`@signature-params`|Active   | {{signature-params}} of this document|
+|`@method`| Active | {{content-request-method}} of this document|
+|`@authority`| Active | {{content-request-authority}} of this document|
+|`@scheme`| Active | {{content-request-scheme}} of this document|
+|`@request-origin`| Active | {{content-request-origin}} of this document|
+|`@path`| Active | {{content-request-path}} of this document|
+|`@query-param`| Active | {{content-request-query}} of this document|
+|`@status-code`| Active | {{content-status-code}} of this document|
 {: title="Initial contents of the HTTP Signature Specialty Content Identifiers Registry." }
 
 # Security Considerations {#security}

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -402,7 +402,8 @@ If used in a response message, the `@target-uri` identifier refers to the associ
 
 ### Authority {#content-request-authority}
 
-The `@authority` identifier refers to the authority component of the target URI of the HTTP request message, as defined in {{SEMANTICS}} Section 7.2. In HTTP 1.1, this is usually conveyed using the `Host` header, while in HTTP 2 and HTTP 3 it is conveyed using the `:authority` pseudo-header. The value is the fully-qualified authority component of the request, comprised of the host and, optionally, port of the request target, as a string. The Authority value MUST be normalized according to the rules in {{SEMANTICS}} Section 7.2.
+The `@authority` identifier refers to the authority component of the target URI of the HTTP request message, as defined in {{SEMANTICS}} Section 7.2. In HTTP 1.1, this is usually conveyed using the `Host` header, while in HTTP 2 and HTTP 3 it is conveyed using the `:authority` pseudo-header. The value is the fully-qualified authority component of the request, comprised of the host and, optionally, port of the request target, as a string.
+The Authority value MUST be normalized according to the rules in {{SEMANTICS}} Section 4.2.3. Namely, the host name is normalized to lowercase and the default port is omitted.
 If used, the `@authority` identifier MUST occur only once in the signature input.
 
 For example, the following request message:
@@ -423,6 +424,8 @@ If used in a response message, the `@authority` identifier refers to the associa
 ### Scheme {#content-request-scheme}
 
 The `@scheme` identifier refers to the scheme of the target URL of the HTTP request message. The value is the scheme as a string as defined in {{SEMANTICS}} Section 4.2.
+While the scheme itself is case-insensitive, it MUST be normalized to lowercase for
+inclusion in the signature input string.
 
 For example, the following request message requested over plain HTTP:
 
@@ -502,7 +505,7 @@ If used in a response message, the `@request-target` identifier refers to the as
 
 ### Path {#content-request-path}
 
-The `@path` identifier refers to the target path of the HTTP request message. The value is the absolute path of the request target defined by {{RFC3986}}, with no query component and no trailing `?` character.
+The `@path` identifier refers to the target path of the HTTP request message. The value is the absolute path of the request target defined by {{RFC3986}}, with no query component and no trailing `?` character. The value is normalized according to the rules in {{SEMANTICS}} Section 4.2.3. Namely, an empty path string is normalized as a single slash `/` character, and path components are represented by their values after decoding any percent-encoded octets.
 If used, the `@path` identifier MUST occur only once in the signature input.
 
 For example, the following request message:
@@ -520,7 +523,7 @@ Would result in the following `@path` value:
 
 ### Query {#content-request-query}
 
-The `@query` identifier refers to the query component of the HTTP request message. The value is the entire normalized query string defined by {{RFC3986}}, not including the leading `?` character.
+The `@query` identifier refers to the query component of the HTTP request message. The value is the entire normalized query string defined by {{RFC3986}}, including the leading `?` character. The value is normalized according to the rules in {{SEMANTICS}} Section 4.2.3. Namely, percent-encoded octets are decoded.
 If used, the `@query` identifier MUST occur only once in the signature input.
 
 For example, the following request message:
@@ -533,7 +536,7 @@ Host: www.example.com
 Would result in the following `@query` value:
 
 ~~~
-"@query": param=value&foo=bar&baz=batman
+"@query": ?param=value&foo=bar&baz=batman
 ~~~
 
 The following request message:
@@ -546,7 +549,7 @@ Host: www.example.com
 Would result in the following `@query` value:
 
 ~~~
-"@query": queryString
+"@query": ?queryString
 ~~~
 
 ### Query Parameters {#content-request-query-params}
@@ -557,7 +560,7 @@ The REQUIRED `name` parameter of each input identifier contains the `nameString`
 Several named query parameters MAY be included in a single signature input.
 Single named parameters MAY occur in any order in the signature input string.
 
-The value of a single named parameter is the the `valueString` of the named query parameter defined by {{HTMLURL}} Section 5.1, which is the value after URL decoding.
+The value of a single named parameter is the the `valueString` of the named query parameter defined by {{HTMLURL}} Section 5.1, which is the value after percent-encoded octets are decoded.
 Note that this value does not include any leading `?` characters, equals sign `=`, or separating `&` characters.
 Named query parameters with an empty `valueString` are included with an empty string as the covered content value.
 

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -1289,7 +1289,7 @@ Signature: sig1=:HWP69ZNiom9Obu1KIdqPPcu/C1a5ZUMBbqS/xwJECV8bhIQVmE\
 
 ### Selective Coverage using rsa-pss-sha512
 
-This example covers additional elements in `test-request`, not including the body Digest header using the `rsa-pss-sha512` algorithm.
+This example covers additional elements in `test-request`, not including the body Digest header, using the `rsa-pss-sha512` algorithm.
 
 The corresponding signature input is:
 


### PR DESCRIPTION
This adds several new specialty identifiers for requests and responses to cover the method, authority, scheme, origin, path, query, and status code values of the HTTP message.

It also edits the `request-target` identifier's associated value to remove the verb and the string construction rules and instead align with HTTP Semantics.
