### PR TITLE
it is sufficient to state the urgency levels without justification

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -266,8 +266,7 @@ types MUST be ignored.
 ## Urgency
 
 The urgency parameter (`u`) takes an integer between 0 and 7, in descending
-order of priority. This range provides sufficient granularity for prioritizing
-responses for ordinary web browsing, at minimal complexity.
+order of priority.
 
 The value is encoded as an sf-integer. The default value is 3.
 


### PR DESCRIPTION
fixes #1718 by taking MT's suggestion.

This is the right thing to do editorially even if it might make @kixelated a little sad