### PR TITLE
RFC6265bis: Improve handling of nameless cookies when serializing

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1735,12 +1735,15 @@ cookie-string from a given cookie store.
 4. Serialize the cookie-list into a cookie-string by processing each cookie
    in the cookie-list in order:
 
-   1.  If the cookies' name is not empty, output the cookie's name followed by
-       the %x3D ("=") character.
+   1.  If the cookie's name is not empty, output the cookie's name.
 
-   2.  If the cookies' value is not empty, output the cookie's value.
+   2.  If the cookie's name is empty and the cookie's value does not contain
+       the %x3D ("=") character, either output the %x3D ("=") character or
+       skip this step.  Otherwise, output the %x3D ("=") character.
 
-   3.  If there is an unprocessed cookie in the cookie-list, output the
+   3.  If the cookie's value is not empty, output the cookie's value.
+
+   4.  If there is an unprocessed cookie in the cookie-list, output the
        characters %x3B and %x20 ("; ").
 
 NOTE: Despite its name, the cookie-string is actually a sequence of octets, not


### PR DESCRIPTION
Update the cookie serialization logic so that cookies without a name and that have a '=' character in the value aren't serialized in a way that would cause them to be interpreted incorrectly.

See https://github.com/httpwg/http-extensions/issues/1210#issuecomment-893863325 for more details