### PR TITLE
Digest option 2.5

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -371,8 +371,9 @@ List (see {{Section 3.2 of STRUCTURED-FIELDS}}):
 
 Dictionary members convey hashing algorithm preferences (see {{algorithms}}).
 Member-keys convey the hashing algorithm (see {{algorithms}}), member-values convey
-an ascending relative weighted preference between 0 and 10. Member-values MUST
-be of type sf-integer, in the range 0 to 10.
+an ascending relative weighted preference between 0 and 10. 1 is the least
+preferred, 10 is the most preferred; a value of 0 means "not acceptable".
+Member-values MUST be of type sf-integer, in the range 0 to 10.
 
 Examples:
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -122,8 +122,9 @@ This document obsoletes [RFC3230].
 
 This document is structured as follows:
 
-- {{digest}} describes concepts related to representation digests. It also
-  defines the Digest request and response header and trailer field,
+- {{representation-digest}} describes concepts related to representation
+  digests,
+- {{digest}} defines the Digest request and response header and trailer field,
 - {{content-digest}} defines the Content-Digest request and response header and trailer field,
 - {{want-fields}} defines the Want-Digest and Want-Content-Digest request and response header and
   trailer field,
@@ -148,12 +149,9 @@ To support use-cases where a simple checksum of the content bytes is required,
 this document introduces the `Content-Digest` request and response header and trailer field; see
 {{content-digest}}.
 
-`Digest` and `Content-Digest` contain checksums that are calculated using one of
-the digest-algorithms listed in the HTTP Digest Algorithm Values Registry (see
-{{algorithms}}), which are encoded in the format associated with each encoding.
-Algorithm agility is supported. The `Want-Digest` and `Want-Content-Digest`
-fields allows endpoints to express interest in `Digest` and `Content-Digest`
-respectively, and preference of algorithms in either.
+`Digest` and `Content-Digest` support algorithm agility. The `Want-Digest` and
+`Want-Content-Digest` fields allows endpoints to express interest in `Digest` and
+`Content-Digest` respectively, and preference of algorithms in either.
 
 Digest field calculations are tied to the `Content-Encoding`
 and `Content-Type` header fields. Therefore, a given resource may have multiple
@@ -219,28 +217,48 @@ The term "checksum" describes the output of the application of an algorithm
 to a sequence of bytes,
 whereas digest is only used in relation to the value of the fields.
 
+# Representation Digest {#representation-digest}
+
+The representation digest is an integrity mechanism for HTTP resources
+which uses a checksum  that is calculated independently of the content
+(see {{Section 6.4 of SEMANTICS}}).
+It uses the representation data (see {{Section 8.1 of SEMANTICS}}),
+that can be fully or partially contained in the content, or not contained at all.
+
+This takes into account the effect of the HTTP semantics on the messages;
+for example, the content can be affected by Range Requests or methods such as HEAD,
+while the way the content is transferred "on the wire" is dependent on other
+transformations (e.g. transfer codings for HTTP/1.1 - see {{Section 6.1 of
+HTTP11}}). To help illustrate how such things affect `Digest`,
+several examples are provided in {{resource-representation}}.
+
+A representation digest consists of
+the value of a checksum computed on the entire selected `representation data`
+(see {{Section 8.1 of SEMANTICS}}) of a resource identified according to {{Section 6.4.2 of SEMANTICS}}
+together with an indication of the algorithm used:
+
+~~~ abnf
+   representation-data-digest = digest-algorithm "="
+                                <encoded checksum output>
+~~~
+
+When a message has no representation data
+it is still possible to assert that no representation data was sent
+computing the representation digest on an empty string
+(see {{usage-in-signatures}}).
+
+The checksum is computed using one of the digest-algorithms listed in
+the HTTP Digest Algorithm Values Registry (see {{algorithms}})
+and then encoded in the associated format.
+
 # The Digest Field {#digest}
 
-The `Digest` field contains a comma-separated list of one or more representation
-digest values. It can be used in both requests and responses.
-
-A representation digest is an integrity mechanism for HTTP resources that uses a
-checksum  calculated independently of the content (see {{Section 6.4 of
-SEMANTICS}}).
-A representation digest consists of the value of a checksum computed on
-the entire selected `representation data` (see {{Section 8.1 of SEMANTICS}})
-of a resource identified according to {{Section 6.4.2 of SEMANTICS}},
-together with an indication of the algorithm used.
-Note that representation data can be fully or partially contained in the content,
-or not contained at all.
-When a message has no representation data it is possible to
-assert that no representation data was sent by using the representation digest
-on an empty string (see {{usage-in-signatures}}).
+The `Digest` field contains a comma-separated list of one or more representation digest values as
+defined in {{representation-digest}}. It can be used in both requests and
+responses.
 
 ~~~ abnf
    Digest = 1#representation-data-digest
-   representation-data-digest = digest-algorithm "="
-                                <encoded checksum output>
 ~~~
 
 For example:
@@ -249,13 +267,6 @@ For example:
 Digest: sha-512=WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
                 AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==
 ~~~
-
-Basing `Digest` on representation data takes into account the effect of HTTP
-semantics on messages; for example, the content can be affected by Range
-Requests or methods such as HEAD, while the way the content is transferred "on
-the wire" is dependent on other transformations (e.g. transfer codings for
-HTTP/1.1 - see {{Section 6.1 of HTTP11}}). To help illustrate how such things
-affect `Digest`, several examples are provided in {{resource-representation}}.
 
 A `Digest` field MAY contain multiple representation-data-digest values.
 For example, a server may provide representation-data-digest values using different algorithms,
@@ -496,7 +507,7 @@ does not describe the target resource,
 the representation digest MUST be computed on the
 representation-data.
 This is the only possible choice because representation digest requires complete
-representation metadata (see {{digest}}).
+representation metadata (see {{representation-digest}}).
 
 In responses,
 
@@ -1178,7 +1189,7 @@ Digest: sha-256=KPqhVXAT25LLitV1w0O167unHmVQusu+fpxm65zAsvk=
 An origin server sends `Digest` as trailer field, so it can calculate digest-value
 while streaming content and thus mitigate resource consumption.
 The `Digest` field-value is the same as in {{example-full-representation}} because `Digest` is designed to
-be independent from the use of one or more transfer codings (see {{digest}}).
+be independent from the use of one or more transfer codings (see {{representation-digest}}).
 
 ~~~ http-message
 GET /items/123 HTTP/1.1

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -414,7 +414,7 @@ The entries in {{iana-hash-algorithm-table}} are registered by this document.
 | unixsum        | insecure | The algorithm used by the UNIX "sum" command. | [RFC4648], [RFC6234], [UNIX], this document. |
 | unixcksum      | insecure | The algorithm used by the UNIX "cksum" command. | [RFC4648], [RFC6234], [UNIX], this document. |
 | adler          | insecure | The ADLER32 algorithm.                          | [RFC1950], this document. |
