### PR TITLE
Cite only Marx paper

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -183,7 +183,7 @@ applications that generate requests without knowledge of how other requests
 might share a connection, or into protocols that do not have strong ordering
 guarantees across streams, like HTTP/3 {{HTTP3}}.
 
-Multiple experiments from independent research ({{MARX}}, {{MEENAN}}) have shown
+Experiments from independent research ({{MARX}}) have shown
 that simpler schemes can reach at least equivalent performance characteristics
 compared to the more complex RFC 7540 setups seen in practice, at least for the
 web use case.


### PR DESCRIPTION
I was noted that the citation to Pat Meenan's blog post lacked scientific experimental data and a decent permalink. Since we already acknowledge Pat's original scheme proposal in the acknowledgements, lets just remove this one. 

To avoid anyone picking up on a lack of multiple citations to match the multiple experiments statement, lets drop that qualifier too.