### PR TITLE
Enable linting by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ $(GHPAGES_EXTRA):
 clean::
 	-rm -f $(GHPAGES_EXTRA)
 
+lint:: http-lint
+
 rfc-http-validate ?= rfc-http-validate.py
 .PHONY: http-lint
 http-lint: $(drafts_xml) http-lint-install


### PR DESCRIPTION
No sense in having a linter if you don't lint.

That said, the signatures draft is currently failing validation.  I think that it isn't picking up
the line folding annotations properly.