### PR TITLE
Fix: #1687. Improve  description of want-digest and bad request.

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1309,7 +1309,7 @@ the request and return an error.
 In this example, the client requests a "sha" `Digest`, and the server returns an
 error with problem details {{?RFC7807}} contained in the content. The problem
 details contain a list of the digest algorithms that the server supports. This
-is purely an example, this specification does not specify any format or
+is purely an example, this specification does not define any format or
 requirements for such content.
 
 ~~~ http-message


### PR DESCRIPTION
## This PR

- improves the example description wrt #1687 
- fixes the response, since `Want-Digest` cannot be used to advertise the list of supported algorithms (like Accept) but only the list of the acceptable ones.
