### PR TITLE
Add venue section to all drafts

### DIFF
--- a/draft-ietf-httpbis-bcp56bis.md
+++ b/draft-ietf-httpbis-bcp56bis.md
@@ -18,6 +18,13 @@ stand_alone: yes
 smart_quotes: no
 pi: [sortrefs]
 
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/bcp56bis
 github-issue-label: bcp56bis
 
 author:
@@ -68,14 +75,6 @@ Applications often use HTTP as a substrate to create HTTP-based APIs. This docum
 
 This document obsoletes {{?RFC3205}}.
 
-
---- note_Note_to_Readers_
-
-*RFC EDITOR: please remove this section before publication*
-
-Discussion of this draft takes place on the HTTP working group mailing list (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <http://httpwg.github.io/>; source code and issues list for this draft can be found at <https://github.com/httpwg/http-extensions/labels/bcp56bis>.
 
 --- middle
 

--- a/draft-ietf-httpbis-bcp56bis.md
+++ b/draft-ietf-httpbis-bcp56bis.md
@@ -21,7 +21,7 @@ pi: [sortrefs]
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/bcp56bis

--- a/draft-ietf-httpbis-binary-message.md
+++ b/draft-ietf-httpbis-binary-message.md
@@ -13,6 +13,13 @@ venue:
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/binary-messages
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/binary-messages
 github-issue-label: binary-messages
 
 stand_alone: yes

--- a/draft-ietf-httpbis-binary-message.md
+++ b/draft-ietf-httpbis-binary-message.md
@@ -16,7 +16,7 @@ venue:
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/binary-messages

--- a/draft-ietf-httpbis-cache-header.md
+++ b/draft-ietf-httpbis-cache-header.md
@@ -14,6 +14,13 @@ keyword:
 - debugging
 - x-cache
 
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/cache-header
 github-issue-label: cache-header
 
 stand_alone: yes
@@ -53,14 +60,6 @@ informative:
 
 To aid debugging, HTTP caches often append header fields to a response explaining how they handled the request in an ad hoc manner. This specification defines a standard mechanism to do so that is aligned with HTTP's caching model.
 
-
---- note_Note_to_Readers
-
-*RFC EDITOR: please remove this section before publication*
-
-Discussion of this draft takes place on the HTTP working group mailing list (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <https://httpwg.org/>; source code and issues list for this draft can be found at <https://github.com/httpwg/http-extensions/labels/cache-header>.
 
 --- middle
 

--- a/draft-ietf-httpbis-cache-header.md
+++ b/draft-ietf-httpbis-cache-header.md
@@ -17,7 +17,7 @@ keyword:
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/cache-header

--- a/draft-ietf-httpbis-client-cert-field.md
+++ b/draft-ietf-httpbis-client-cert-field.md
@@ -18,7 +18,7 @@ smart_quotes: no
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/client-cert-field

--- a/draft-ietf-httpbis-client-cert-field.md
+++ b/draft-ietf-httpbis-client-cert-field.md
@@ -15,6 +15,13 @@ keyword:
 stand_alone: yes
 smart_quotes: no
 
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/client-cert-field
 github-issue-label: client-cert-field
 
 author:
@@ -37,14 +44,6 @@ This document defines the HTTP header field `Client-Cert` that allows a TLS
 terminating reverse proxy to convey the client certificate of a
 mutually-authenticated TLS connection to the origin server in a common and
 predictable manner.
-
---- note_Note_to_Readers_
-
-*RFC EDITOR: please remove this section before publication*
-
-Discussion of this draft takes place on the HTTP working group mailing list (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <http://httpwg.github.io/>; source code and issues list for this draft can be found at <https://github.com/httpwg/http-extensions/labels/client-cert-field>.
 
 --- middle
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -16,7 +16,7 @@ pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline, docma
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/digest-headers

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -13,6 +13,13 @@ stand_alone: yes
 smart_quotes: no
 pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline, docmapping]
 
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/digest-headers
 github-issue-label: digest-headers
 
 author:
@@ -83,18 +90,6 @@ Want-Digest and Want-Content-Digest can be used to indicate a sender's desire to
 receive integrity fields respectively.
 
 This document obsoletes RFC 3230.
-
-
---- note_Note_to_Readers
-
-*RFC EDITOR: please remove this section before publication*
-
-Discussion of this draft takes place on the HTTP working group mailing list
-(ietf-http-wg@w3.org), which is archived at
-<https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-The source code and issues list for this draft can be found at
-<https://github.com/httpwg/http-extensions>.
 
 
 --- middle

--- a/draft-ietf-httpbis-expect-ct.md
+++ b/draft-ietf-httpbis-expect-ct.md
@@ -37,16 +37,6 @@ Transparency deployments. Further, web host operaters can use Expect-CT to
 ensure that, if a UA which supports Expect-CT accepts a misissued certificate,
 that certificate will be discoverable in Certificate Transparency logs.
 
---- note_Note_to_Readers
-
-Discussion of this draft takes place on the HTTP working group mailing list
-(ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <http://httpwg.github.io/>; source
-code and issues list for this draft can be found at
-<https://github.com/httpwg/http-extensions/labels/expect-ct>.
-
-
 --- middle
 
 # Introduction

--- a/draft-ietf-httpbis-h3-websockets.md
+++ b/draft-ietf-httpbis-h3-websockets.md
@@ -10,7 +10,7 @@ keyword: Internet-Draft
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/h3-websockets

--- a/draft-ietf-httpbis-h3-websockets.md
+++ b/draft-ietf-httpbis-h3-websockets.md
@@ -7,6 +7,13 @@ ipr: trust200902
 area: ART
 workgroup: HTTP
 keyword: Internet-Draft
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/h3-websockets
 github-issue-label: h3-websockets
 stand_alone: yes
 smart_quotes: no
@@ -30,14 +37,6 @@ The mechanism for running the WebSocket Protocol over a single stream
 of an HTTP/2 connection is equally applicable to HTTP/3, but the HTTP
 version-specific details need to be specified. This document describes
 how the mechanism is adapted for HTTP/3.
-
---- note_Note_to_Readers
-
-*RFC EDITOR: please remove this section before publication*
-
-Discussion of this draft takes place on the HTTP working group mailing list (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <https://httpwg.org/>; source code and issues list for this draft can be found at <https://github.com/httpwg/http-extensions/labels/h3-websockets>.
 
 --- middle
 

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -18,7 +18,7 @@ pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline, docma
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/signatures

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -15,6 +15,13 @@ stand_alone: yes
 smart_quotes: no
 pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline, docmapping]
 
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/signatures
 github-issue-label: signatures
 
 author:
@@ -79,14 +86,6 @@ informative:
 
 This document describes a mechanism for creating, encoding, and verifying digital signatures or message authentication codes over components of an HTTP message.  This mechanism supports use cases where the full HTTP message may not be known to the signer, and where the message may be transformed (e.g., by intermediaries) before reaching the verifier.
 This document also describes a means for requesting that a signature be applied to a subsequent HTTP message in an ongoing HTTP exchange.
-
---- note_Note_to_Readers
-
-*RFC EDITOR: please remove this section before publication*
-
-Discussion of this draft takes place on the HTTP working group mailing list (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <https://httpwg.org/>; source code and issues list for this draft can be found at <https://github.com/httpwg/http-extensions/labels/signatures>.
 
 --- middle
 
@@ -987,7 +986,7 @@ Use of this algorithm can be indicated at runtime using the `ecdsa-p256-sha256` 
 ### JSON Web Signature (JWS) algorithms {#method-jose}
 
 If the signing algorithm is a JOSE signing algorithm from the JSON Web Signature and Encryption Algorithms Registry established by {{RFC7518}}, the
-JWS algorithm definition determines the signature and hashing algorithms to apply for both signing and verification. 
+JWS algorithm definition determines the signature and hashing algorithms to apply for both signing and verification.
 
 For both signing and verification, the HTTP messages signature input string ({{create-sig-input}}) is used as the entire "JWS Signing Input".
 The JOSE Header defined in {{RFC7517}} is not used, and the signature input string is not first encoded in Base64 before applying the algorithm.
@@ -1384,7 +1383,7 @@ Additionally, if symmetric algorithms are allowed within a system, special care 
 
 ## Canonicalization Attacks {#security-canonicalization}
 
-Any ambiguity in the generation of the signature input string could provide an attacker with leverage to substitute or break a signature on a message. Some message component values, particularly HTTP field values, are potentially susceptible to broken implementations that could lead to unexpected and insecure behavior. Naive implementations of this specification might implement HTTP field processing by taking the single value of a field and using it as the direct component value without processing it appropriately. 
+Any ambiguity in the generation of the signature input string could provide an attacker with leverage to substitute or break a signature on a message. Some message component values, particularly HTTP field values, are potentially susceptible to broken implementations that could lead to unexpected and insecure behavior. Naive implementations of this specification might implement HTTP field processing by taking the single value of a field and using it as the direct component value without processing it appropriately.
 
 For example, if the handling of `obs-fold` field values does not remove the internal line folding and whitespace, additional newlines could be introduced into the signature input string by the signer, providing a potential place for an attacker to mount a [signature collision](#security-collision) attack. Alternatively, if header fields that appear multiple times are not joined into a single string value, as is required by this specification, similar attacks can be mounted as a signed component value would show up in the input string more than once and could be substituted or otherwise attacked in this way.
 
@@ -1396,7 +1395,7 @@ The existence of a valid signature on an HTTP message is not sufficient to prove
 
 ## HTTP Versions and Component Ambiguity {#security-versions}
 
-Some message components are expressed in different ways across HTTP versions. For example, the authority of the request target is sent using the `Host` header field in HTTP 1.1 but with the `:authority` pseudo-header in HTTP 2. If a signer sends an HTTP 1.1 message and signs the `Host` field, but the message is translated to HTTP 2 before it reaches the verifier, the signature will not validate as the `Host` header field could be dropped. 
+Some message components are expressed in different ways across HTTP versions. For example, the authority of the request target is sent using the `Host` header field in HTTP 1.1 but with the `:authority` pseudo-header in HTTP 2. If a signer sends an HTTP 1.1 message and signs the `Host` field, but the message is translated to HTTP 2 before it reaches the verifier, the signature will not validate as the `Host` header field could be dropped.
 
 It is for this reason that HTTP Message Signatures defines a set of specialty components that define a single way to get value in question, such as the `@authority` specialty component identifier ({{content-request-authority}}). Applications should therefore prefer specialty component identifiers for such options where possible.
 
@@ -1444,7 +1443,7 @@ It is important to balance the need for providing useful feedback to developers 
 
 ## Required Content {#privacy-required}
 
-A core design tenet of this specification is that all message components covered by the signature need to be available to the verifier in order to recreate the signature input string and verify the signature. As a consequence, if an application of this specification requires that a particular field be signed, the verifier will need access to the value of that field. 
+A core design tenet of this specification is that all message components covered by the signature need to be available to the verifier in order to recreate the signature input string and verify the signature. As a consequence, if an application of this specification requires that a particular field be signed, the verifier will need access to the value of that field.
 
 For example, in some complex systems with intermediary processors this could cause the surprising behavior of an intermediary not being able to remove privacy-sensitive information from a message before forwarding it on for processing, for fear of breaking the signature. A possible mitigation for this specific situation would be for the intermediary to verify the signature itself, then modifying the message to remove the privacy-sensitive information. The intermediary can ad its own signature at this point to signal to the next destination that the incoming signature was validated, as is shown in the example in {{signature-multiple}}.
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -13,6 +13,13 @@ stand_alone: yes
 smart_quotes: no
 pi: [toc, docindent, sortrefs, symrefs, strict, compact, comments, inline]
 
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/priorities
 github-issue-label: priorities
 
 author:
@@ -45,17 +52,6 @@ Priority header field for communicating the initial priority in an HTTP
 version-independent manner, as well as HTTP/2 and HTTP/3 frames for
 reprioritizing responses. These share a common format structure that is designed
 to provide future extensibility.
-
---- note_Note_to_Readers
-
-*RFC EDITOR: please remove this section before publication*
-
-Discussion of this draft takes place on the HTTP working group mailing list
-(ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <https://httpwg.org/>; source
-code and issues list for this draft can be found at
-<https://github.com/httpwg/http-extensions/labels/priorities>.
 
 --- middle
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -16,7 +16,7 @@ pi: [toc, docindent, sortrefs, symrefs, strict, compact, comments, inline]
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/priorities

--- a/draft-ietf-httpbis-proxy-status.md
+++ b/draft-ietf-httpbis-proxy-status.md
@@ -10,6 +10,13 @@ workgroup: HTTP
 keyword: Internet-Draft
 stand_alone: yes
 smart_quotes: no
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/proxy-status
 github-issue-label: proxy-status
 
 author:
@@ -42,14 +49,6 @@ informative:
 
 This document defines the Proxy-Status HTTP field to convey the details of intermediary response handling, including generated errors.
 
-
---- note_Note_to_Readers
-
-*RFC EDITOR: please remove this section before publication*
-
-Discussion of this draft takes place on the HTTP working group mailing list (ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <https://httpwg.org/>; source code and issues list for this draft can be found at <https://github.com/httpwg/http-extensions/labels/proxy-status>.
 
 --- middle
 

--- a/draft-ietf-httpbis-proxy-status.md
+++ b/draft-ietf-httpbis-proxy-status.md
@@ -13,7 +13,7 @@ smart_quotes: no
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/proxy-status

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -12,6 +12,13 @@ pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline]
 stand_alone: yes #_
 smart_quotes: no
 
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/6265bis
 github-issue-label: 6265bis
 
 author:
@@ -224,14 +231,6 @@ mostly stateless HTTP protocol. Although cookies have many historical
 infelicities that degrade their security and privacy, the Cookie and Set-Cookie
 header fields are widely used on the Internet. This document obsoletes RFC
 6265.
-
---- note_Note_to_Readers
-
-Discussion of this draft takes place on the HTTP working group mailing list
-(ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <http://httpwg.github.io/>; source
-code and issues list for this draft can be found at <https://github.com/httpwg/http-extensions/labels/6265bis>.
 
 --- middle
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -15,7 +15,7 @@ smart_quotes: no
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/6265bis

--- a/draft-ietf-httpbis-rfc7838bis.md
+++ b/draft-ietf-httpbis-rfc7838bis.md
@@ -11,7 +11,7 @@ keyword: Internet-Draft
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/alt-svc

--- a/draft-ietf-httpbis-rfc7838bis.md
+++ b/draft-ietf-httpbis-rfc7838bis.md
@@ -8,6 +8,13 @@ ipr: trust200902
 area: General
 workgroup: HTTP Working Group
 keyword: Internet-Draft
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/alt-svc
 github-issue-label: alt-svc
 
 stand_alone: yes
@@ -57,19 +64,6 @@ This document specifies "Alternative Services" for HTTP, which allow
 an origin's resources to be authoritatively available at a separate
 network location, possibly accessed with a different protocol
 configuration.
-
---- note_Note_to_Readers
-
-*RFC EDITOR: please remove this section before publication*
-
-Discussion of this draft takes place on the HTTP working group mailing list
-(ietf-http-wg@w3.org), which is archived at
-<https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <https://httpwg.org/>; source code and
-issues list for this draft can be found at
-<https://github.com/httpwg/http-extensions/labels/alt-svc>.
-
 
 --- middle
 

--- a/draft-ietf-httpbis-targeted-cache-control.md
+++ b/draft-ietf-httpbis-targeted-cache-control.md
@@ -14,6 +14,13 @@ keyword:
 
 stand_alone: yes
 pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline]
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/targeted-cc
 github-issue-label: targeted-cc
 
 author:
@@ -64,17 +71,6 @@ informative:
 --- abstract
 
 This specification defines a convention for HTTP response header fields that allow cache directives to be targeted at specific caches or classes of caches. It also defines one such header field, targeted at Content Delivery Network (CDN) caches.
-
---- note_Note_to_Readers
-
-*RFC EDITOR: please remove this section before publication*
-
-The issues list for this draft can be found at <https://github.com/httpwg/http-extensions/labels/targeted-cc>.
-
-The most recent (often, unpublished) draft is at <https://httpwg.org/http-extensions/draft-ietf-httpbis-targeted-cache-control.html>.
-
-See also the draft's current status in the IETF datatracker, at
-<https://datatracker.ietf.org/doc/draft-ietf-httpbis-targeted-cache-control/>.
 
 --- middle
 

--- a/draft-ietf-httpbis-targeted-cache-control.md
+++ b/draft-ietf-httpbis-targeted-cache-control.md
@@ -17,7 +17,7 @@ pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline]
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/targeted-cc

--- a/draft-ietf-httpbis-variants.md
+++ b/draft-ietf-httpbis-variants.md
@@ -16,6 +16,13 @@ keyword: content negotiation
 stand_alone: yes
 smart_quotes: no
 pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline]
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.github.io/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/variants
 github-issue-label: variants
 
 author:
@@ -38,18 +45,6 @@ informative:
 --- abstract
 
 This specification introduces an alternative way to select a HTTP response from a cache based upon its request headers, using the HTTP "Variants" and "Variant-Key" response header fields. Its aim is to make HTTP proactive content negotiation more cache-friendly.
-
---- note_Note_to_Readers
-
-*RFC EDITOR: please remove this section before publication*
-
-Discussion of this draft takes place on the HTTP working group mailing list
-(ietf-http-wg@w3.org), which is archived at <https://lists.w3.org/Archives/Public/ietf-http-wg/>.
-
-Working Group information can be found at <https://httpwg.github.io/>; source code and issues list
-for this draft can be found at <https://github.com/httpwg/http-extensions/labels/variants>.
-
-There is a prototype implementation of the algorithms herein at <https://github.com/mnot/variants-toy>.
 
 --- middle
 
@@ -523,6 +518,11 @@ To be usable with Variants, proactive content negotiation mechanisms need to be 
 
 {{backports}} fulfils these requirements for some existing proactive content negotiation mechanisms in HTTP.
 
+
+# Implementations
+{: removeInRFC="true"}
+
+There is a prototype implementation of the algorithms in this document at [](https://github.com/mnot/variants-toy).
 
 # IANA Considerations
 

--- a/draft-ietf-httpbis-variants.md
+++ b/draft-ietf-httpbis-variants.md
@@ -19,7 +19,7 @@ pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline]
 venue:
   group: HTTP
   type: Working Group
-  home: https://httpwg.github.io/
+  home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/variants


### PR DESCRIPTION
This removes some of the customization, but I think we're good.

The only one that is special is the variants draft, which had information about implementation.
I've moved that to a section in the document.

Fixup script that I used:

```py

import fileinput, re

label = re.compile('^github-issue-label: (\S+)')
note = re.compile('^--- note_')
middle = re.compile('^--- middle')

is_note = False

for line in fileinput.input():
    m = label.match(line)
    if m:
        print(f"""venue:
  group: HTTP
  type: Working Group
  home: https://httpwg.github.io/
  mail: ietf-http-wg@w3.org
  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
  repo: https://github.com/httpwg/http-extensions/labels/{m[1]}""")
    elif note.match(line):
        is_note = True
    elif middle.match(line):
        is_note = False
    if not is_note:
        print(line.rstrip())
```