### PR TITLE
Problems with HTTP/2 are not our security consideration

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -35,13 +35,6 @@ author:
     email: lucaspardue.24.7@gmail.com
 
 informative:
-  CVE-2019-9513:
-    title: CVE-2019-9513
-    author:
-      org: Common Vulnerabilities and Exposures
-    date: 2019-03-01
-    target: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513
-
   MARX:
     target: https://www.doi.org/10.5220/0008191701300143
     title: "Of the Utmost Importance: Resource Prioritization in HTTP/3 over QUIC"
@@ -886,12 +879,6 @@ It should also be noted that the use of a header field carrying a textual value
 makes the prioritization scheme extensible; see the discussion below.
 
 # Security Considerations
-
-{{?RFC7540}} stream prioritization relies on dependencies. Considerations are
-presented to implementations, describing how limiting state or work commitments
-can avoid some types of problems. In addition, [CVE-2019-9513] aka "Resource
-Loop", is an example of a DoS attack that abuses stream dependencies. Extensible
-priorities does not use dependencies, which avoids these issues.
 
 {{frame}} describes considerations for server buffering of PRIORITY_UPDATE
 frames.


### PR DESCRIPTION
In Bob's TSVART review, he notes in T#2b that the mention the H2 DoS attack in Security seems useful and we should probably expand on it.

The mentions of H2 have been whittled down as 7540bis progresses and the reference to CVE-2019-9513 in the security section now seems misplaced. It's cleaner to just remove it so that the section focuses on considerations for using this document.

P.S I think this means that MT was right ;)
