### PR TITLE
Standardize maximum Expires/Max-Age

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1247,7 +1247,7 @@ user agent MUST process the cookie-av as follows.
 2.  If the remainder of attribute-value contains a non-DIGIT character, ignore
     the cookie-av.
 
-3.  Let delta-seconds be the attribute-value converted to an integer
+3.  Let delta-seconds be the attribute-value converted to an integer.
  
 4.  Let cookie-age-limit be the maximum age of the cookie (which must be 400 days
     or less, see {{attribute-max-age}}).


### PR DESCRIPTION
The current spec is ambiguous on (1) what the maximum `Expires`/`Max-Age` attribute values can be and (2) whether the two must be consistent. This resolves both by requiring:

1. The maximum attribute value to be 400 days in the future or less
2. The maximum set for Max-Age and Expires be consistent.

Why 400 days? The goal was to get close to 13 months so that functions one might perform annually (e.g., selecting insurance benefits for the next year) would work even as specific dates varied slightly. Since `Expires` deals in a specific date while `Max-Age` deals in delta-seconds, it seems ideal to select a value with an unambiguous meaning. If the cap were set at 13 months (instead of 400 days) in the future, the maximum TTL varies by the month it was set in and whether or not it's a leap year.

Who is compliant with this modification? Currently, only Safari sets a cap lower than 400 days (one week).

closes #1600