### PR TITLE
Fix field length issues

### DIFF
--- a/draft-ietf-httpbis-binary-message.md
+++ b/draft-ietf-httpbis-binary-message.md
@@ -125,7 +125,7 @@ Message with Known-Length {
 }
 
 Known-Length Field Section {
-  Length (i) = 2..,
+  Length (i),
   Field Line (..) ...,
 }
 
@@ -150,8 +150,7 @@ Response messages that contain informational status codes result in a different
 structure; see {{informational}}.
 
 Fields in the header and trailer sections consist of a length-prefixed name and
-length-prefixed value. Both name and value are sequences of bytes that cannot
-be zero length.
+length-prefixed value; see {{fields}}.
 
 The format allows for the message to be truncated before any of the length
 prefixes that precede the field sections or content. This reduces the overall


### PR DESCRIPTION
Closes #1945 by using a citation rather than a redundant and wrong statement.
Closes #1944 by removing the minimum length (zero is totally fine).