### PR TITLE
Mark normative statements

### DIFF
--- a/draft-ietf-httpbis-binary-message.md
+++ b/draft-ietf-httpbis-binary-message.md
@@ -82,7 +82,7 @@ Two modes for encoding are described:
 
 # Conventions and Definitions
 
-{::boilerplate bcp14}
+{::boilerplate bcp14-tagged}
 
 This document uses terminology from HTTP ({{HTTP}}) and notation from QUIC
 ({{Section 1.3 of QUIC}}).

--- a/draft-ietf-httpbis-client-cert-field.md
+++ b/draft-ietf-httpbis-client-cert-field.md
@@ -99,10 +99,7 @@ connection to the TTRP.
 
 ## Requirements Notation and Conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+{::boilerplate bcp14-tagged}
 
 ## Terminology
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -201,7 +201,7 @@ The algorithm table has been updated to reflect the current state of the art,
 
 
 ## Notational Conventions
-{::boilerplate bcp14}
+{::boilerplate bcp14-tagged}
 
 This document uses the Augmented BNF defined in [RFC5234] and updated by
 [RFC7405] along with the "#rule" extension defined in {{Section 5.6.1 of

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -141,7 +141,7 @@ Additionally, all changes to components not covered by the signature are conside
 
 ## Conventions and Terminology {#definitions}
 
-{::boilerplate bcp14}
+{::boilerplate bcp14-tagged}
 
 The terms "HTTP message", "HTTP request", "HTTP response",
 `absolute-form`, `absolute-path`, "effective request URI",


### PR DESCRIPTION
This changes the boilerplate import of bcp14 to bcp14-tagged, which now automatically scans for and marks uppercase normative words like MUST and MAY in semantically-appropriate tags.﻿
