### PR TITLE
refactor priority parameters and Priority header bits

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -376,7 +376,9 @@ The Priority HTTP header field carries priority parameters {{parameters}}. It
 can appear in requests and responses. It is an end-to-end signal of the request
 priority from the client or the response priority from the server. {{merging}}
 describes how intermediaries can combine the priority information from client
-requests and server responses to correct or amend the precedence.
+requests and server responses to correct or amend the precedence. Clients cannot
+interpret the appearance or omission of a Priority response header as
+acknowledgement that any prioritization has occurred.
 
 Priority is a Dictionary ({{Section 3.2 of STRUCTURED-FIELDS}}):
 


### PR DESCRIPTION
Fixes #1716 and closes #1720.

We define priority parameters as a structured fields dictionary. But
don't explicitly come out and say that the Priority header fields should
be treated that way. So this change fixes that.

The text in the Priority header section attempts to give a concise
overview of how it is used but that caused confusion. Since the text
just summarised information presented elsewhere, this change refactors
things to point to those sections.

While we are tweaking the priority header section, we can pull the text
about parsing failure handling up into the priority parameters section
so that there is a single place that gathers parsing considerations.

Finally, I noticed that our header registration was a bit old fashioned
in light of what's happening in HTTP core. So I updated that too.