### PR TITLE
be clearer regarding what is preserved

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -276,10 +276,10 @@ parameters on a single hop only.
 
 Intermediaries can consume and produce priority signals in a PRIORITY_UPDATE
 frame or Priority header field. Sending a PRIORITY_UPDATE frame preserves the
-signal from the client, but provides a signal that overrides that for the next
-hop; see {{header-field-rationale}}. Replacing or adding a Priority header field
-overrides any signal from a client and can affect prioritization for all
-subsequent recipients.
+signal from the client carried by the Priority header field, but provides a
+signal that overrides that for the next hop; see {{header-field-rationale}}.
+Replacing or adding a Priority header field overrides any signal from a client
+and can affect prioritization for all subsequent recipients.
 
 For both the Priority header field and the PRIORITY_UPDATE frame, the set of
 priority parameters is encoded as a Structured Fields Dictionary (see


### PR DESCRIPTION
Addresses the following comment from [Benjamin Kaduk's review](https://lists.w3.org/Archives/Public/ietf-http-wg/2021OctDec/0225.html):
```
Section 4

   Intermediaries can consume and produce priority signals in a
   PRIORITY_UPDATE frame or Priority header field.  Sending a
   PRIORITY_UPDATE frame preserves the signal from the client, but
   provides a signal that overrides that for the next hop; see
   Section 14.  [...]

I'm having a bit of trouble following "provides a signal that overrides
that for the next hop"; is the "that" in "overrides that" referring to
"the signal from the client"?  Is the "signal that overrides" referring
to the PRIORITY_UPDATE frame emitted by the intermediary in question?
That seems to set us up for a scenario where the same frame is both
preserving and overriding the signal from the client, which doesn't make
much sense.  Is it perhaps that "when used by downstream intermediaries,
this mechanism would override the signal from the client, even though
the current intermediary under discussion has preserved the signal from
the client"?
```