### PR TITLE
RFC 6265bis: Add domain attribute '.' prefix/suffix handling to storage model

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1443,7 +1443,10 @@ user agent MUST process the cookie as follows:
     1.  Let the domain-attribute be the attribute-value of the last
         attribute in the cookie-attribute-list with both an
         attribute-name of "Domain" and an attribute-value whose
-        length is no more than 1024 octets.
+        length is no more than 1024 octets. (Note that a leading %x2E
+        ("."), if present, is ignored even though that character is not
+        permitted, but a trailing %x2E ("."), if present, will cause
+        the user agent to ignore the attribute.)
 
     Otherwise:
 


### PR DESCRIPTION
The general storage model should be consistent with the Set-Cookie header parsing model.

The current behavior can be tested as follows:

1. `test1=set1; Domain=github.com` (Should Accept)
2. `test2=set2; Domain=.github.com` (Should Accept)
3. `test3=set3; Domain=github.com.` (Should Reject)

Per-browser results were:

- Chrome 94.0.4606.50 - Consistent
- Firefox: 93.0b6 - Consistent
- Safari: 15.0 (17612.1.28.5) - Didn't reject 3

Fixes #1583