### PR TITLE
Varints not minimal varints

### DIFF
--- a/draft-ietf-httpbis-binary-message.md
+++ b/draft-ietf-httpbis-binary-message.md
@@ -105,7 +105,8 @@ indicator is added to signal how these parts are composed:
 7. Optional padding. Any amount of zero-valued bytes.
 
 All lengths and numeric values are encoded using the variable-length integer
-encoding from {{Section 16 of QUIC}}.
+encoding from {{Section 16 of QUIC}}.  Integer values do not need to be encoded
+on the minimum number of bytes necessary.
 
 
 ## Known Length Messages


### PR DESCRIPTION
For the avoidance of doubt.

This makes encoding easier if you don't care about wasting a few bytes.

Closes #1943.