### PR TITLE
Update RFC6265bis changelog to mention HTAB change

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2420,6 +2420,9 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 * Reject cookies with control characters:
   <https://github.com/httpwg/http-extensions/pull/1576>
 
+* No longer treat horizontal tab as a control character:
+  <https://github.com/httpwg/http-extensions/pull/1589>
+
 # Acknowledgements
 {:numbered="false"}
 RFC 6265 was written by Adam Barth. This document is an update of RFC 6265,


### PR DESCRIPTION
Minor update to the RFC6265bis changelog to mention the change in treatment of the horizontal tab character (now it's essentially handled the same way as space instead of how control characters are handled).

If you think the summary text here should be improved please let me know. Thanks!