### PR TITLE
H2 PRIORITY_UPDATE type field is 8 bits

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -509,7 +509,7 @@ type PROTOCOL_ERROR.
 ~~~ drawing
 HTTP/2 PRIORITY_UPDATE Frame {
   Length (24),
-  Type (i) = 10,
+  Type (8) = 0x10,
 
   Unused Flags (8).
 


### PR DESCRIPTION
During IESG review, Éric Vyncke noted that the prose for the HTTP/2 PRIORITY_UPDATE frame used a type value written as `0x10` while the diagram used `10`. That inconsistency stems from 7540bis and I opened https://github.com/httpwg/http2-spec/pull/1002/files to fix that there.

While looking again at our type definition, we incorrectly stated `Type(i) = 10`. By convention, that suggest the type is a QUIC variable length integer. But that was never the intention. HTTP/2 frame type is part of the HTTP/2 frame header, which is an 8-bit field. In this draft, we are not changing the definition of HTTP/2 frame headers. Therefore the diagram is currently wrong. 

This change is editorial to address the above two issues.