-| crc32          | insecure | The CRC32c algorithm.                           | {{!RFC4960}} appendix B, this document. |
+| crc32c         | insecure | The CRC32c algorithm.                           | {{!RFC4960}} appendix B, this document. |
 | -------------- | -------- | ----------------------------------- | -------------- |
 {: #iana-hash-algorithm-table title="Initial Hash Algorithms"}
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -85,9 +85,10 @@ This document defines HTTP fields that support integrity checksums. The
 Representation-Digest field can be used for the integrity of HTTP
 representations. The Content-Digest field can be used for the integrity of
 HTTP message content. Want-Representation-Digest and Want-Content-Digest can be
-used to indicate a sender's interest and preferences for receiving respective integrity fields.
+used to indicate a sender's interest and preferences for receiving the respective
+integrity fields.
 
-This document obsoletes RFC 3230 and therefore the Digest and Wants-Digest HTTP
+This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP
 fields.
 
 
@@ -112,7 +113,7 @@ First, content integrity, which acts on conveyed content ({{Section 6.4 of
 SEMANTICS}}).
 Second, representation data integrity, which acts on representation data ({{Section 3.2
 of SEMANTICS}}). This supports more advanced use cases such as validating the
-integrity of a resource the was reconstructed from parts retrieved using
+integrity of a resource that was reconstructed from parts retrieved using
 multiple requests or connections.
 
 This document obsoletes RFC 3230 and therefore the Digest and Want-Digest HTTP
@@ -264,7 +265,7 @@ Representation-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
 Since `Representation-Digest` is a Dictionary, it can contain multiple
 members. This could be used, for example, to attach multiple checksums
 calculated using different hashing algorithms in order to support a population
-of endpoints with different evolving capabilities. Such an approach could
+of endpoints with different or evolving capabilities. Such an approach could
 support transitions away from weaker algorithms (see {{algorithm-agility}}).
 
 ~~~ http-message
@@ -310,7 +311,7 @@ Content-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
 Since `Content-Digest` is a Dictionary, it can contain multiple
 members. This could be used, for example, to attach multiple checksums
 calculated using different hashing algorithms in order to support a population
-of endpoints with different evolving capabilities. Such an approach could
+of endpoints with different or evolving capabilities. Such an approach could
 support transitions away from weaker algorithms (see {{algorithm-agility}}).
 
 ~~~ http-message

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -78,6 +78,8 @@ informative:
   RFC2818:
   HTTP11: I-D.ietf-httpbis-messaging
   PATCH: RFC5789
+  NO-MD5: RFC6151
+  NO-SHA: RFC6194
 
 --- abstract
 
@@ -370,16 +372,18 @@ Want-Content-Digest: sha-512=3, sha-256=10, unixsum=0
 ~~~
 
 
-# Structured Digest Algorithm Registry {#algorithms}
+# Hash Algorithms for HTTP Digest Fields Registry {#algorithms}
 
-The "HTTP Structured Digest Algorithm Registry", maintained by IANA at
-<https://www.iana.org/assignments/http-dig-alg/> registers algorithms for use
-with a range of HTTP fields.
+The "Hash Algorithms for HTTP Digest Fields", maintained by IANA at
+<https://www.iana.org/assignments/http-dig-alg/>, registers algorithms for use
+with the Representation-Digest, Content-Digest, Want-Representation-Digest, and
+Want-Content-Digest fields defined in this document.
+
+This registry uses the Specification
+Required policy ({{Section 4.6 of !RFC8126}}).
 
 Registrations MUST include the following fields:
 
- - Algorithm: a friendly name of the algorithm
- - Description: a short description of the algorithm
  - Algorithm Key: the Structured Fields key value used in
    `Representation-Digest`, `Content-Digest`, `Want-Representation-Digest` or
     `Want-Content-Digest` field Dictionary member keys
@@ -390,75 +394,29 @@ Registrations MUST include the following fields:
      in which the algorithm is defined;
      "insecure" when the algorithm is insecure;
      "reserved" when the algorithm references a reserved token value
- - Reference: a set of pointers to the primary documents defining the algorithm
-   and key
+ - Description: a short description of the algorithm
+ - Reference(s): a set of pointers to the primary documents defining the
+   algorithm and key
 
 Insecure digest algorithms MAY be used to preserve integrity against corruption, but MUST
 NOT be used in a potentially adversarial setting; for example, when signing digest fields' values for
 authenticity.
 
-The registry is initialized with the algorithms listed below.
+The entries in {{iana-hash-algorithm-table}} are registered by this document.
 
-  {: vspace="0"}
-  SHA-512
-  : * Algorithm: SHA-512
-    * Description: The SHA-512 algorithm [RFC6234].
-    * Algorithm Key: sha-512
-    * Reference: [RFC6234], [RFC4648], this document.
-    * Status: standard
-
-  SHA-256
-  : * Algorithm: SHA-256
-    * Description: The SHA-256 algorithm [RFC6234].
-    * Algorithm Key: sha-256
-    * Reference: [RFC6234], [RFC4648], this document.
-    * Status: standard
-
-  MD5
-  : * Algorithm: md5
-    * Description: The MD5 algorithm [RFC1321].
-      This algorithm is now vulnerable
-      to collision attacks. See {{?NO-MD5=RFC6151}} and [CMU-836068].
-    * Algorithm Key: md5
-    * Reference: [RFC1321], [RFC4648], this document.
-    * Status: insecure
-
-  SHA
-  : * Algorithm: SHA
-    * Description:  The SHA-1 algorithm [RFC3174].
-      This algorithm is now vulnerable
-      to collision attacks. See {{?NO-SHA1=RFC6194}} and [IACR-2020-014].
-    * Algorithm Key: sha
-    * Reference: [RFC3174], [RFC6234], [RFC4648], this document.
-    * Status: insecure
-
-  UNIXSUM
-  : * Algorithm: UNIXSUM
-    * Description: The algorithm used by the UNIX "sum" command [UNIX].
-    * Algorithm Key: unixsum
-    * Reference: [UNIX], this document.
-    * Status: insecure
-
-  UNIXCKSUM
-  : * Algorithm: UNIXCKSUM
-    * Description: The algorithm used by the UNIX "cksum" command [UNIX].
-    * Algorithm Key: unixcksum
-    * Reference: [UNIX], this document.
-    * Status: insecure
-
-  ADLER
-  : * Algorithm: ADLER32
-    * Description: The ADLER32 algorithm [RFC1950].
-    * Algorithm Key: adler32
-    * Reference: [RFC1950], this document.
-    * Status: insecure
-
-  CRC32C
-  : * Algorithm: CRC32C
-    * Description: The CRC32c algorithm {{!RFC4960}}.
-    * Algorithm Key: crc32c
-    * Reference: {{!RFC4960}} appendix B, this document.
-    * Status: insecure
+| -------------- | -------- | ----------------------------------- | -------------- |
+| Algorithm Key  | Status   | Description                         | Reference(s)   |
+| -------------- | -------- | ----------------------------------- | --------- |
+| sha-512        | standard | The SHA-512 algorithm.              | [RFC6234], [RFC4648], this document. |
+| sha-256        | standard | The SHA-256 algorithm.              | [RFC6234], [RFC4648], this document. |
+| md5            | insecure | The MD5 algorithm. It is vulnerable to collision attacks; see {{NO-MD5}} and [CMU-836068] | [RFC1321], [RFC4648], this document. |
+| sha            | insecure | The SHA-1 algorithm. It is vulnerable to collision attacks; see {{NO-SHA}} and [CMU-836068] | [RFC3174], [RFC4648], [RFC6234] this document. |
+| unixsum        | insecure | The algorithm used by the UNIX "sum" command. | [RFC4648], [RFC6234], [UNIX], this document. |
+| unixcksum      | insecure | The algorithm used by the UNIX "cksum" command. | [RFC4648], [RFC6234], [UNIX], this document. |
+| adler          | insecure | The ADLER32 algorithm.                          | [RFC1950], this document. |
+| crc32          | insecure | The CRC32c algorithm.                           | {{!RFC4960}} appendix B, this document. |
+| -------------- | -------- | ----------------------------------- | -------------- |
+{: #iana-hash-algorithm-table title="Initial Hash Algorithms"}
 
 # Using Representation-Digest in State-Changing Requests {#state-changing-requests}
 
@@ -577,8 +535,8 @@ a proof of integrity "at rest" unless the whole (e.g. encoded) content is persis
 
 The security properties of hashing algorithms are not fixed.
 Algorithm Agility (see {{?RFC7696}}) is achieved by providing implementations with flexibility
-to choose hashing algorithms from the IANA HTTP Structured Digest Algorithm Values registry in
-{{iana-digest-algorithm-registry}}.
+to choose hashing algorithms from the IANA Hash Algorithms for HTTP Digest Fields registry; see
+{{establish-hash-algorithm-registry}}.
 
 To help endpoints distinguish weaker algorithms from stronger ones,
 this document adds to the IANA Digest Algorithm Values registry
@@ -607,16 +565,14 @@ validation of the algorithm types, number of validations, or the size of content
 
 # IANA Considerations
 
-## Establish the HTTP Structured Digest Algorithm Values Registry {#iana-digest-algorithm-registry}
+## Establish the Hash Algorithms for HTTP Digest Fields Registry {#establish-hash-algorithm-registry}
 
-This memo sets this specification to be the establishing document for the [HTTP Structured Digest
-Algorithm](https://www.iana.org/assignments/http-structured-dig-alg/) registry.
+This memo sets this specification to be the establishing document for the
+[Hash Algorithms for HTTP Digest Fields](https://www.iana.org/assignments/http-structured-dig-alg/)
+registry defined in {{algorithms}}.
 
-IANA is asked to initialize the registry with the tokens
-defined in {{algorithms}}.
-
-This registry uses the Specification
-Required policy ({{Section 4.6 of !RFC8126}}).
+IANA is asked to initialize the registry with the entries in
+{{iana-hash-algorithm-table}}.
 
 ## Representation-Digest Field Registration
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -141,7 +141,7 @@ The HTTP fields defined in this document can be used for HTTP integrity. Senders
 choose a hashing algorithm and calculate a digest from an input related to the
 HTTP message, the algorithm identifier and digest are transmitted in an HTTP
 field. Receivers can validate the digest for integrity purposes. Hashing
-algorithms are registered in the HTTP Digest Algorithm Values Registry (see
+algorithms are registered in the "Hash Algorithms for HTTP Digest Fields" (see
 {{algorithms}}).
 
 Selecting the data on which digests are calculated depends on the use case of
@@ -538,9 +538,6 @@ Algorithm Agility (see {{?RFC7696}}) is achieved by providing implementations wi
 to choose hashing algorithms from the IANA Hash Algorithms for HTTP Digest Fields registry; see
 {{establish-hash-algorithm-registry}}.
 
-To help endpoints distinguish weaker algorithms from stronger ones,
-this document adds to the IANA Digest Algorithm Values registry
-a new "Status" field containing the most recent appraisal of the hashing algorithm.
 
 An endpoint might have a preference for algorithms,
 such as preferring "standard" algorithms over "insecure" ones.

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -254,7 +254,7 @@ Representation-Digest   = sf-dictionary
 ~~~
 
 `Representation-Digest` member-keys convey the hashing algorithm (see
-{{algorithms}}) used to compute the digest. Member-values are the the output
+{{algorithms}}) used to compute the digest. Member-values are the output
 of the digest calculation. Member-values MUST be of type sf-binary.
 
 For example:
@@ -300,7 +300,7 @@ Content-Digest   = sf-dictionary
 ~~~
 
 `Content-Digest` member-keys convey the hashing algorithm (see {{algorithms}})
-used to compute the digest. Member-values are the the output of the digest
+used to compute the digest. Member-values are the output of the digest
 calculation. Member-values MUST be of type sf-binary.
 
 For example:

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1,5 +1,5 @@
 ---
-title: Structured Digest Fields
+title: Digest Fields
 docname: draft-ietf-httpbis-digest-headers-latest
 category: std
 obsoletes: 3230

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -111,12 +111,12 @@ and make a choice about how to act on it. An example use case is to aid
 fault detection and diagnosis across system boundaries.
 
 This document defines two digest integrity mechanisms for HTTP.
-First, content integrity, which acts on conveyed content ({{Section 6.4 of
-SEMANTICS}}).
-Second, representation data integrity, which acts on representation data ({{Section 3.2
-of SEMANTICS}}). This supports more advanced use cases such as validating the
+First, representation data integrity, which acts on representation data ({{Section 3.2
+of SEMANTICS}}). This supports advanced use cases such as validating the
 integrity of a resource that was reconstructed from parts retrieved using
 multiple requests or connections.
+Second, content integrity, which acts on conveyed content ({{Section 6.4 of
+SEMANTICS}}).
 
 This document obsoletes RFC 3230 and therefore the Digest and Want-Digest HTTP
 fields; see {{obsolete-3230}}.

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -371,9 +371,9 @@ List (see {{Section 3.2 of STRUCTURED-FIELDS}}):
 
 Dictionary members convey hashing algorithm preferences (see {{algorithms}}).
 Member-keys convey the hashing algorithm (see {{algorithms}}), member-values convey
-an ascending relative weighted preference between 0 and 10. 1 is the least
-preferred, 10 is the most preferred; a value of 0 means "not acceptable".
-Member-values MUST be of type sf-integer, in the range 0 to 10.
+an ascending relative weighted preference between 0 and 10 inclusive. 1 is the
+least preferred, 10 is the most preferred; a value of 0 means "not acceptable".
+Member-values MUST be of type sf-integer, in the range 0 to 10 inclusive.
 
 Examples:
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -410,7 +410,7 @@ The entries in {{iana-hash-algorithm-table}} are registered by this document.
 | sha-512        | standard | The SHA-512 algorithm.              | [RFC6234], [RFC4648], this document. |
 | sha-256        | standard | The SHA-256 algorithm.              | [RFC6234], [RFC4648], this document. |
 | md5            | insecure | The MD5 algorithm. It is vulnerable to collision attacks; see {{NO-MD5}} and [CMU-836068] | [RFC1321], [RFC4648], this document. |
-| sha            | insecure | The SHA-1 algorithm. It is vulnerable to collision attacks; see {{NO-SHA}} and [CMU-836068] | [RFC3174], [RFC4648], [RFC6234] this document. |
+| sha            | insecure | The SHA-1 algorithm. It is vulnerable to collision attacks; see {{NO-SHA}} and [IACR-2020-014] | [RFC3174], [RFC4648], [RFC6234] this document. |
 | unixsum        | insecure | The algorithm used by the UNIX "sum" command. | [RFC4648], [RFC6234], [UNIX], this document. |
 | unixcksum      | insecure | The algorithm used by the UNIX "cksum" command. | [RFC4648], [RFC6234], [UNIX], this document. |
 | adler          | insecure | The ADLER32 algorithm.                          | [RFC1950], this document. |

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -502,7 +502,7 @@ enclosed representation refers to the resource identified by its value and
 
 # Security Considerations
 
-## HTTP Messages are not protected in full
+## HTTP Messages Are Not Protected In Full
 
 This document specifies a data integrity mechanism that protects HTTP
 `representation data` or content, but not HTTP header and trailer fields, from

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -83,7 +83,7 @@ informative:
 
 --- abstract
 
-This document defines HTTP fields that support integrity checksums. The
+This document defines HTTP fields that support integrity digests. The
 Representation-Digest field can be used for the integrity of HTTP
 representations. The Content-Digest field can be used for the integrity of
 HTTP message content. Want-Representation-Digest and Want-Content-Digest can be
@@ -138,18 +138,18 @@ This document is structured as follows:
 ## Concept Overview
 
 The HTTP fields defined in this document can be used for HTTP integrity. Senders
-choose a hashing algorithm and calculate a checksum from an input related to the
-HTTP message, the algorithm identifier and checksum are transmitted in an HTTP
-field. Receivers can validate the checksum for integrity purposes. Hashing
+choose a hashing algorithm and calculate a digest from an input related to the
+HTTP message, the algorithm identifier and digest are transmitted in an HTTP
+field. Receivers can validate the digest for integrity purposes. Hashing
 algorithms are registered in the HTTP Digest Algorithm Values Registry (see
 {{algorithms}}).
 
-Selecting the data on which checksums are calculated depends on the use case of
+Selecting the data on which digests are calculated depends on the use case of
 HTTP messages. This document provides different headers for HTTP representation
 data and HTTP content.
 
 This document defines the `Representation-Digest` request and response header
-and trailer field ({{representation-digest}}) that contains a checksum value
+and trailer field ({{representation-digest}}) that contains a digest value
 computed by applying a hashing algorithm to `selected representation data`
 ({{Section 3.2 of SEMANTICS}}). Basing `Representation-Digest` on the selected
 representation makes it straightforward to apply it to use-cases where the
@@ -157,9 +157,9 @@ transferred data requires some sort of manipulation to be considered a
 representation or conveys a partial representation of a resource, such as Range
 Requests (see {{Section 14.2 of SEMANTICS}}).
 
-There are use-cases where a simple checksum of the HTTP content bytes is
+There are use-cases where a simple digest of the HTTP content bytes is
 required. The `Content-Digest` request and response header and trailer field is
-defined to support checksums of content ({{Section 3.2 of SEMANTICS}}); see
+defined to support digests of content ({{Section 3.2 of SEMANTICS}}); see
 {{content-digest}}.
 
 `Representation-Digest` and `Content-Digest` support hashing algorithm agility.
@@ -173,7 +173,7 @@ collectively termed integrity preference fields.
 
 Integrity fields are tied to the `Content-Encoding`
 and `Content-Type` header fields. Therefore, a given resource may have multiple
-different checksum values when transferred with HTTP.
+different digest values when transferred with HTTP.
 
 Integrity fields do not provide integrity for
 HTTP messages or fields. However, they can be combined with other mechanisms that
@@ -191,9 +191,9 @@ semantics such as `selected representation data` ({{Section 3.2 of SEMANTICS}}).
 
 Experience has shown that implementations of [RFC3230] have interpreted the
 meaning of "instance" inconsistently, leading to interoperability issues. The
-most common mistake being the calculation of the checksum using (what we now call)
+most common mistake being the calculation of the digest using (what we now call)
 message content, rather than using (what we now call) representation data as was
-originally intended. Interestingly, time has also shown that a checksum of
+originally intended. Interestingly, time has also shown that a digest of
 message content can be beneficial for some use cases. So it is difficult to
 detect if non-conformance to [RFC3230] is intentional or unintentional.
 
@@ -232,7 +232,7 @@ Integrity preference fields: collective term for `Want-Representation-Digest` an
 # The Representation-Digest Field {#representation-digest}
 
 The `Representation-Digest` HTTP field can be used in requests and responses to
-communicate checksums that are calculated using a hashing algorithm applied to
+communicate digests that are calculated using a hashing algorithm applied to
 the entire selected `representation data` (see {{Section 8.1 of SEMANTICS}}).
 
 Representations take into account the effect of the HTTP semantics on
@@ -254,8 +254,8 @@ Representation-Digest   = sf-dictionary
 ~~~
 
 `Representation-Digest` member-keys convey the hashing algorithm (see
-{{algorithms}}) used to compute the checksum. Member-values are the the output
-of the checksum calculation. Member-values MUST be of type sf-binary.
+{{algorithms}}) used to compute the digest. Member-values are the the output
+of the digest calculation. Member-values MUST be of type sf-binary.
 
 For example:
 
@@ -265,7 +265,7 @@ Representation-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
 ~~~
 
 Since `Representation-Digest` is a Dictionary, it can contain multiple
-members. This could be used, for example, to attach multiple checksums
+members. This could be used, for example, to attach multiple digests
 calculated using different hashing algorithms in order to support a population
 of endpoints with different or evolving capabilities. Such an approach could
 support transitions away from weaker algorithms (see {{algorithm-agility}}).
@@ -291,7 +291,7 @@ In this case,
 # The Content-Digest Field {#content-digest}
 
 The `Content-Digest` HTTP field can be used in requests and responses to
-communicate checksums that are calculated using a hashing algorithm applied to
+communicate digests that are calculated using a hashing algorithm applied to
 the actual message content (see {{Section 6.4 of SEMANTICS}}). It is a
 Structured Fields Dictionary (see {{Section 3.2 of STRUCTURED-FIELDS}}):
 
@@ -300,7 +300,7 @@ Content-Digest   = sf-dictionary
 ~~~
 
 `Content-Digest` member-keys convey the hashing algorithm (see {{algorithms}})
-used to compute the checksum. Member-values are the the output of the checksum
+used to compute the digest. Member-values are the the output of the digest
 calculation. Member-values MUST be of type sf-binary.
 
 For example:
@@ -311,7 +311,7 @@ Content-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
 ~~~
 
 Since `Content-Digest` is a Dictionary, it can contain multiple
-members. This could be used, for example, to attach multiple checksums
+members. This could be used, for example, to attach multiple digests
 calculated using different hashing algorithms in order to support a population
 of endpoints with different or evolving capabilities. Such an approach could
 support transitions away from weaker algorithms (see {{algorithm-agility}}).
@@ -490,7 +490,7 @@ certain identification of the origin of a message [NIST800-32]. Such signatures
 can protect one or more HTTP fields and there are additional considerations when
 `Representation-Digest` or `Content-Digest` is included in this set.
 
-Checksums explicitly
+Digests explicitly
 depend on the "representation metadata" (e.g. the values of `Content-Type`,
 `Content-Encoding` etc). A signature that protects `Representation-Digest` but not other
 "representation metadata" can expose the communication to tampering. For

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -115,7 +115,7 @@ of SEMANTICS}}). This supports more advanced use cases such as validating the
 integrity of a resource the was reconstructed from parts retrieved using
 multiple requests or connections.
 
