### PR TITLE
Fix: #1533. Add registration policy for digest algorithms.

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1267,7 +1267,7 @@ IANA is asked to update the "Reference" for this registry
 to refer this document.
 
 New registrations will be permitted
-through the Specification Required policy {{!BCP26}}.
+through the RFC Required policy {{!BCP26}}.
 
 
 ## Obsolete "contentMD5" token in Digest Algorithm {#iana-contentMD5}

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1273,8 +1273,8 @@ to refer this document
 and to inizialize the registry with the tokens 
 defined in {{algorithms}}.
 
-New registrations will be permitted
-through the RFC Required policy (see Section 4.7 of {{!RFC8126}}).
+This registry uses the Specification
+Required policy (Section 4.6 of {{!RFC8126}}).
 
 
 ## Obsolete "contentMD5" token in Digest Algorithm {#iana-contentMD5}

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1270,7 +1270,7 @@ Values](https://www.iana.org/assignments/http-dig-alg/) registry.
 IANA is asked to update the "Reference" for this registry
 to refer this document
 and to inizialize the registry with the tokens 
-defined in {{digest-algorithms}}.
+defined in {{algorithms}}.
 
 New registrations will be permitted
 through the RFC Required policy (see Section 4.7 of {{!RFC8126}}).

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -418,8 +418,9 @@ All digest-algorithm token values are case-insensitive
 but lower case is preferred;
 digest-algorithm token values MUST be compared in a case-insensitive fashion.
 
-Every digest-algorithm defines its computation procedure and,
-unless specified otherwise, the comparison is case-sensitive.  
+Every digest-algorithm defines its computation procedure and
+encoding output. Unless specified otherwise, comparison of
+encoded output is case-sensitive.  
 
 The "HTTP Digest Algorithm Values Registry",
 maintained by IANA at <https://www.iana.org/assignments/http-dig-alg/> registers

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1263,6 +1263,13 @@ This memo sets this specification to be the establishing document for the [HTTP 
 Algorithm
 Values](https://www.iana.org/assignments/http-dig-alg/) registry.
 
+IANA is asked to update the "Reference" for this registry
+to refer this document.
+
+New registrations will be permitted
+through the Specification Required policy {{!BCP26}}.
+
+
 ## Obsolete "contentMD5" token in Digest Algorithm {#iana-contentMD5}
 
 This memo adds the "contentMD5" token in the [HTTP Digest Algorithm

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -250,7 +250,8 @@ it is still possible to assert that no representation data was sent
 computing the representation digest on an empty string
 (see {{usage-in-signatures}}).
 
-The checksum is computed using one of the digest-algorithms listed in {{algorithms}}
+The checksum is computed using one of the digest-algorithms listed in
+the HTTP Digest Algorithm Values Registry (see {{algorithms}})
 and then encoded in the associated format.
 
 # The Digest Field {#digest}
@@ -1264,7 +1265,9 @@ Algorithm
 Values](https://www.iana.org/assignments/http-dig-alg/) registry.
 
 IANA is asked to update the "Reference" for this registry
-to refer this document.
+to refer this document
+and to inizialize the registry with the tokens 
+defined in {{digest-algorithms}}.
 
 New registrations will be permitted
 through the RFC Required policy {{!BCP26}}.
@@ -1283,18 +1286,18 @@ registry:
 * Status: obsoleted
 
 ## Changes Compared to RFC3230
-￼
-The `contentMD5` digest-algorithm token defined in Section 5 of [RFC3230] is removed from
-the HTTP Digest Algorithm Values Registry.
+
+The `contentMD5` digest-algorithm token defined in Section 5 of [RFC3230]
+has been added to the HTTP Digest Algorithm Values Registry with the "obsoleted" status.
 
 All digest-algorithms defined in [RFC3230] are now "deprecated".
 
 ## Changes Compared to RFC5843
 
-The digest-algorithm values for "MD5", "SHA", "SHA-256", "SHA-512" have been updated to lowercase.
+The digest-algorithm tokens for "MD5", "SHA", "SHA-256", "SHA-512" have been updated to lowercase.
 
-The status of "MD5" and "SHA" has been updated to "deprecated", and their description states
-that they MUST NOT be used.
+The status of "MD5" and "SHA" has been updated to "deprecated", and their description
+has been modified accordingly.
 
 The "id-sha-256" and "id-sha-512" algorithms have been added to the registry.
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -418,6 +418,9 @@ All digest-algorithm token values are case-insensitive
 but lower case is preferred;
 digest-algorithm token values MUST be compared in a case-insensitive fashion.
 
+Every digest-algorithm defines its computation procedure and,
+unless specified otherwise, the comparison is case-sensitive.  
+
 The "HTTP Digest Algorithm Values Registry",
 maintained by IANA at <https://www.iana.org/assignments/http-dig-alg/> registers
 digest-algorithm values.

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1273,7 +1273,7 @@ and to inizialize the registry with the tokens
 defined in {{digest-algorithms}}.
 
 New registrations will be permitted
-through the RFC Required policy {{!BCP26}}.
+through the RFC Required policy (see Section 4.7 of {{!RFC8126}}).
 
 
 ## Obsolete "contentMD5" token in Digest Algorithm {#iana-contentMD5}


### PR DESCRIPTION
## This PR

- add registration policy cc: @seanturner and @mnot

## It's done

- according to https://www.rfc-editor.org/rfc/rfc8126.html#section-4.7

## Note

Using RFC policy avoids the issues we had to face to refresh the current table.

See #1533 