### PR TITLE
Change emphesis of urgency prose

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -287,7 +287,7 @@ order of priority.
 
 The value is encoded as an sf-integer. The default value is 3.
 
-Clients can use this parameter to communicate their view of the precedence of
+Endpoints use this parameter to communicate their view of the precedence of
 HTTP responses. The chosen value of urgency can be based on the expectation that
 servers might use this information to transmit HTTP responses in the order of
 their urgency. The smaller the value, the higher the precedence.


### PR DESCRIPTION
Fixes #1766 .

By replacing "sender" with "client", we make the urgency and incremental section more consistent with how they discuss these concepts.