### PR TITLE
The server doesn't override priority

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -376,8 +376,8 @@ where to send registration requests.
 
 The Priority HTTP header field can appear in requests and responses. A client
 uses it to specify the priority of the response. A server uses it to inform
-the client that the priority was overwritten. An intermediary can use the
-Priority information from client requests and server responses to correct or
+the client that the priority that was applied. An intermediary can use
+priority information from client requests and server responses to correct or
 amend the precedence to suit it (see {{merging}}).
 
 The Priority header field is an end-to-end signal of the request priority from


### PR DESCRIPTION
The server only informs the client of what it did.  This also informs intermediaries, who might
factor that into how they operate.

I tweaked the next sentence here for grammar, though I think that sentence needs a little work too.