-This document obsoletes RFC 3230 and therefore the Digest and Wants-Digest HTTP
+This document obsoletes RFC 3230 and therefore the Digest and Want-Digest HTTP
 fields; see {{obsolete-3230}}.
 
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -260,8 +260,11 @@ of the digest calculation. Member-values MUST be of type sf-binary.
 For example:
 
 ~~~ http-message
-Representation-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
-                AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==:
+NOTE: '\' line wrapping per RFC 8792
+
+Representation-Digest: \
+  sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrI\
+  iYllu7BNNyealdVLvRwEmTHWXvJwew==:
 ~~~
 
 Since `Representation-Digest` is a Dictionary, it can contain multiple
@@ -271,9 +274,12 @@ of endpoints with different or evolving capabilities. Such an approach could
 support transitions away from weaker algorithms (see {{algorithm-agility}}).
 
 ~~~ http-message
-Representation-Digest: sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:,
-        sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
-                AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==:
+NOTE: '\' line wrapping per RFC 8792
+
+Representation-Digest: \
+  sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:,\
+  sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrI\
+  iYllu7BNNyealdVLvRwEmTHWXvJwew==:
 ~~~
 
 A recipient MAY ignore any or all of members of `Representation-Digest`.
@@ -306,8 +312,11 @@ calculation. Member-values MUST be of type sf-binary.
 For example:
 
 ~~~ http-message
-Content-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
-                        AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==:
+NOTE: '\' line wrapping per RFC 8792
+
+Content-Digest: \
+  sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrI\
+  iYllu7BNNyealdVLvRwEmTHWXvJwew==:
 ~~~
 
 Since `Content-Digest` is a Dictionary, it can contain multiple
@@ -317,9 +326,12 @@ of endpoints with different or evolving capabilities. Such an approach could
 support transitions away from weaker algorithms (see {{algorithm-agility}}).
 
 ~~~ http-message
-Content-Digest: sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:,
-                sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
-                        AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==:
+NOTE: '\' line wrapping per RFC 8792
+
+Representation-Digest: \
+  sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:,\
+  sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrI\
+  iYllu7BNNyealdVLvRwEmTHWXvJwew==:
 ~~~
 
 A recipient MAY ignore any or all of members of `Content-Digest`. This allows
