### PR TITLE
Tweak the server scheduling text to clarify what is covered

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -678,11 +678,12 @@ a particular order using priority. Expressing priority is therefore only a
 suggestion.
 
 A server can use priority signals along with other inputs to make scheduling
-decisions. No guidance is provided about how this can or should be done. Factors
-such as implementation choices or deployment environment also play a role. Any
-given connection is likely to have many dynamic permutations. For these reasons,
-there is no unilateral perfect scheduler and this document only provides some
-basic recommendations for implementations.
+decisions. Factors such as implementation choices or deployment environment also
+play a role. Any given connection is likely to have many dynamic permutations.
+For these reasons, there is no unilateral perfect scheduler. This document
+provides some basic, non-exhaustive, recommendations for how servers might act
+on priority parameters. It does not describe in detail how servers might combine
+priority signals with other factors.
 
 Clients cannot depend on particular treatment based on priority signals. Servers
 can use other information to prioritize responses.


### PR DESCRIPTION
Addresses E#10a of #1802

Bob comments that the "no guidance is provided" s﻿ounds like it is in conflict with the rest of the section that includes some normative recommendations. The intent of this text was to highlight there is no (or at least very little) about how servers are supposed to combine priority parameters with the million other things that they have to worry about. 

This change shuffles the sentences around to try and make the original intent clearer.
