### PR TITLE
Erroring on invalid Priority Field Values in frames is optional

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -439,9 +439,9 @@ initial priority of a response instead of the Priority header field.
 
 A PRIORITY_UPDATE frame communicates a complete set of all parameters in the
 Priority Field Value field. Omitting a parameter is a signal to use the
-parameter's default value. Failure to parse the Priority Field Value MUST be
+parameter's default value. Failure to parse the Priority Field Value MAY be
 treated as a connection error. In HTTP/2 the error is of type PROTOCOL_ERROR; in
-HTTP/3 the error is of type H3_FRAME_ERROR.
+HTTP/3 the error is of type H3_GENERAL_PROTOCOL_ERROR.
 
 A client MAY send a PRIORITY_UPDATE frame before the stream that it references
 is open (except for HTTP/2 push streams; see {{h2-update-frame}}). Furthermore,


### PR DESCRIPTION
Fixes #1741.

This lets servers be more permissive if they want to treat it like the Header but allows them to be strict if they want.

Since this is not an error in the frame itself, change the code to a general error; reason phrase is available if people feel it important to share.