### PR TITLE
Editorial tweak to the abstract

### DIFF
--- a/draft-ietf-httpbis-h3-websockets.md
+++ b/draft-ietf-httpbis-h3-websockets.md
@@ -27,8 +27,9 @@ informative:
 --- abstract
 
 The mechanism for running the WebSocket Protocol over a single stream
-of an HTTP/2 connection is equally applicable to HTTP/3, but needs to be
-separately registered.  This document describes the mechanism for HTTP/3.
+of an HTTP/2 connection is equally applicable to HTTP/3, but the HTTP
+version-specific details need to be specified. This document describes
+how the mechanism is adapted for HTTP/3.
 
 --- note_Note_to_Readers
 


### PR DESCRIPTION
Tweak the phrasing of the abstract to make it a bit more clear that the document is adapting the mechanism not defining a mechanism.

Fixes #1703