### PR TITLE
HTTP/3 websocket should be standards track

### DIFF
--- a/draft-ietf-httpbis-h3-websockets.md
+++ b/draft-ietf-httpbis-h3-websockets.md
@@ -1,7 +1,7 @@
 ---
 title: "Bootstrapping WebSockets with HTTP/3"
 docname: draft-ietf-httpbis-h3-websockets-latest
-category: info
+category: std
 
 ipr: trust200902
 area: ART


### PR DESCRIPTION
I assume the current category is just an oversight