@@ -752,10 +764,14 @@ Host: foo.example
 {: title="GET request for an item"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 200 OK
 Content-Type: application/json
-Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
-Content-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Representation-Digest: \
+  sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Content-Digest: \
+  sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 {"hello": "world"}
 ~~~
@@ -779,10 +795,14 @@ Host: foo.example
 {: title="HEAD request for an item"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 200 OK
 Content-Type: application/json
-Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
-Content-Digest: sha-256=:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=:
+Representation-Digest: \
+  sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Content-Digest: \
+  sha-256=:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=:
 
 ~~~
 {: title="Response with both Content-Digest and Digest; empty content"}
@@ -803,11 +823,15 @@ Range: bytes=1-7
 {: title="Request for partial content"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 206 Partial Content
 Content-Type: application/json
 Content-Range: bytes 1-7/18
-Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
-Content-Digest: sha-256=:Wqdirjg/u3J688ejbUlApbjECpiUUtIwT8lY/z81Tno=:
+Representation-Digest: \
+  sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Content-Digest: \
+  sha-256=:Wqdirjg/u3J688ejbUlApbjECpiUUtIwT8lY/z81Tno=:
 
 "hello"
 ~~~
@@ -828,23 +852,29 @@ For presentation purposes, the response body is displayed as a Base64-encoded st
 non-printable characters.
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 PUT /items/123 HTTP/1.1
 Host: foo.example
 Content-Type: application/json
 Accept-Encoding: br
-Representation-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+Representation-Digest: \
+  sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 {"hello": "world"}
 ~~~
 {: title="PUT Request with Digest"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Location: /items/123
 Content-Encoding: br
 Content-Length: 22
-Representation-Digest: sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:
+Representation-Digest: \
+  sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:
 
 iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 ~~~
@@ -861,22 +891,28 @@ depends on the representation metadata header fields, including
 
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 PUT /items/123 HTTP/1.1
 Host: foo.example
 Content-Type: application/json
 Content-Length: 18
 Accept-Encoding: br
-Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Representation-Digest: \
+  sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 {"hello": "world"}
 ~~~
 {: title="PUT Request with Digest}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 204 No Content
 Content-Type: application/json
 Content-Encoding: br
-Representation-Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=
+Representation-Digest: \
+  sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:
 
 ~~~
 {: title="Empty response with Digest"}
@@ -889,24 +925,30 @@ As the response body contains non-printable characters, it is displayed as a
 base64-encoded string.
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 PUT /items/123 HTTP/1.1
 Host: foo.example
 Content-Type: application/json
 Accept-Encoding: br
-Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Representation-Digest: \
+  sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 {"hello": "world"}
 ~~~
 {: title="PUT Request with Digest"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Encoding: br
 Content-Location: /items/123
-Representation-Digest: sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:,
-        sha-512=:pxo7aYzcGI88pnDnoSmAnaOEVys0MABhgvHY9+VI+ElE6
-                0jBCwnMPyA/s3NF3ZO5oIWA7lf8ukk+\n5KJzm3p5og==:
+Representation-Digest: \
+  sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:,\
+  sha-512=:pxo7aYzcGI88pnDnoSmAnaOEVys0MABhgvHY9+VI+ElE60jBCwnMPyA/\
+  s3NF3ZO5oIWA7lf8ukk+5KJzm3p5og==:
 
 iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 ~~~
@@ -921,23 +963,29 @@ The representation enclosed in the response refers to the resource identified by
 `Content-Location` (see {{Section 6.4.2 of SEMANTICS}}). `Representation-Digest` is thus computed on the enclosed representation.
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 POST /books HTTP/1.1
 Host: foo.example
 Content-Type: application/json
 Accept: application/json
 Accept-Encoding: identity
-Representation-Digest: sha-256=:bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=:
+Representation-Digest: \
+  sha-256=:bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=:
 
 {"title": "New Title"}
 ~~~
 {: title="POST Request with Digest"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 201 Created
 Content-Type: application/json
 Content-Location: /books/123
 Location: /books/123
-Representation-Digest: sha-256=:yxOAqEeoj+reqygSIsLpT0LhumrNkIds5uLKtmdLyYE=:
+Representation-Digest: \
+  sha-256=:yxOAqEeoj+reqygSIsLpT0LhumrNkIds5uLKtmdLyYE=:
 
 {
   "id": "123",
@@ -962,21 +1010,27 @@ Response `Representation-Digest` has no explicit relation with the resource refe
 `Location`.
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 POST /books HTTP/1.1
 Host: foo.example
 Content-Type: application/json
 Accept: application/json
 Accept-Encoding: identity
-Representation-Digest: sha-256=:bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=:
+Representation-Digest: \
+  sha-256=:bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=:
 
 {"title": "New Title"}
 ~~~
 {: title="POST Request with Digest"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 201 Created
 Content-Type: application/json
-Representation-Digest: sha-256=:2LBp5RKZGpsSNf8BPXlXrX4Td4Tf5R5bZ9z7kdi5VvY=:
+Representation-Digest: \
+  sha-256=:2LBp5RKZGpsSNf8BPXlXrX4Td4Tf5R5bZ9z7kdi5VvY=:
 Location: /books/123
 
 {
@@ -1004,21 +1058,27 @@ The response `Representation-Digest` field-value is computed on the complete rep
 resource.
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 PATCH /books/123 HTTP/1.1
 Host: foo.example
 Content-Type: application/merge-patch+json
 Accept: application/json
 Accept-Encoding: identity
-Representation-Digest: sha-256=:bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=:
+Representation-Digest: \
+  sha-256=:bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=:
 
 {"title": "New Title"}
 ~~~
 {: #fig-patch title="PATCH Request with Digest"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 200 OK
 Content-Type: application/json
-Representation-Digest: sha-256=:yxOAqEeoj+reqygSIsLpT0LhumrNkIds5uLKtmdLyYE=:
+Representation-Digest: \
+  sha-256=:yxOAqEeoj+reqygSIsLpT0LhumrNkIds5uLKtmdLyYE=:
 
 {
   "id": "123",
@@ -1043,9 +1103,12 @@ accordance with {{?RFC7807}}.
 The response `Representation-Digest` field-value is computed on this enclosed representation.
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 404 Not Found
 Content-Type: application/problem+json
-Representation-Digest: sha-256=:KPqhVXAT25LLitV1w0O167unHmVQusu+fpxm65zAsvk=:
+Representation-Digest: \
+  sha-256=:KPqhVXAT25LLitV1w0O167unHmVQusu+fpxm65zAsvk=:
 
 {
   "title": "Not Found",
@@ -1070,6 +1133,8 @@ Host: foo.example
 {: title="GET Request"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 200 OK
 Content-Type: application/json
 Transfer-Encoding: chunked
@@ -1082,7 +1147,8 @@ Trailer: Digest
 2\r\n
 "}\r\n
 0\r\n
-Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Representation-Digest: \
+  sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 ~~~
 {: title="Chunked Response with Digest"}
@@ -1118,9 +1184,12 @@ Want-Representation-Digest: sha-256=3, sha=10
 {: title="GET Request with Want-Representation-Digest"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 200 OK
 Content-Type: application/json
-Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Representation-Digest: \
+  sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 {"hello": "world"}
 ~~~
@@ -1141,10 +1210,13 @@ Want-Representation-Digest: sha=1
 {: title="GET Request with Want-Representation-Digest"}
 
 ~~~ http-message
+NOTE: '\' line wrapping per RFC 8792
+
 HTTP/1.1 200 OK
 Content-Type: application/json
-Representation-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
-                +AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==:
+Representation-Digest: \
+  sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrI\
+  iYllu7BNNyealdVLvRwEmTHWXvJwew==:
 
 {"hello": "world"}
 ~~~
@@ -1253,9 +1325,9 @@ print("Brotli | sha512 |", digest(item, algorithm=hashlib.sha512,
                                     encoding=brotli.compress))
 # Encoding | hashing algorithm | digest-value
 # Identity | sha512 |b'WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm'
-#                     '+AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew=='
+#                     '+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew=='
 # Brotli | sha512 | b'pxo7aYzcGI88pnDnoSmAnaOEVys0MABhgvHY9+VI+ElE6'
-#                   '0jBCwnMPyA/s3NF3ZO5oIWA7lf8ukk+\n5KJzm3p5og=='
+#                   '0jBCwnMPyA/s3NF3ZO5oIWA7lf8ukk+5KJzm3p5og=='
 
 ~~~
 

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1,5 +1,5 @@
 ---
-title: Digest Fields
+title: Structured Digest Fields
 docname: draft-ietf-httpbis-digest-headers-latest
 category: std
 obsoletes: 3230
@@ -40,7 +40,6 @@ normative:
   RFC3174:
   RFC1950:
   RFC3230:
-  RFC5843:
   RFC4648:
   RFC5234:
   RFC6234:
@@ -77,430 +76,390 @@ normative:
 
 informative:
   RFC2818:
-  RFC7231:
   HTTP11: I-D.ietf-httpbis-messaging
   PATCH: RFC5789
 
 --- abstract
 
-This document defines HTTP fields that support integrity checksums.
-The Digest field can be used for the integrity of HTTP representations.
-The Content-Digest field can be used for the integrity of HTTP message content.
-Want-Digest and Want-Content-Digest can be used to indicate a sender's desire to
-receive integrity fields respectively.
+This document defines HTTP fields that support integrity checksums. The
+Representation-Digest field can be used for the integrity of HTTP
+representations. The Content-Digest field can be used for the integrity of
+HTTP message content. Want-Representation-Digest and Want-Content-Digest can be
+used to indicate a sender's interest and preferences for receiving respective integrity fields.
 
-This document obsoletes RFC 3230.
+This document obsoletes RFC 3230 and therefore the Digest and Wants-Digest HTTP
+fields.
 
 
 --- middle
 
 # Introduction
 
-HTTP does not define a means to protect the integrity of representations. When
-HTTP messages are transferred between endpoints, the protocol might choose to
-make use of features of the lower layer in order to provide some integrity
-protection; for instance, TCP checksums or TLS records [RFC2818].
+HTTP does not define the means to protect the data integrity of representations
+or content. When HTTP messages are transferred between endpoints, lower layer
+features or properties such as TCP checksums or TLS records [RFC2818] can provide
+some integrity protection. However, transport-oriented integrity provides a
+limited utility because it is opaque to the application layer and only covers
+the extent of a single connection. HTTP messages often travel over a chain of
+separate connections, in between connections there is a possibility for
+unintended or malicious data corruption. An HTTP integrity mechanism can provide
+the means for endpoints, or applications using HTTP, to detect data corruption
+and make a choice about how to act on it. An example use case is to aid
+fault detection and diagnosis across system boundaries.
 
 This document defines two digest integrity mechanisms for HTTP.
-First, representation data integrity, which acts on representation data ({{Section 3.2
-of SEMANTICS}}).
-Second, content integrity, which acts on conveyed content ({{Section 6.4 of
+First, content integrity, which acts on conveyed content ({{Section 6.4 of
 SEMANTICS}}).
-Both mechanisms operate independent of transport integrity, offering
-the potential to detect programming errors and corruption of data in flight or
-at rest.
-They can be used across multiple hops in order to provide end-to-end
-integrity guarantees, which can aid fault diagnosis when resources are
-transferred across hops and system boundaries.
-Finally, they can be used to
-validate integrity when reconstructing a resource fetched using different HTTP
-connections.
+Second, representation data integrity, which acts on representation data ({{Section 3.2
+of SEMANTICS}}). This supports more advanced use cases such as validating the
+integrity of a resource the was reconstructed from parts retrieved using
+multiple requests or connections.
 
-This document obsoletes [RFC3230].
+This document obsoletes RFC 3230 and therefore the Digest and Wants-Digest HTTP
+fields; see {{obsolete-3230}}.
+
 
 ## Document Structure
 
 This document is structured as follows:
 
-- {{representation-digest}} describes concepts related to representation
-  digests,
-- {{digest}} defines the Digest request and response header and trailer field,
+- {{representation-digest}} defines the Representation-Digest request and response header and trailer field,
 - {{content-digest}} defines the Content-Digest request and response header and trailer field,
-- {{want-fields}} defines the Want-Digest and Want-Content-Digest request and response header and
+- {{want-fields}} defines the Want-Representation-Digest and Want-Content-Digest request and response header and
   trailer field,
-- {{algorithms}} describes algorithms and their relation to Digest,
+- {{algorithms}} describes algorithms and their relation to the fields defined in this document,
 - {{state-changing-requests}} details computing representation digests,
 - {{examples-unsolicited}} and {{examples-solicited}} provide examples of using
-  Digest and Want-Digest.
+  Representation-Digest and Want-Representation-Digest.
 
 ## Concept Overview
 
-This document defines the `Digest` request and response header and trailer
-field; see {{digest}}. At a high level, the value contains a checksum, computed
-over `selected representation data` ({{Section 3.2 of
-SEMANTICS}}), that the recipient can use to
-validate integrity. Basing `Digest` on the selected representation makes it
-straightforward to apply it to use-cases where the transferred data requires
-some sort of manipulation to be considered a representation or conveys a
-partial representation of a resource, such as Range Requests (see {{Section
-14.2 of SEMANTICS}}).
+The HTTP fields defined in this document can be used for HTTP integrity. Senders
+choose a hashing algorithm and calculate a checksum from an input related to the
+HTTP message, the algorithm identifier and checksum are transmitted in an HTTP
+field. Receivers can validate the checksum for integrity purposes. Hashing
+algorithms are registered in the HTTP Digest Algorithm Values Registry (see
+{{algorithms}}).
 
-To support use-cases where a simple checksum of the content bytes is required,
-this document introduces the `Content-Digest` request and response header and trailer field; see
+Selecting the data on which checksums are calculated depends on the use case of
+HTTP messages. This document provides different headers for HTTP representation
+data and HTTP content.
+
+This document defines the `Representation-Digest` request and response header
+and trailer field ({{representation-digest}}) that contains a checksum value
+computed by applying a hashing algorithm to `selected representation data`
+({{Section 3.2 of SEMANTICS}}). Basing `Representation-Digest` on the selected
+representation makes it straightforward to apply it to use-cases where the
+transferred data requires some sort of manipulation to be considered a
+representation or conveys a partial representation of a resource, such as Range
+Requests (see {{Section 14.2 of SEMANTICS}}).
+
+There are use-cases where a simple checksum of the HTTP content bytes is
+required. The `Content-Digest` request and response header and trailer field is
+defined to support checksums of content ({{Section 3.2 of SEMANTICS}}); see
 {{content-digest}}.
 
-`Digest` and `Content-Digest` support algorithm agility. The `Want-Digest` and
-`Want-Content-Digest` fields allows endpoints to express interest in `Digest` and
-`Content-Digest` respectively, and preference of algorithms in either.
+`Representation-Digest` and `Content-Digest` support hashing algorithm agility.
+The `Want-Representation-Digest` and `Want-Content-Digest` fields allows
+endpoints to express interest in `Representation-Digest` and `Content-Digest`
+respectively, and preference of algorithms in either.
 
-Digest field calculations are tied to the `Content-Encoding`
+`Representation-Digest` and `Content-Digest` are collectively termed
+integrity fields. `Want-Representation-Digest` and `Want-Content-Digest`are
+collectively termed integrity preference fields.
+
+Integrity fields are tied to the `Content-Encoding`
 and `Content-Type` header fields. Therefore, a given resource may have multiple
 different checksum values when transferred with HTTP.
 
-Digest fields do not provide integrity for
+Integrity fields do not provide integrity for
 HTTP messages or fields. However, they can be combined with other mechanisms that
 protect metadata, such as digital signatures, in order to protect
 the phases of an HTTP exchange in whole or in part.
 
 This specification does not define means for authentication, authorization or privacy.
 
-## Replacing RFC 3230
+## Obsoleting RFC 3230 {#obsolete-3230}
 
-Historically, the `Content-MD5` header field provided an HTTP integrity mechanism
-but HTTP/1.1 ([RFC7231], Appendix B) obsoleted it due to inconsistent handling
-of partial responses. [RFC3230] defined the concept of "instance" digests and a
-more flexible integrity scheme to help address issues with `Content-MD5`. It first
-introduced the `Digest` and `Want-Digest` fields. HTTP terminology has evolved
-since [RFC3230] was published. The concept of "instance" has been superseded by
-`selected representation`.
+[RFC3230] defined the `Digest` and `Want-Digest` HTTP fields for HTTP integrity.
+It also coined the term "instance" and "instance manipulation" in order to
+explain concepts that are now more universally defined, and implemented, as HTTP
+semantics such as `selected representation data` ({{Section 3.2 of SEMANTICS}}).
 
-This document replaces [RFC3230]. The changes described in the following
-paragraphs are intended to be syntactically and semantically compatible with existing
-implementations where possible.
+Experience has shown that implementations of [RFC3230] have interpreted the
+meaning of "instance" inconsistently, leading to interoperability issues. The
+most common mistake being the calculation of the checksum using (what we now call)
+message content, rather than using (what we now call) representation data as was
+originally intended. Interestingly, time has also shown that a checksum of
+message content can be beneficial for some use cases. So it is difficult to
+detect if non-conformance to [RFC3230] is intentional or unintentional.
 
-The `Digest` and `Want-Digest` field definitions are updated to align with the
-terms and notational conventions in {{SEMANTICS}}.
-
-Negotiation of `Content-MD5` is deprecated and has been replaced by
-`Content-Digest` negotiation via `Want-Content-Digest`.
-
-{{Sections 4.1.1 and 4.2 of RFC3230}} defined field parameters. This document
-obsoletes the usage of parameters with `Digest` because this feature has not
-been widely deployed and complicates field-value processing. [RFC3230] intended
-field parameters to provide a common way to attach additional information to a
-representation-data-digest. However, if parameters are used as an input to
-validate the checksum, an attacker could alter them to steer the validation
-behavior. A digest-algorithm can still be parameterized by defining its own way
-to encode parameters into the representation-data-digest, in such a way as to
-mitigate security risks related to its computation.
-
-The algorithm table has been updated to reflect the current state of the art,
-(see {{algorithms}}).
+In order to address potential inconsistencies and ambiguity across
+implementations of `Digest` and `Want-Digest`, this document obsoletes
+[RFC3230]. The Integrity fields ({{representation-digest}} and
+{{content-digest}}) and integrity preference fields ({{want-fields}})
+defined in this document are better aligned with current HTTP semantics and
+have names that more clearly articulate the intended usages.
 
 
 ## Notational Conventions
 {::boilerplate bcp14-tagged}
 
 This document uses the Augmented BNF defined in [RFC5234] and updated by
-[RFC7405] along with the "#rule" extension defined in {{Section 5.6.1 of
-SEMANTICS}}
-and the "qvalue" rule defined in {{Section 12.4.2 of SEMANTICS}}.
+[RFC7405].
+
+The terms Dictionary, List, sf-dictionary, sf-integer and sf-binary are imported from
+{{!STRUCTURED-FIELDS=RFC8941}}.
 
 The definitions "representation", "selected representation", "representation
 data", "representation metadata", and "content" in this document are to be
 interpreted as described in {{SEMANTICS}}.
 
-Algorithm names respect the casing used in their definition document (e.g. SHA-1, CRC32c)
-whereas digest-algorithm tokens are quoted (e.g. "sha", "crc32c").
+Hashing algorithm names respect the casing used in their definition document (e.g. SHA-1, CRC32c)
+whereas hashing algorithm keys are quoted (e.g. "sha", "crc32c").
 
 The term "checksum" describes the output of the application of an algorithm
 to a sequence of bytes,
 whereas digest is only used in relation to the value of the fields.
 
-# Representation Digest {#representation-digest}
+Integrity fields: collective term for `Representation-Digest` and `Content-Digest`
 
-The representation digest is an integrity mechanism for HTTP resources
-which uses a checksum  that is calculated independently of the content
-(see {{Section 6.4 of SEMANTICS}}).
-It uses the representation data (see {{Section 8.1 of SEMANTICS}}),
-that can be fully or partially contained in the content, or not contained at all.
+Integrity preference fields: collective term for `Want-Representation-Digest` and `Want-Content-Digest`
 
-This takes into account the effect of the HTTP semantics on the messages;
-for example, the content can be affected by Range Requests or methods such as HEAD,
-while the way the content is transferred "on the wire" is dependent on other
-transformations (e.g. transfer codings for HTTP/1.1 - see {{Section 6.1 of
-HTTP11}}). To help illustrate how such things affect `Digest`,
+# The Representation-Digest Field {#representation-digest}
+
+The `Representation-Digest` HTTP field can be used in requests and responses to
+communicate checksums that are calculated using a hashing algorithm applied to
+the entire selected `representation data` (see {{Section 8.1 of SEMANTICS}}).
+
+Representations take into account the effect of the HTTP semantics on
+messages. For example, the content can be affected by Range Requests or methods
+such as HEAD, while the way the content is transferred "on the wire" is
+dependent on other transformations (e.g. transfer codings for HTTP/1.1 - see
+{{Section 6.1 of HTTP11}}). To help illustrate HTTP representation concepts,
 several examples are provided in {{resource-representation}}.
 
-A representation digest consists of
-the value of a checksum computed on the entire selected `representation data`
-(see {{Section 8.1 of SEMANTICS}}) of a resource identified according to {{Section 6.4.2 of SEMANTICS}}
-together with an indication of the algorithm used:
+When a message has no representation data it is still possible to assert that no
+representation data was sent computing the representation digest on an empty
+string (see {{usage-in-signatures}}).
+
+`Representation-Digest` is a Structured Fields Dictionary (see {{Section 3.2 of
+STRUCTURED-FIELDS}}):
 
 ~~~ abnf
-   representation-data-digest = digest-algorithm "="
-                                <encoded checksum output>
+Representation-Digest   = sf-dictionary
 ~~~
 
-When a message has no representation data
-it is still possible to assert that no representation data was sent
-computing the representation digest on an empty string
-(see {{usage-in-signatures}}).
-
-The checksum is computed using one of the digest-algorithms listed in
-the HTTP Digest Algorithm Values Registry (see {{algorithms}})
-and then encoded in the associated format.
-
-# The Digest Field {#digest}
-
-The `Digest` field contains a comma-separated list of one or more representation digest values as
-defined in {{representation-digest}}. It can be used in both requests and
-responses.
-
-~~~ abnf
-   Digest = 1#representation-data-digest
-~~~
+`Representation-Digest` member-keys convey the hashing algorithm (see
+{{algorithms}}) used to compute the checksum. Member-values are the the output
+of the checksum calculation. Member-values MUST be of type sf-binary.
 
 For example:
 
 ~~~ http-message
-Digest: sha-512=WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
-                AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==
+Representation-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
+                AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==:
 ~~~
 
-A `Digest` field MAY contain multiple representation-data-digest values.
-For example, a server may provide representation-data-digest values using different algorithms,
-allowing it to support a population of clients with different evolving capabilities;
-this is particularly useful in support of transitioning away
-from weaker algorithms should the need arise (see {{algorithm-agility}}).
+Since `Representation-Digest` is a Dictionary, it can contain multiple
+members. This could be used, for example, to attach multiple checksums
+calculated using different hashing algorithms in order to support a population
+of endpoints with different evolving capabilities. Such an approach could
+support transitions away from weaker algorithms (see {{algorithm-agility}}).
 
 ~~~ http-message
-Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=,
-        sha-512=WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
-                AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==
+Representation-Digest: sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:,
+        sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
+                AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==:
 ~~~
 
-A recipient MAY ignore any or all of the representation-data-digests in a Digest
-field. This allows the recipient to choose which digest-algorithm(s) to use for
+A recipient MAY ignore any or all of members of `Representation-Digest`.
+This allows the recipient to choose which hashing algorithm(s) to use for
 validation instead of verifying every received representation-data-digest.
 
-A sender MAY send a representation-data-digest using a digest-algorithm without
-knowing whether the recipient supports the digest-algorithm, or even knowing
-that the recipient will ignore it.
+A sender MAY send a `Representation-Digest` member without knowing whether the
+recipient supports a given hashing algorithm, or even knowing that the recipient
+will ignore it.
 
-`Digest` can be sent in a trailer section.
+`Representation-Digest` can be sent in a trailer section.
 In this case,
-`Digest` MAY be merged into the header section; see {{Section 6.5.1 of SEMANTICS}}.
-
-A non-comprehensive set of examples showing the impacts of
-representation metadata, payload transformations and HTTP methods on `Digest` is
-provided in {{examples-unsolicited}} and {{examples-solicited}}.
-
+`Representation-Digest` MAY be merged into the header section; see {{Section 6.5.1 of SEMANTICS}}.
 
 # The Content-Digest Field {#content-digest}
 
-The `Content-Digest` field contains a comma-separated list of one or more content digest
-values.
-A content digest value is computed by applying a digest-algorithm to the actual message content
-(see {{Section 6.4 of SEMANTICS}}).
-It can be used in both requests and responses.
+The `Content-Digest` HTTP field can be used in requests and responses to
+communicate checksums that are calculated using a hashing algorithm applied to
+the actual message content (see {{Section 6.4 of SEMANTICS}}). It is a
+Structured Fields Dictionary (see {{Section 3.2 of STRUCTURED-FIELDS}}):
 
 ~~~ abnf
-   Content-Digest = 1#content-digest
-   content-digest = digest-algorithm "="
-                    <encoded checksum output>
+Content-Digest   = sf-dictionary
 ~~~
+
+`Content-Digest` member-keys convey the hashing algorithm (see {{algorithms}})
+used to compute the checksum. Member-values are the the output of the checksum
+calculation. Member-values MUST be of type sf-binary.
 
 For example:
 
 ~~~ http-message
-Content-Digest: sha-512=WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
-                        AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==
+Content-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
+                        AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==:
 ~~~
 
-A `Content-Digest` field MAY contain multiple content-digest values,
-similarly to `Digest` (see {{digest}})
+Since `Content-Digest` is a Dictionary, it can contain multiple
+members. This could be used, for example, to attach multiple checksums
+calculated using different hashing algorithms in order to support a population
+of endpoints with different evolving capabilities. Such an approach could
+support transitions away from weaker algorithms (see {{algorithm-agility}}).
 
 ~~~ http-message
-Content-Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=,
-                sha-512=WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
-                        AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==
+Content-Digest: sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:,
+                sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
+                        AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==:
 ~~~
 
-A recipient MAY ignore any or all of the content-digests in a Content-Digest
-field. This allows the recipient to choose which digest-algorithm(s) to use for
-validation instead of verifying every received content-digest.
+A recipient MAY ignore any or all of members of `Content-Digest`. This allows
+the recipient to choose which hashing algorithm(s) to use for validation instead
+of verifying every received representation-data-digest.
 
-A sender MAY send a content-digest using a digest-algorithm without
-knowing whether the recipient supports the digest-algorithm, or even knowing
+A sender MAY send a representation-data-digest using a hashing algorithm without
+knowing whether the recipient supports the hashing algorithm, or even knowing
 that the recipient will ignore it.
 
 `Content-Digest` can be sent in a trailer section.
 In this case,
 `Content-Digest` MAY be merged into the header section; see {{Section 6.5.1 of SEMANTICS}}.
 
-# Want-Digest and Want-Content-Digest Fields {#want-fields}
+# Integrity preference fields  {#want-fields}
 
-Senders can indicate their integrity checksum preferences using the
-`Want-Digest` or `Want-Content-Digest` fields. These can be used in both
+Senders can indicate their interest in integrity fields and hashing algorithm
+preferences using the
+`Want-Representation-Digest` or `Want-Content-Digest` fields. These can be used in both
 requests and responses.
 
-`Want-Digest` indicates the sender's desire to receive a representation digest
+`Want-Representation-Digest` indicates the sender's desire to receive a representation digest
 on messages associated with the request URI and representation metadata, using
-the `Digest` field.
+the `Representation-Digest` field.
 
 `Want-Content-Digest` indicates the sender's desire to receive a content digest
 on messages associated with the request URI and representation metadata, using
 the `Content-Digest` field.
 
+`Want-Representation-Digest` and `Want-Content-Digest` are Structured Fields
+List (see {{Section 3.2 of STRUCTURED-FIELDS}}):
+
 ~~~ abnf
-   Want-Digest = 1#want-digest-value
-   Want-Content-Digest = 1#want-digest-value
-   want-digest-value = digest-algorithm [ ";" "q" "=" qvalue]
+   Want-Representation-Digest = sf-dictionary
+   Want-Content-Digest = sf-dictionary
 ~~~
 
-`qvalue` indicates the sender's digest-algorithm preferences.
-{{Section 12.4.2 of SEMANTICS}}) describes  `qvalue` usage and semantics.
-
-Senders can provide multiple digest-algorithm items with the same qvalue.
+Dictionary members convey hashing algorithm preferences (see {{algorithms}}).
+Member-keys convey the hashing algorithm (see {{algorithms}}), member-values convey
+an ascending relative weighted preference between 0 and 10. Member-values MUST
+be of type sf-integer, in the range 0 to 10.
 
 Examples:
 
 ~~~ http-message
-Want-Digest: sha-256
-Want-Digest: sha-512;q=0.3, sha-256;q=1, unixsum;q=0
-Want-Content-Digest: sha-256
-Want-Content-Digest: sha-512;q=0.3, sha-256;q=1, unixsum;q=0
+Want-Representation-Digest: sha-256=1
+Want-Representation-Digest: sha-512=3, sha-256=10, unixsum=0
+Want-Content-Digest: sha-256=1
+Want-Content-Digest: sha-512=3, sha-256=10, unixsum=0
 ~~~
 
 
-# Digest Algorithm Values {#algorithms}
+# Structured Digest Algorithm Registry {#algorithms}
 
-Digest-algorithm values are used to indicate a specific digest computation.
+The "HTTP Structured Digest Algorithm Registry", maintained by IANA at
+<https://www.iana.org/assignments/http-dig-alg/> registers algorithms for use
+with a range of HTTP fields.
 
-~~~ abnf
-   digest-algorithm = token
-~~~
-
-All digest-algorithm token values are case-insensitive
-but lower case is preferred;
-digest-algorithm token values MUST be compared in a case-insensitive fashion.
-
-Every digest-algorithm defines its computation procedure and
-encoding output. Unless specified otherwise, comparison of
-encoded output is case-sensitive.
-
-The "HTTP Digest Algorithm Values Registry",
-maintained by IANA at <https://www.iana.org/assignments/http-dig-alg/> registers
-digest-algorithm values.
 Registrations MUST include the following fields:
 
-Digest algorithm:
-: the token value.
-
-: The registry can be used to reserve token values.
-
-Status:
-: the status of the algorithm
-
-: Use "standard" for standardized algorithms without known problems;
-"experimental" or some other appropriate value
-- e.g., according to the type and status of the primary document
-in which the algorithm is defined;
-"insecure" when the algorithm is insecure;
-"reserved" when Digest algorithm references a reserved token value.
-
-Description:
-: the description of the digest-algorithm and its encoding
-
-Reference:
-: a set of pointers to the primary documents defining the digest-algorithm
-
-The associated encoding for new digest-algorithms MUST either
-be represented as a quoted string
-or MUST NOT include ";" or "," in the character sets used for the encoding.
+ - Algorithm: a friendly name of the algorithm
+ - Description: a short description of the algorithm
+ - Algorithm Key: the Structured Fields key value used in
+   `Representation-Digest`, `Content-Digest`, `Want-Representation-Digest` or
+    `Want-Content-Digest` field Dictionary member keys
+ - Status: the status of the algorithm.
+     Use "standard" for standardized algorithms without known problems;
+     "experimental" or some other appropriate value
+     - e.g. according to the type and status of the primary document
+     in which the algorithm is defined;
+     "insecure" when the algorithm is insecure;
+     "reserved" when the algorithm references a reserved token value
+ - Reference: a set of pointers to the primary documents defining the algorithm
+   and key
 
 Insecure digest algorithms MAY be used to preserve integrity against corruption, but MUST
 NOT be used in a potentially adversarial setting; for example, when signing digest fields' values for
 authenticity.
 
-The registry is initialized with the tokens listed below.
+The registry is initialized with the algorithms listed below.
 
   {: vspace="0"}
-  sha-512
-  : * Digest Algorithm: sha-512
+  SHA-512
+  : * Algorithm: SHA-512
     * Description: The SHA-512 algorithm [RFC6234].
-      The output of this algorithm is encoded using base64 [RFC4648].
+    * Algorithm Key: sha-512
     * Reference: [RFC6234], [RFC4648], this document.
     * Status: standard
 
-  sha-256
-  : * Digest Algorithm: sha-256
+  SHA-256
+  : * Algorithm: SHA-256
     * Description: The SHA-256 algorithm [RFC6234].
-      The output of this algorithm is encoded using base64 [RFC4648].
+    * Algorithm Key: sha-256
     * Reference: [RFC6234], [RFC4648], this document.
     * Status: standard
 
-  md5
-  : * Digest Algorithm: md5
+  MD5
+  : * Algorithm: md5
     * Description: The MD5 algorithm [RFC1321].
-      The output of this algorithm is encoded using base64 [RFC4648].
-      This digest-algorithm is now vulnerable
+      This algorithm is now vulnerable
       to collision attacks. See {{?NO-MD5=RFC6151}} and [CMU-836068].
+    * Algorithm Key: md5
     * Reference: [RFC1321], [RFC4648], this document.
     * Status: insecure
 
-  sha
-  : * Digest Algorithm: sha
+  SHA
+  : * Algorithm: SHA
     * Description:  The SHA-1 algorithm [RFC3174].
-      The output of this algorithm is encoded using base64 [RFC4648].
-      This digest-algorithm is now vulnerable
+      This algorithm is now vulnerable
       to collision attacks. See {{?NO-SHA1=RFC6194}} and [IACR-2020-014].
+    * Algorithm Key: sha
     * Reference: [RFC3174], [RFC6234], [RFC4648], this document.
     * Status: insecure
 
-  unixsum
-  : * Digest Algorithm: unixsum
+  UNIXSUM
+  : * Algorithm: UNIXSUM
     * Description: The algorithm used by the UNIX "sum" command [UNIX].
-      The output of this algorithm is an
-      ASCII decimal-digit string representing the 16-bit
-      checksum, which is the first word of the output of
-      the UNIX "sum" command.
+    * Algorithm Key: unixsum
     * Reference: [UNIX], this document.
     * Status: insecure
 
-  unixcksum
-  : * Digest Algorithm: unixcksum
+  UNIXCKSUM
+  : * Algorithm: UNIXCKSUM
     * Description: The algorithm used by the UNIX "cksum" command [UNIX].
-      The output of this algorithm is an
-      ASCII digit string representing the 32-bit CRC,
-      which is the first word of the output of the UNIX
-      "cksum" command.
+    * Algorithm Key: unixcksum
     * Reference: [UNIX], this document.
     * Status: insecure
 
-  adler32
-  : * Digest Algorithm: adler32
+  ADLER
+  : * Algorithm: ADLER32
     * Description: The ADLER32 algorithm [RFC1950].
-      The 32-bit output is encoded in hexadecimal (using
-      between 1 and 8 ASCII characters from 0-9, A-F, and a-f; leading 0's are
-      allowed). For example, adler32=03da0195 and adler32=3DA0195 are both valid
-      checksums for the 4-byte message "Wiki". This algorithm is obsoleted and
-      SHOULD NOT be used.
+    * Algorithm Key: adler32
     * Reference: [RFC1950], this document.
     * Status: insecure
 
-  crc32c
-  : * Digest Algorithm: crc32c
+  CRC32C
+  : * Algorithm: CRC32C
     * Description: The CRC32c algorithm {{!RFC4960}}.
-      The 32-bit output is encoded in hexadecimal (using between 1 and 8
-      ASCII characters from 0-9, A-F, and a-f; leading 0's are allowed). For
-      example, crc32c=0a72a4df and crc32c=A72A4DF are both valid checksums for the
-      3-byte message "dog".
+    * Algorithm Key: crc32c
     * Reference: {{!RFC4960}} appendix B, this document.
     * Status: insecure
 
-# Using Digest in State-Changing Requests {#state-changing-requests}
+# Using Representation-Digest in State-Changing Requests {#state-changing-requests}
 
 When the representation enclosed in a state-changing request
 does not describe the target resource,
@@ -512,18 +471,18 @@ representation metadata (see {{representation-digest}}).
 In responses,
 
 - if the representation describes the status of the request,
-  `Digest` MUST be computed on the enclosed representation
+  `Representation-Digest` MUST be computed on the enclosed representation
    (see {{post-referencing-status}} );
 
 - if there is a referenced resource
-  `Digest` MUST be computed on the selected representation of the referenced resource
+  `Representation-Digest` MUST be computed on the selected representation of the referenced resource
    even if that is different from the target resource.
-   That might or might not result in computing `Digest` on the enclosed representation.
+   That might or might not result in computing `Representation-Digest` on the enclosed representation.
 
 The latter case is done according to the HTTP semantics of the given
 method, for example using the `Content-Location` header field (see {{Section 8.7 of
 SEMANTICS}}).
-In contrast, the `Location` header field does not affect `Digest` because
+In contrast, the `Location` header field does not affect `Representation-Digest` because
 it is not representation metadata.
 
 For example, in PATCH requests, the representation digest
@@ -533,16 +492,16 @@ to the target resource (see {{Section 2 of PATCH}}).
 In responses, instead, the representation digest will be computed on the selected
 representation of the patched resource.
 
-## Digest and Content-Location in Responses {#digest-and-content-location}
+## Representation-Digest and Content-Location in Responses {#digest-and-content-location}
 
 When a state-changing method returns the `Content-Location` header field, the
 enclosed representation refers to the resource identified by its value and
-`Digest` is computed accordingly. An example is given in {{post-not-request-uri}}.
+`Representation-Digest` is computed accordingly. An example is given in {{post-not-request-uri}}.
 
 
 # Security Considerations
 
-## Digest Does Not Protect the Full HTTP Message
+## HTTP Messages are not protected in full
 
 This document specifies a data integrity mechanism that protects HTTP
 `representation data` or content, but not HTTP header and trailer fields, from
@@ -552,16 +511,16 @@ Digest fields are not intended to be a general protection against malicious tamp
 HTTP messages. This can be achieved by combining it with other approaches such
 as transport-layer security or digital signatures.
 
-## Digest for End-to-End Integrity
+## End-to-End Integrity
 
-Digest fields can help detect `representation data` or content modification due to implementation errors,
+Representation-Digest and Content-Digest can help detect `representation data` or content modification due to implementation errors,
 undesired "transforming proxies" (see {{Section 7.7 of SEMANTICS}})
 or other actions as the data passes across multiple hops or system boundaries.
 Even a simple mechanism for end-to-end `representation data` integrity is valuable
 because user-agent can validate that resource retrieval succeeded before handing off to a
 HTML parser, video player etc. for parsing.
 
-Note that using digest fields alone does not provide end-to-end integrity of HTTP messages over
+Note that using these mechanisms alone does not provide end-to-end integrity of HTTP messages over
 multiple hops, since metadata could be manipulated at any stage. Methods to protect
 metadata are discussed in {{usage-in-signatures}}.
 
@@ -570,20 +529,22 @@ metadata are discussed in {{usage-in-signatures}}.
 Digital signatures are widely used together with checksums to provide the
 certain identification of the origin of a message [NIST800-32]. Such signatures
 can protect one or more HTTP fields and there are additional considerations when
-digest fields are included in this set.
+`Representation-Digest` or `Content-Digest` is included in this set.
 
-Since digest fields are checksums of resource representations, they explicitly
+Checksums explicitly
 depend on the "representation metadata" (e.g. the values of `Content-Type`,
-`Content-Encoding` etc). A signature that protects `Digest` but not other
+`Content-Encoding` etc). A signature that protects `Representation-Digest` but not other
 "representation metadata" can expose the communication to tampering. For
 example, an actor could manipulate the `Content-Type` field-value and cause a
 digest validation failure at the recipient, preventing the application from
 accessing the representation. Such an attack consumes the resources of both
 endpoints. See also {{digest-and-content-location}}.
 
-Since signatures are meant to protect against adversarial use cases,
-insecure and collision-prone algorithms do not provide adequate guarantees
-(see {{algorithms}}).
+Digest fields SHOULD always be used over a connection that provides integrity at
+the transport layer that protects HTTP fields.
+
+A `Representation-Digest` field using NOT RECOMMENDED hashing algorithms SHOULD NOT be used in
+signatures.
 
 Using signatures to protect the checksum of an empty representation
 allows receiving endpoints to detect if an eventual payload has been stripped or added.
@@ -602,7 +563,7 @@ When digest fields are used in a trailer section, the field-values are received 
 Eager processing of content before the trailer section prevents digest validation, possibly leading to
 processing of invalid data.
 
-Not every digest-algorithm is suitable for use in the trailer section, some may require to pre-process
+Not every hashing algorithm is suitable for use in the trailer section, some may require to pre-process
 the whole payload before sending a message (e.g. see {{?I-D.thomson-http-mice}}).
 
 ## Usage with Encryption
@@ -613,43 +574,29 @@ a proof of integrity "at rest" unless the whole (e.g. encoded) content is persis
 
 ## Algorithm Agility
 
-The security properties of digest-algorithms are not fixed.
+The security properties of hashing algorithms are not fixed.
 Algorithm Agility (see {{?RFC7696}}) is achieved by providing implementations with flexibility
-choose digest-algorithms from the IANA Digest Algorithm Values registry in
+to choose hashing algorithms from the IANA HTTP Structured Digest Algorithm Values registry in
 {{iana-digest-algorithm-registry}}.
 
 To help endpoints distinguish weaker algorithms from stronger ones,
 this document adds to the IANA Digest Algorithm Values registry
-a new "Status" field containing the most recent appraisal of the digest-algorithm.
+a new "Status" field containing the most recent appraisal of the hashing algorithm.
 
 An endpoint might have a preference for algorithms,
 such as preferring "standard" algorithms over "insecure" ones.
 Transition from weak algorithms is supported
-by negotiation of digest-algorithm using `Want-Digest` or `Want-Content-Digest` (see {{want-fields}})
+by negotiation of hashing algorithm using `Want-Representation-Digest` or `Want-Content-Digest` (see {{want-fields}})
 or by sending multiple representation-data-digest values from which the receiver chooses.
 Endpoints are advised that sending multiple values consumes resources,
-which may be wasted if the receiver ignores them (see {{digest}}).
+which may be wasted if the receiver ignores them (see {{representation-digest}}).
 
 While algorithm agility allows the migration to stronger algorithms
 it does not prevent the use of weaker algorithms.
-Digest fields do not provide any mitigiations for downgrade or substitution
-attacks (see Section 1 of {{?RFC6211}}) of the digest-algorithm.
+Integrity fields do not provide any mitigiations for downgrade or substitution
+attacks (see Section 1 of {{?RFC6211}}) of the hashing algorithm.
 To protect against such attacks, endpoints could restrict their set of supported algorithms
 to stronger ones and protect the fields value by using TLS and/or digital signatures.
-
-## Duplicate digest-algorithm in field value
-
-An endpoint might receive multiple representation-data-digest values (see {{digest}}) that use the same digest-algorithm with different or identical digest-values. For example:
-
-~~~ example
-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=,
-        sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
-~~~
-
-A receiver is permitted to ignore any representation-data-digest value,
-so validation of duplicates is left as an implementation decision.
-Endpoints might select all, some, or none of the values for checksum comparison and,
-based on the intersection of those results, conditionally pass or fail digest validation.
 
 ## Resource exhaustion
 
@@ -659,79 +606,27 @@ validation of the algorithm types, number of validations, or the size of content
 
 # IANA Considerations
 
-## Establish the HTTP Digest Algorithm Values Registry {#iana-digest-algorithm-registry}
+## Establish the HTTP Structured Digest Algorithm Values Registry {#iana-digest-algorithm-registry}
 
-This memo sets this specification to be the establishing document for the [HTTP Digest
-Algorithm
-Values](https://www.iana.org/assignments/http-dig-alg/) registry.
+This memo sets this specification to be the establishing document for the [HTTP Structured Digest
+Algorithm](https://www.iana.org/assignments/http-structured-dig-alg/) registry.
 
-IANA is asked to update the "Reference" for this registry
-to refer this document
-and to inizialize the registry with the tokens
+IANA is asked to initialize the registry with the tokens
 defined in {{algorithms}}.
 
 This registry uses the Specification
 Required policy ({{Section 4.6 of !RFC8126}}).
 
+## Representation-Digest Field Registration
 
-## Obsolete "contentMD5" token in Digest Algorithm {#iana-contentMD5}
-
-This memo adds the "contentMD5" token in the [HTTP Digest Algorithm
-Values](https://www.iana.org/assignments/http-dig-alg/)
-registry:
-
-* Digest Algorithm: contentMD5
-* Description: {{Section 5 of RFC3230}} defined the "contentMD5" token to be used only in Want-Digest.
-  This token is obsoleted by this document.
-* Reference: {{iana-contentMD5}} of this document, {{Section 5 of RFC3230}}.
-* Status: obsoleted
-
-## Changes Compared to RFC3230
-
-The `contentMD5` digest-algorithm token defined in {{Section 5 of RFC3230}}
-has been added to the HTTP Digest Algorithm Values Registry with the "obsoleted" status.
-
-All digest-algorithms defined in [RFC3230] are now "insecure".
-
-## Changes Compared to RFC5843
-
-The digest-algorithm tokens for "MD5", "SHA", "SHA-256", "SHA-512" have been updated to lowercase.
-
-The status of "MD5" and "SHA" has been updated to "insecure", and their description
-has been modified accordingly.
-
-## Want-Digest Field Registration
-
-This section registers the `Want-Digest` field in the "Hypertext Transfer
-Protocol (HTTP) Field Name Registry" {{SEMANTICS}}.
-
-Field name:  `Want-Digest`
-
-Status:  permanent
-
-Specification document(s):  {{want-fields}} of this document
-
-## Digest Field Registration
-
-This section registers the `Digest` field in the "Hypertext Transfer Protocol
+This section registers the `Representation-Digest` field in the "Hypertext Transfer Protocol
 (HTTP) Field Name Registry" {{SEMANTICS}}.
 
-Field name:  `Digest`
+Field name:  `Representation-Digest`
 
 Status:  permanent
 
-Specification document(s):  {{digest}} of this document
-
-## Want-Content-Digest Field Registration
-
-This section registers the `Want-Content-Digest` field in the "Hypertext Transfer
-Protocol (HTTP) Field Name Registry" {{SEMANTICS}}.
-
-Field name:  `Want-Content-Digest`
-
-Status:  permanent
-
-Specification document(s):  {{want-fields}} of this document
+Specification document(s):  {{representation-digest}} of this document
 
 ## Content-Digest Field Registration
 
@@ -743,6 +638,28 @@ Field name:  `Content-Digest`
 Status:  permanent
 
 Specification document(s):  {{content-digest}} of this document
+
+## Want-Representation-Digest Field Registration
+
+This section registers the `Want-Representation-Digest` field in the "Hypertext Transfer
+Protocol (HTTP) Field Name Registry" {{SEMANTICS}}.
+
+Field name:  `Want-Representation-Digest`
+
+Status:  permanent
+
+Specification document(s):  {{want-fields}} of this document
+
+## Want-Content-Digest Field Registration
+
+This section registers the `Want-Content-Digest` field in the "Hypertext Transfer
+Protocol (HTTP) Field Name Registry" {{SEMANTICS}}.
+
+Field name:  `Want-Content-Digest`
+
+Status:  permanent
+
+Specification document(s):  {{want-fields}} of this document
 
 --- back
 
@@ -853,8 +770,8 @@ Location: /authors/123
 # Examples of Unsolicited Digest {#examples-unsolicited}
 
 The following examples demonstrate interactions where a server responds with a
-`Digest` or `Content-Digest` fields even though the client did not solicit one using
-`Want-Digest` or `Want-Content-Digest`.
+`Representation-Digest` or `Content-Digest` fields even though the client did not solicit one using
+`Want-Representation-Digest` or `Want-Content-Digest`.
 
 Some examples include JSON objects in the content.
 For presentation purposes, objects that fit completely within the line-length limits
@@ -866,12 +783,12 @@ Checksum mechanisms defined in this document are media-type agnostic
 and do not provide canonicalization algorithms for specific formats.
 Examples are calculated inclusive of any space.
 While examples can include both fields,
-`Digest` and `Content-Digest` can be returned independently.
+`Representation-Digest` and `Content-Digest` can be returned independently.
 
 ## Server Returns Full Representation Data {#example-full-representation}
 
 In this example, the message content conveys complete representation data,
-so `Digest` and `Content-Digest` have the same value.
+so `Representation-Digest` and `Content-Digest` have the same value.
 
 ~~~ http-message
 GET /items/123 HTTP/1.1
@@ -883,8 +800,8 @@ Host: foo.example
 ~~~ http-message
 HTTP/1.1 200 OK
 Content-Type: application/json
-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-Content-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Content-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 {"hello": "world"}
 ~~~
@@ -895,7 +812,7 @@ Content-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
 In this example, a HEAD request is used to retrieve the checksum
 of a resource.
 
-The response `Digest` field-value is calculated over the JSON object
+The response `Representation-Digest` field-value is calculated over the JSON object
 `{"hello": "world"}`, which is not shown because there is no payload
 data.
 `Content-Digest` is computed on empty content.
@@ -910,8 +827,8 @@ Host: foo.example
 ~~~ http-message
 HTTP/1.1 200 OK
 Content-Type: application/json
-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-Content-Digest: sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Content-Digest: sha-256=:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=:
 
 ~~~
 {: title="Response with both Content-Digest and Digest; empty content"}
@@ -919,7 +836,7 @@ Content-Digest: sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
 ## Server Returns Partial Representation Data
 
 In this example, the client makes a range request and the server responds with
-partial content. The `Digest` field-value represents the entire JSON object
+partial content. The `Representation-Digest` field-value represents the entire JSON object
 `{"hello": "world"}`, while the `Content-Digest` field-value is computed on the
 message content `"hello"`.
 
@@ -935,8 +852,8 @@ Range: bytes=1-7
 HTTP/1.1 206 Partial Content
 Content-Type: application/json
 Content-Range: bytes 1-7/18
-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
-Content-Digest: sha-256=Wqdirjg/u3J688ejbUlApbjECpiUUtIwT8lY/z81Tno=
+Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+Content-Digest: sha-256=:Wqdirjg/u3J688ejbUlApbjECpiUUtIwT8lY/z81Tno=:
 
 "hello"
 ~~~
@@ -945,12 +862,12 @@ Content-Digest: sha-256=Wqdirjg/u3J688ejbUlApbjECpiUUtIwT8lY/z81Tno=
 
 ## Client and Server Provide Full Representation Data
 
-The request contains a `Digest` field-value calculated on the enclosed
+The request contains a `Representation-Digest` field-value calculated on the enclosed
 representation. It also includes an `Accept-Encoding: br` header field that advertises the
 client supports Brotli encoding.
 
 The response includes a `Content-Encoding: br` that indicates the selected
-representation is Brotli-encoded. The `Digest` field-value is therefore
+representation is Brotli-encoded. The `Representation-Digest` field-value is therefore
 different compared to the request.
 
 For presentation purposes, the response body is displayed as a Base64-encoded string because it contains
@@ -961,7 +878,7 @@ PUT /items/123 HTTP/1.1
 Host: foo.example
 Content-Type: application/json
 Accept-Encoding: br
-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+Representation-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
 
 {"hello": "world"}
 ~~~
@@ -973,7 +890,7 @@ Content-Type: application/json
 Content-Location: /items/123
 Content-Encoding: br
 Content-Length: 22
-Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=
+Representation-Digest: sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:
 
 iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 ~~~
@@ -982,9 +899,9 @@ iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 
 ## Client Provides Full Representation Data, Server Provides No Representation Data
 
-The request `Digest` field-value is calculated on the enclosed payload.
+The request `Representation-Digest` field-value is calculated on the enclosed payload.
 
-The response `Digest` field-value
+The response `Representation-Digest` field-value
 depends on the representation metadata header fields, including
 `Content-Encoding: br` even when the response does not contain content.
 
@@ -995,7 +912,7 @@ Host: foo.example
 Content-Type: application/json
 Content-Length: 18
 Accept-Encoding: br
-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 {"hello": "world"}
 ~~~
@@ -1005,7 +922,7 @@ Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
 HTTP/1.1 204 No Content
 Content-Type: application/json
 Content-Encoding: br
-Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=
+Representation-Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=
 
 ~~~
 {: title="Empty response with Digest"}
@@ -1022,7 +939,7 @@ PUT /items/123 HTTP/1.1
 Host: foo.example
 Content-Type: application/json
 Accept-Encoding: br
-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 {"hello": "world"}
 ~~~
@@ -1033,9 +950,9 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Encoding: br
 Content-Location: /items/123
-Digest: sha-256=4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=,
-        sha-512=pxo7aYzcGI88pnDnoSmAnaOEVys0MABhgvHY9+VI+ElE6
-                0jBCwnMPyA/s3NF3ZO5oIWA7lf8ukk+\n5KJzm3p5og==
+Representation-Digest: sha-256=:4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=:,
+        sha-512=:pxo7aYzcGI88pnDnoSmAnaOEVys0MABhgvHY9+VI+ElE6
+                0jBCwnMPyA/s3NF3ZO5oIWA7lf8ukk+\n5KJzm3p5og==:
 
 iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 ~~~
@@ -1043,11 +960,11 @@ iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 
 ## POST Response does not Reference the Request URI {#post-not-request-uri}
 
-The request `Digest` field-value is computed on the enclosed representation (see
+The request `Representation-Digest` field-value is computed on the enclosed representation (see
 {{state-changing-requests}}).
 
 The representation enclosed in the response refers to the resource identified by
-`Content-Location` (see {{Section 6.4.2 of SEMANTICS}}). `Digest` is thus computed on the enclosed representation.
+`Content-Location` (see {{Section 6.4.2 of SEMANTICS}}). `Representation-Digest` is thus computed on the enclosed representation.
 
 ~~~ http-message
 POST /books HTTP/1.1
@@ -1055,7 +972,7 @@ Host: foo.example
 Content-Type: application/json
 Accept: application/json
 Accept-Encoding: identity
-Digest: sha-256=bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=
+Representation-Digest: sha-256=:bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=:
 
 {"title": "New Title"}
 ~~~
@@ -1066,7 +983,7 @@ HTTP/1.1 201 Created
 Content-Type: application/json
 Content-Location: /books/123
 Location: /books/123
-Digest: sha-256=yxOAqEeoj+reqygSIsLpT0LhumrNkIds5uLKtmdLyYE=
+Representation-Digest: sha-256=:yxOAqEeoj+reqygSIsLpT0LhumrNkIds5uLKtmdLyYE=:
 
 {
   "id": "123",
@@ -1076,18 +993,18 @@ Digest: sha-256=yxOAqEeoj+reqygSIsLpT0LhumrNkIds5uLKtmdLyYE=
 {: title="Response with Digest of Resource"}
 
 Note that a `204 No Content` response without content but with the same
-`Digest` field-value would have been legitimate too.
+`Representation-Digest` field-value would have been legitimate too.
 In that case, `Content-Digest` would have been computed on an empty content.
 
 ## POST Response Describes the Request Status {#post-referencing-status}
 
-The request `Digest` field-value is computed on the enclosed representation (see
+The request `Representation-Digest` field-value is computed on the enclosed representation (see
 {{state-changing-requests}}).
 
 The representation enclosed in the response describes the status of the request,
-so `Digest` is computed on that enclosed representation.
+so `Representation-Digest` is computed on that enclosed representation.
 
-Response `Digest` has no explicit relation with the resource referenced by
+Response `Representation-Digest` has no explicit relation with the resource referenced by
 `Location`.
 
 ~~~ http-message
@@ -1096,7 +1013,7 @@ Host: foo.example
 Content-Type: application/json
 Accept: application/json
 Accept-Encoding: identity
-Digest: sha-256=bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=
+Representation-Digest: sha-256=:bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=:
 
 {"title": "New Title"}
 ~~~
@@ -1105,7 +1022,7 @@ Digest: sha-256=bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=
 ~~~ http-message
 HTTP/1.1 201 Created
 Content-Type: application/json
-Digest: sha-256=2LBp5RKZGpsSNf8BPXlXrX4Td4Tf5R5bZ9z7kdi5VvY=
+Representation-Digest: sha-256=:2LBp5RKZGpsSNf8BPXlXrX4Td4Tf5R5bZ9z7kdi5VvY=:
 Location: /books/123
 
 {
@@ -1126,10 +1043,10 @@ effective request URI.
 The PATCH request uses the `application/merge-patch+json` media type defined in
 {{?RFC7396}}.
 
-`Digest` is calculated on the enclosed payload, which corresponds to the patch
+`Representation-Digest` is calculated on the enclosed payload, which corresponds to the patch
 document.
 
-The response `Digest` field-value is computed on the complete representation of the patched
+The response `Representation-Digest` field-value is computed on the complete representation of the patched
 resource.
 
 ~~~ http-message
@@ -1138,7 +1055,7 @@ Host: foo.example
 Content-Type: application/merge-patch+json
 Accept: application/json
 Accept-Encoding: identity
-Digest: sha-256=bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=
+Representation-Digest: sha-256=:bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=:
 
 {"title": "New Title"}
 ~~~
@@ -1147,7 +1064,7 @@ Digest: sha-256=bWopGGNiZtbVgHsG+I4knzfEJpmmmQHf7RHDXA3o1hQ=
 ~~~ http-message
 HTTP/1.1 200 OK
 Content-Type: application/json
-Digest: sha-256=yxOAqEeoj+reqygSIsLpT0LhumrNkIds5uLKtmdLyYE=
+Representation-Digest: sha-256=:yxOAqEeoj+reqygSIsLpT0LhumrNkIds5uLKtmdLyYE=:
 
 {
   "id": "123",
@@ -1157,7 +1074,7 @@ Digest: sha-256=yxOAqEeoj+reqygSIsLpT0LhumrNkIds5uLKtmdLyYE=
 {: title="Response with Digest of Representation"}
 
 Note that a `204 No Content` response without content but with the same
-`Digest` field-value would have been legitimate too.
+`Representation-Digest` field-value would have been legitimate too.
 
 ## Error responses
 
@@ -1169,12 +1086,12 @@ patch the resource located at /books/123. However, the resource does not exist
 and the server generates a 404 response with a body that describes the error in
 accordance with {{?RFC7807}}.
 
-The response `Digest` field-value is computed on this enclosed representation.
+The response `Representation-Digest` field-value is computed on this enclosed representation.
 
 ~~~ http-message
 HTTP/1.1 404 Not Found
 Content-Type: application/problem+json
-Digest: sha-256=KPqhVXAT25LLitV1w0O167unHmVQusu+fpxm65zAsvk=
+Representation-Digest: sha-256=:KPqhVXAT25LLitV1w0O167unHmVQusu+fpxm65zAsvk=:
 
 {
   "title": "Not Found",
@@ -1186,9 +1103,9 @@ Digest: sha-256=KPqhVXAT25LLitV1w0O167unHmVQusu+fpxm65zAsvk=
 
 ## Use with Trailer Fields and Transfer Coding
 
-An origin server sends `Digest` as trailer field, so it can calculate digest-value
+An origin server sends `Representation-Digest` as trailer field, so it can calculate digest-value
 while streaming content and thus mitigate resource consumption.
-The `Digest` field-value is the same as in {{example-full-representation}} because `Digest` is designed to
+The `Representation-Digest` field-value is the same as in {{example-full-representation}} because `Representation-Digest` is designed to
 be independent from the use of one or more transfer codings (see {{representation-digest}}).
 
 ~~~ http-message
@@ -1211,16 +1128,16 @@ Trailer: Digest
 2\r\n
 "}\r\n
 0\r\n
-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 ~~~
 {: title="Chunked Response with Digest"}
 
 
-# Examples of Want-Digest Solicited Digest {#examples-solicited}
+# Examples of Want-Representation-Digest Solicited Digest {#examples-solicited}
 
 The following examples demonstrate interactions where a client solicits a
-`Digest` using `Want-Digest`.
+`Representation-Digest` using `Want-Representation-Digest`.
 The behavior of `Content-Digest` and `Want-Content-Digest` is identical.
 
 Some examples include JSON objects in the content.
@@ -1241,15 +1158,15 @@ The client requests a digest, preferring "sha". The server is free to reply with
 ~~~ http-message
 GET /items/123 HTTP/1.1
 Host: foo.example
-Want-Digest: sha-256;q=0.3, sha;q=1
+Want-Representation-Digest: sha-256=3, sha=10
 
 ~~~
-{: title="GET Request with Want-Digest"}
+{: title="GET Request with Want-Representation-Digest"}
 
 ~~~ http-message
 HTTP/1.1 200 OK
 Content-Type: application/json
-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+Representation-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
 
 {"hello": "world"}
 ~~~
@@ -1264,16 +1181,16 @@ digest, it instead uses a different algorithm.
 ~~~ http-message
 GET /items/123 HTTP/1.1
 Host: foo.example
-Want-Digest: sha;q=1
+Want-Representation-Digest: sha=1
 
 ~~~
-{: title="GET Request with Want-Digest"}
+{: title="GET Request with Want-Representation-Digest"}
 
 ~~~ http-message
 HTTP/1.1 200 OK
 Content-Type: application/json
-Digest: sha-512=WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
-                +AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==
+Representation-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
+                +AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew==:
 
 {"hello": "world"}
 ~~~
@@ -1285,7 +1202,7 @@ Digest: sha-512=WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm
 the client's preferred digest algorithm. Alternatively a server can also reject
 the request and return an error.
 
-In this example, the client requests a "sha" `Digest`, and the server returns an
+In this example, the client requests a "sha" `Representation-Digest`, and the server returns an
 error with problem details {{?RFC7807}} contained in the content. The problem
 details contain a list of the digest algorithms that the server supports. This
 is purely an example, this specification does not define any format or
@@ -1294,10 +1211,10 @@ requirements for such content.
 ~~~ http-message
 GET /items/123 HTTP/1.1
 Host: foo.example
-Want-Digest: sha;q=1
+Want-Representation-Digest: sha=1
 
 ~~~
-{: title="GET Request with Want-Digest"}
+{: title="GET Request with Want-Representation-Digest"}
 
 ~~~ http-message
 HTTP/1.1 400 Bad Request
@@ -1305,7 +1222,7 @@ Content-Type: application/problem+json
 
 {
   "title": "Bad Request",
-  "detail": "Supported digest-algorithms: sha-256, sha-512",
+  "detail": "Supported hashing algorithms: sha-256, sha-512",
   "status": 400
 }
 ~~~
@@ -1314,9 +1231,9 @@ Content-Type: application/problem+json
 
 # Acknowledgements
 {:numbered="false"}
-The vast majority of this document is inherited from [RFC3230], so thanks
+This document is based on ideas from [RFC3230], so thanks
 to J. Mogul and A. Van Hoff for their great work.
-The original idea of refreshing this document arose from an interesting
+The original idea of refreshing RFC3230 arose from an interesting
 discussion with M. Nottingham, J. Yasskin and M. Thomson when reviewing
 the MICE content coding.
 
@@ -1332,70 +1249,12 @@ Sean Turner,
 and Erik Wilde.
 
 
-
-
-
-
-# FAQ
-{:numbered="false"}
-
-_RFC Editor: Please remove this section before publication._
-
-1. Why remove all references to content-md5?
-
-   Those were unnecessary to understanding and using this specification.
-
-2. Why remove references to instance manipulation?
-
-   Those were unnecessary for correctly using and applying the specification. An example
-   with Range Request is more than enough. This document uses the term "partial
-   representation" which should group all those cases.
-
-3. How to use `Digest` with `PATCH` method?
-
-   See {{state-changing-requests}}.
-
-4. Why remove references to delta-encoding?
-
-   Unnecessary for a correct implementation of this specification. The revised specification can
-   be nicely adapted to "delta encoding", but all the references here to delta
-   encoding don't add anything to this RFC. Another job would be to refresh
-   delta encoding.
-
-5. Why remove references to Digest Authentication?
-
-   This specification seems to me completely unrelated to Digest Authentication but for
-   the word "Digest".
-
-6. What changes in `Want-Digest`?
-
-   The contentMD5 token defined in {{Section 5 of RFC3230}} is deprecated by this document.
-
-7. Does this specification change supported algorithms?
-
-   Yes. This RFC updates [RFC5843] which is still delegated for all algorithms
-   updates.
-   To simplify a future transition to Structured Fields {{?RFC8941}}
-   we suggest to use lowercase for digest-algorithms.
-
-8. What about mid-stream trailer fields?
-
-   While
-   [mid-stream trailer fields](https://github.com/httpwg/http-core/issues/313#issuecomment-584389706)
-   are interesting, since this specification is a rewrite of [RFC3230] we do not
-   think we should face that. As a first thought, nothing in this document
-   precludes future work that would find a use for mid-stream trailers
-   with specific algorithms.
-   A document defining such a
-   digest-algorithm is best positioned to describe how it is used.
-
-
 # Code Samples
 {:numbered="false"}
 
 _RFC Editor: Please remove this section before publication._
 
-How can I generate and validate the `Digest` values shown in the examples
+How can I generate and validate the `Representation-Digest` values shown in the examples
 throughout this document?
 
 The following python3 code can be used to generate digests for JSON objects
@@ -1424,21 +1283,21 @@ def digest(item, encoding=lambda x: x, algorithm=hashlib.sha256):
 
 item = {"hello": "world"}
 
-print("Encoding | digest-algorithm | digest-value")
+print("Encoding | hashing algorithm | digest-value")
 print("Identity | sha256 |", digest(item))
-# Encoding | digest-algorithm | digest-value
+# Encoding | hashing algorithm | digest-value
 # Identity | sha256 | X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
 
-print("Encoding | digest-algorithm | digest-value")
+print("Encoding | hashing algorithm | digest-value")
 print("Brotli | sha256 |", digest(item, encoding=brotli.compress))
-# Encoding | digest-algorithm | digest-value
+# Encoding | hashing algorithm | digest-value
 # Brotli | sha256 | 4REjxQ4yrqUVicfSKYNO/cF9zNj5ANbzgDZt3/h3Qxo=
 
-print("Encoding | digest-algorithm | digest-value")
+print("Encoding | hashing algorithm | digest-value")
 print("Identity | sha512 |", digest(item, algorithm=hashlib.sha512))
 print("Brotli | sha512 |", digest(item, algorithm=hashlib.sha512,
                                     encoding=brotli.compress))
-# Encoding | digest-algorithm | digest-value
+# Encoding | hashing algorithm | digest-value
 # Identity | sha512 |b'WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm'
 #                     '+AbwAgBWnrIiYllu7BNNyealdVLvRwE\nmTHWXvJwew=='
 # Brotli | sha512 | b'pxo7aYzcGI88pnDnoSmAnaOEVys0MABhgvHY9+VI+ElE6'

--- a/sf.json
+++ b/sf.json
@@ -19,5 +19,9 @@
     "example-token": "item",
     "example-bytesequence": "item",
     "example-boolean": "item",
-    "cdn-cache-control": "dict"
+    "cdn-cache-control": "dict",
+    "representation-digest": "dict",
+    "content-digest": "dict",
+    "want-representation-digest": "dict",
+    "want-content-digest": "dict"
 }


### PR DESCRIPTION
This PR attempts to capture my interpretation of the discussion during the HTTP Interim meeting Feb 2022. Editorial judgement has been applied with judicious KISS.

Executive summary:

1. Obsolete 3230.
  *  The suggestion was to put this in an appendix. However, if we are obsoleting Digest, I don't see much benefit in talking through many details. Stop using it and use the substitutes we spend lots of text on. The text ended up as half a page and I kept it in the Introductory section 1
2. Having a mix of sf-dictionary and sf-list that need to reference each other is really annoying. I'm sure there's a way to square the circle about using List items as lookups for Dictionary keys but after already spending hours noodling on it, it seems like an accident waiting to happen.
  * So I cheated. I switched Want-Representation-Digest and Want-Content-Digest to be Dictionaries too. It's just that the member value is an integer between 0 and 10 that expresses a preference weight. (Thanks MT for the suggestion to use int)
  * Using a dictionary here disposes of the 'q' parameter qvalue problem I mentioned in the meeting
3. New IANA table for the new headers
  * This is another slight cheat that lets us avoid updating a table that implementers of an obsolete RFC might still rely on.
  * It imports all the old headers from before, including insecure stuff that people previously said they wanted.

What this doesn't do is bikeshed on the header name. I suggest we try to find consensus on the general changes in the draft and follow up with issues for any bikeshed issues.