### PR TITLE
Remove redundant text (amends #1803)

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -683,23 +683,15 @@ bandwidth. This section describes considerations regarding how servers can
 schedule the order in which the competing responses will be sent, when such
 competition exists.
 
-Server scheduling is a prioritization process based on many inputs and factors,
-with priority signals being only one form of input. Priority signals do
-not guarantee any particular processing or transmission order for one response
-relative to any other response. An endpoint cannot force a peer to process
-concurrent request in a particular order using priority. Expressing priority is
-therefore only a suggestion.
-
-A server can use priority signals along with other inputs to make scheduling
-decisions. Factors such as implementation choices or deployment environment also
-play a role. Any given connection is likely to have many dynamic permutations.
-For these reasons, there is no unilateral perfect scheduler. This document
-provides some basic, non-exhaustive, recommendations for how servers might act
-on priority parameters. It does not describe in detail how servers might combine
-priority signals with other factors.
-
-Clients cannot depend on particular treatment based on priority signals. Servers
-can use other information to prioritize responses.
+Server scheduling is a prioritization process based on many inputs, with
+priority signals being only one form of input. Factors such as implementation
+choices or deployment environment also play a role. Any given connection is
+likely to have many dynamic permutations. For these reasons, there is no
+unilateral perfect scheduler. This document provides some basic, non-exhaustive,
+recommendations for how servers might act on priority parameters. It does not
+describe in detail how servers might combine priority signals with other
+factors. Endpoints cannot depend on particular treatment based on priority
+signals. Expressing priority is only a suggestion.
 
 It is RECOMMENDED that, when possible, servers respect the urgency parameter
 ({{urgency}}), sending higher urgency responses before lower urgency responses.


### PR DESCRIPTION
This PR proposes changes to #1803, removing redundant text.