### PR TITLE
Split the HTTP Priority Parameters registry in two

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -381,12 +381,9 @@ Specification Required policy, as per {{Section 4.6 of !RFC8126}}.
 Expert Review policy, as per {{Section 4.5 of !RFC8126}}. A specification
 document is appreciated, but not required.
 
-When reviewing registration requests, the designated expert(s) should consider
-if the parameters are sufficiently well-defined and adhere to the guidance
-provided in {{new-parameters}}. The expert(s) should only reject registrations
-where it is clear that the interpretation of urgency ({{urgency}}) or
-incremental ({{incremental}}) parameters are changed in non-compatible or
-fallback-safe way that risks widespread interoperability.
+When reviewing registration requests, the designated expert(s) can consider the
+additional guidance provided in {{new-parameters}} but cannot use it as a basis
+for rejection.
 
 Registration requests should use the following template:
 


### PR DESCRIPTION
Fixes #1717.

We want registration policies that encourage extensions. We also need to bear in mind the existing guidance about how the base scheme, urgency and incremental, are used/applied by clients, servers and intermediaries. The scheme is malleable but it can't implementations are unlikely to be able to swap out prioritization wholesale.  This puts reviewers into an awkward position, so we should document clear guidance on registration review and how or when it might be rejected (airing on the side of permissiveness).

Fortunately, we had some of these considerations already written down. So this change makes those criteria more specific and actionable.

The other important part is that keys are strings, so clashes are less likely. However, given the constraints above and the attractiveness of short key lengths for repeated information, there might be pressure on the finite supply of the 25 remaining single-character keys. So split the IANA registry in two, and place additional Specification Required policy on those precious keys.
