### PR TITLE
Keep XML files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,14 @@ draft-ietf-httpbis-origin-frame.xml
 draft-ietf-httpbis-rand-access-live.xml
 draft-ietf-httpbis-replay.xml
 draft-ietf-httpbis-rfc6265bis.xml
+draft-ietf-httpbis-bcp56bis.xml
+draft-ietf-httpbis-binary-message.xml
+draft-ietf-httpbis-cache-header.xml
+draft-ietf-httpbis-digest-headers.xml
+draft-ietf-httpbis-h3-websockets.xml
+draft-ietf-httpbis-message-signatures.xml
+draft-ietf-httpbis-priority.xml
+draft-ietf-httpbis-proxy-status.xml
+draft-ietf-httpbis-rfc7838bis.xml
+draft-ietf-httpbis-targeted-cache-control.xml
+draft-ietf-httpbis-variants.xml

--- a/.gitignore
+++ b/.gitignore
@@ -25,14 +25,5 @@ draft-ietf-httpbis-origin-frame.xml
 draft-ietf-httpbis-rand-access-live.xml
 draft-ietf-httpbis-replay.xml
 draft-ietf-httpbis-rfc6265bis.xml
-draft-ietf-httpbis-bcp56bis.xml
-draft-ietf-httpbis-binary-message.xml
-draft-ietf-httpbis-cache-header.xml
-draft-ietf-httpbis-digest-headers.xml
-draft-ietf-httpbis-h3-websockets.xml
-draft-ietf-httpbis-message-signatures.xml
-draft-ietf-httpbis-priority.xml
-draft-ietf-httpbis-proxy-status.xml
-draft-ietf-httpbis-rfc7838bis.xml
-draft-ietf-httpbis-targeted-cache-control.xml
-draft-ietf-httpbis-variants.xml
+draft-ietf-httpbis-*.xml
+!draft-ietf-httpbis-safe-method-w-body.xml

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ clean::
 lint:: http-lint
 
 rfc-http-validate ?= rfc-http-validate.py
+.SECONDARY: $(drafts_xml)
 .PHONY: http-lint
 http-lint: $(drafts_xml) http-lint-install
 	$(rfc-http-validate) -q -m sf.json $(filter-out http-lint-install,$^)


### PR DESCRIPTION
Generally, I don't think that it is a good idea to specify the use of `.SECONDARY` in makefiles as
it leaves a bunch of intermediate stuff in the repository.  It also means that you have to update
the .gitignore when you add new non-XML files.

In this case, however, the linting step in this repository ends up being very expensive and noisy as
it uses XML input.  Keeping the XML around manages that a little better.