### PR TITLE
Fix digest in method-rsa-pss-sha512 definition

### DIFF
--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -1199,7 +1199,7 @@ Status:
 : Active
 
 Definition:
-: RSASSA-PSS using SHA-256
+: RSASSA-PSS using SHA-512
 
 Specification document(s):
 : \[\[This document\]\], {{method-rsa-pss-sha512}}


### PR DESCRIPTION
It looks like SHA-512 was intended here, as that is what the description and name use.
Maybe someone had in mind to add an additional rsa-pss-sha256 method.