### PR TITLE
This is for semantics, not forensics

### DIFF
--- a/draft-ietf-httpbis-binary-message.md
+++ b/draft-ietf-httpbis-binary-message.md
@@ -72,6 +72,12 @@ Two modes for encoding are described:
 * an indefinite-length encoding enables efficient generation of messages where
   lengths are not known when encoding starts.
 
+This format is designed to convey the semantics of valid HTTP messages as simply
+and efficiently as possible.  It is not designed to capture all of the details
+of the encoding of messages from specific HTTP versions ({{MESSAGING}}, {{H2}},
+{{H3}}).  As such, this format is unlikely to be suitable for applications that
+depend on an exact recording of the encoding of messages.
+
 
 # Conventions and Definitions
 


### PR DESCRIPTION
The format is capable of capturing messages, but the design only really supports the expression of the semantics of valid messages.  That makes it unsuitable for applications that need to know exactly what was put on the wire in a given protocol.

Closes #1937.