### PR TITLE
Remove "which" from a clause where it did not belong

### DIFF
--- a/draft-ietf-httpbis-h3-websockets.md
+++ b/draft-ietf-httpbis-h3-websockets.md
@@ -72,7 +72,7 @@ in HTTP/2 as defined {{!RFC8441}}. {{Appendix A.3 of HTTP3}} requires that
 HTTP/3 settings be registered separately for HTTP/3. The
 SETTINGS_ENABLE_CONNECT_PROTOCOL value is 0x08 (decimal 8), as in HTTP/2.
 
-If a server which advertises support for Extended CONNECT but receives an
+If a server advertises support for Extended CONNECT but receives an
 Extended CONNECT request with a ":protocol" value that is unknown or is
 not supported, the server SHOULD respond to the request with a 501 (Not
 Implemented) status code ({{Section 15.6.2 of HTTP}}). A server MAY


### PR DESCRIPTION
Remove "which" from a clause where it did not belong, as per feedback from Vijay Gurbani