### PR TITLE
Expand on applicability of this scheme for clarity

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -250,7 +250,7 @@ behind the server that the client is directly connected to.
 
 The priority scheme defined by this document is primarily focused on the
 prioritization of HTTP response messages (see {{Section 3.4 of HTTP}}). It
-defines new priority parameters ({{parameters}}) and signals ({{header-field}}
+defines new priority parameters ({{parameters}}) and their conveyors ({{header-field}}
 and {{frame}}) intended to communicate the priority of responses to a server
 that is responsible for prioritizing them. {{server-scheduling}} provides
 considerations for servers about acting on those signals in combination with
@@ -263,9 +263,9 @@ server prioritization are given in {{connect-scheduling}}.
 {{client-scheduling}} describes how clients can optionally apply elements of
 this scheme locally to the request messages that they generate.
 
-Some forms of HTTP extensions change HTTP/2 or HTTP/3 stream behavior or
-define new data carriage mechanisms. Such extensions are not considered by this
-document; they can define themselves how this priority scheme might be applied.
+Some forms of HTTP extensions might change HTTP/2 or HTTP/3 stream behavior or
+define new data carriage mechanisms. Such extensions can define themselves how
+this priority scheme is to be applied.
 
 
 # Priority Parameters {#parameters}

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -248,12 +248,24 @@ behind the server that the client is directly connected to.
 
 # Applicability of the Extensible Priority Scheme
 
-The priority scheme defined by this document considers only the prioritization
-of HTTP messages and tunnels, see {{client-scheduling}}, {{server-scheduling}},
-and {{connect-scheduling}}.
+The priority scheme defined by this document is primarily focused on the
+prioritization of HTTP response messages (see {{Section 3.4 of HTTP}}). It
+defines new priority parameters ({{parameters}}) and signals ({{header-field}}
+and {{frame}}) intended to communicate the priority of responses to a server
+that is responsible for prioritizing them. {{server-scheduling}} provides
+considerations for servers about acting on those signals in combination with
+other inputs and factors.
 
-Where HTTP extensions change stream behavior or define new data carriage
-mechanisms, they can also define how this priority scheme can be applied.
+The CONNECT method (see {{Section 9.3.6 of HTTP}}) can be used to establish
+tunnels. Signaling applies similarly to tunnels; additional considerations for
+server prioritization are given in {{connect-scheduling}}.
+
+{{client-scheduling}} describes how clients can optionally apply elements of
+this scheme locally to the request messages that they generate.
+
+Some forms of HTTP extensions change HTTP/2 or HTTP/3 stream behavior or
+define new data carriage mechanisms. Such extensions are not considered by this
+document; they can define themselves how this priority scheme might be applied.
 
 
 # Priority Parameters {#parameters}


### PR DESCRIPTION
Addressed E#3a﻿ of #1802

Reference the HTTP terms we are using. Be clearer that we focus on "normal" responses and that there are other possible uses. But avoid making the entire document a piece of abstract art.
