### PR TITLE
stop short of saying one-by-one, entirety

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -696,9 +696,8 @@ incremental parameter ({{incremental}}).
 
 Non-incremental responses of the same urgency SHOULD be served by prioritizing
 bandwidth allocation in ascending order of the stream ID, which corresponds to
-the order in which clients make requests.
-requests. Doing so ensures that clients can use request ordering to influence
-response order.
+the order in which clients make requests. Doing so ensures that clients can use
+request ordering to influence response order.
 
 Incremental responses of the same urgency SHOULD be served by sharing bandwidth
 amongst them. Incremental resources are used as parts, or chunks, of the

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -692,10 +692,11 @@ It is RECOMMENDED that, when possible, servers respect the urgency parameter
 
 The incremental parameter indicates how a client processes response bytes as
 they arrive. It is RECOMMENDED that, when possible, servers respect the
-incremental parameter ({{incremental}}). Non-incremental resources can only be
-used when all of the response payload has been received. Therefore,
-non-incremental responses of the same urgency SHOULD be served in the ascending
-order of the stream ID, which corresponds to the order in which clients make
+incremental parameter ({{incremental}}).
+
+Non-incremental responses of the same urgency SHOULD be served by prioritizing
+bandwidth allocation in ascending order of the stream ID, which corresponds to
+the order in which clients make requests.
 requests. Doing so ensures that clients can use request ordering to influence
 response order.
 

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -692,10 +692,10 @@ It is RECOMMENDED that, when possible, servers respect the urgency parameter
 
 The incremental parameter indicates how a client processes response bytes as
 they arrive. It is RECOMMENDED that, when possible, servers respect the
-incremental parameter ({{incremental}}). Non-incremental resources can only be used
-when all of the response payload has been received. Therefore, non-incremental
-responses of the same urgency SHOULD be served in their entirety, one-by-one,
-based on the stream ID, which corresponds to the order in which clients make
+incremental parameter ({{incremental}}). Non-incremental resources can only be
+used when all of the response payload has been received. Therefore,
+non-incremental responses of the same urgency SHOULD be served in the ascending
+order of the stream ID, which corresponds to the order in which clients make
 requests. Doing so ensures that clients can use request ordering to influence
 response order.
 


### PR DESCRIPTION
As discussed in https://github.com/httpwg/http-extensions/issues/1794#issuecomment-986423620, to avoid confusion, we can stop short of using phrases like "one-by-one" or "entirety," simply stating that non-incremental responses should be served in the order of the stream ID.

Addresses the original point of #1794.