### PR TITLE
[6265bis] Require ASCII for domain attributes (fixes #1707)

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -530,7 +530,7 @@ data in a cookie-value SHOULD encode that data, for example, using Base64
 {{RFC4648}}.
 
 The domain-value is a subdomain as defined by {{RFC1034}}, Section 3.5, and
-as enhanced by {{RFC1123}}, Section 2.1. The domain-value MUST be a string of
+as enhanced by {{RFC1123}}, Section 2.1. Thus, domain-value is a string of
 {{USASCII}} characters, such as one obtained by applying the "ToASCII" operation
 defined in {{Section 4 of RFC3490}}.
 
@@ -1473,7 +1473,7 @@ user agent MUST process the cookie as follows:
     1.  Let the domain-attribute be the empty string.
 
 8.  If the domain-attribute contains a character that is not in the range of {{USASCII}}
-    characters (%x00 - %x7F), abort these steps and ignore the cookie entirely.
+    characters, abort these steps and ignore the cookie entirely.
 
 9.  If the user agent is configured to reject "public suffixes" and the
     domain-attribute is a public suffix:

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1475,11 +1475,6 @@ user agent MUST process the cookie as follows:
 8.  If the domain-attribute contains a character that is not in the range of {{USASCII}}
     characters, abort these steps and ignore the cookie entirely.
 
-    NOTE: The user agent MAY also reject any cookies that contain characters not
-    in the LDH (letter, digit, hyphen) range of %x41-5A / %x61-7A / %x30-39 / %x2D,
-    which is the character range of the canonicalized request-host the
-    domain-attribute is compared against.
-
 9.  If the user agent is configured to reject "public suffixes" and the
     domain-attribute is a public suffix:
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -530,7 +530,9 @@ data in a cookie-value SHOULD encode that data, for example, using Base64
 {{RFC4648}}.
 
 The domain-value is a subdomain as defined by {{RFC1034}}, Section 3.5, and
-as enhanced by {{RFC1123}}, Section 2.1.
+as enhanced by {{RFC1123}}, Section 2.1. The domain-value MUST be a string of
+{{USASCII}} characters, such as one obtained by applying the "ToASCII" operation
+defined in {{Section 4 of RFC3490}}.
 
 Per the grammar above, the cookie-value MAY be wrapped in DQUOTE characters.
 Note that in this case, the initial and trailing DQUOTE characters are not
@@ -1470,7 +1472,10 @@ user agent MUST process the cookie as follows:
 
     1.  Let the domain-attribute be the empty string.
 
-8.  If the user agent is configured to reject "public suffixes" and the
+8.  If the domain-attribute contains a character that is not in the range of {{USASCII}}
+    characters (%x00 - %x7F), abort these steps and ignore the cookie entirely.
+
+9.  If the user agent is configured to reject "public suffixes" and the
     domain-attribute is a public suffix:
 
     1.  If the domain-attribute is identical to the canonicalized
@@ -1485,7 +1490,7 @@ user agent MUST process the cookie as follows:
     NOTE: This step prevents `attacker.example` from disrupting the integrity of
     `site.example` by setting a cookie with a Domain attribute of "example".
 
-9.  If the domain-attribute is non-empty:
+10. If the domain-attribute is non-empty:
 
     1.  If the canonicalized request-host does not domain-match the
         domain-attribute:
@@ -1504,29 +1509,29 @@ user agent MUST process the cookie as follows:
 
     2.  Set the cookie's domain to the canonicalized request-host.
 
-10. If the cookie-attribute-list contains an attribute with an
+11. If the cookie-attribute-list contains an attribute with an
     attribute-name of "Path", set the cookie's path to attribute-value of
     the last attribute in the cookie-attribute-list with both an
     attribute-name of "Path" and an attribute-value whose length is no
     more than 1024 octets. Otherwise, set the cookie's path to the
     default-path of the request-uri.
 
-11. If the cookie-attribute-list contains an attribute with an
+12. If the cookie-attribute-list contains an attribute with an
     attribute-name of "Secure", set the cookie's secure-only-flag to true.
     Otherwise, set the cookie's secure-only-flag to false.
 
-12.  If the scheme component of the request-uri does not denote a "secure"
+13.  If the scheme component of the request-uri does not denote a "secure"
     protocol (as defined by the user agent), and the cookie's secure-only-flag
     is true, then abort these steps and ignore the cookie entirely.
 
-13. If the cookie-attribute-list contains an attribute with an
+14. If the cookie-attribute-list contains an attribute with an
     attribute-name of "HttpOnly", set the cookie's http-only-flag to true.
     Otherwise, set the cookie's http-only-flag to false.
 
-14. If the cookie was received from a "non-HTTP" API and the cookie's
+15. If the cookie was received from a "non-HTTP" API and the cookie's
     http-only-flag is true, abort these steps and ignore the cookie entirely.
 
-15. If the cookie's secure-only-flag is false, and the scheme component of
+16. If the cookie's secure-only-flag is false, and the scheme component of
     request-uri does not denote a "secure" protocol, then abort these steps and
     ignore the cookie entirely if the cookie store contains one or more cookies
     that meet all of the following criteria:
@@ -1548,13 +1553,13 @@ user agent MUST process the cookie as follows:
     non-secure cookie named 'a' could be set for a path of '/' or '/foo', but
     not for a path of '/login' or '/login/en'.
 
-16. If the cookie-attribute-list contains an attribute with an
+17. If the cookie-attribute-list contains an attribute with an
     attribute-name of "SameSite", and an attribute-value of "Strict", "Lax", or
     "None", set the cookie's same-site-flag to the attribute-value of the last
     attribute in the cookie-attribute-list with an attribute-name of "SameSite".
     Otherwise, set the cookie's same-site-flag to "Default".
 
-17. If the cookie's `same-site-flag` is not "None":
+18. If the cookie's `same-site-flag` is not "None":
 
     1.  If the cookie was received from a "non-HTTP" API, and the API was called
         from a browsing context's active document whose "site for cookies" is
@@ -1577,14 +1582,14 @@ user agent MUST process the cookie as follows:
 
     4.  Abort these steps and ignore the newly created cookie entirely.
 
-18. If the cookie's "same-site-flag" is "None", abort these steps and ignore the
+19. If the cookie's "same-site-flag" is "None", abort these steps and ignore the
     cookie entirely unless the cookie's secure-only-flag is true.
 
-19. If the cookie-name begins with a case-sensitive match for the string
+20. If the cookie-name begins with a case-sensitive match for the string
     "__Secure-", abort these steps and ignore the cookie entirely unless the
     cookie's secure-only-flag is true.
 
-20. If the cookie-name begins with a case-sensitive match for the string
+21. If the cookie-name begins with a case-sensitive match for the string
     "__Host-", abort these steps and ignore the cookie entirely unless the
     cookie meets all the following criteria:
 
@@ -1595,7 +1600,7 @@ user agent MUST process the cookie as follows:
     3.  The cookie-attribute-list contains an attribute with an attribute-name
         of "Path", and the cookie's path is `/`.
 
-21. If the cookie store contains a cookie with the same name, domain,
+22. If the cookie store contains a cookie with the same name, domain,
     host-only-flag, and path as the newly-created cookie:
 
     1.  Let old-cookie be the existing cookie with the same name, domain,
@@ -1612,7 +1617,7 @@ user agent MUST process the cookie as follows:
 
     4.  Remove the old-cookie from the cookie store.
 
-22. Insert the newly-created cookie into the cookie store.
+23. Insert the newly-created cookie into the cookie store.
 
 A cookie is "expired" if the cookie has an expiry date in the past.
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1475,6 +1475,11 @@ user agent MUST process the cookie as follows:
 8.  If the domain-attribute contains a character that is not in the range of {{USASCII}}
     characters, abort these steps and ignore the cookie entirely.
 
+    NOTE: The user agent MAY also reject any cookies that contain characters not
+    in the LDH (letter, digit, hyphen) range of %x41-5A / %x61-7A / %x30-39 / %x2D,
+    which is the character range of the canonicalized request-host the
+    domain-attribute is compared against.
+
 9.  If the user agent is configured to reject "public suffixes" and the
     domain-attribute is a public suffix:
 


### PR DESCRIPTION
See #1707 for discussion and rationale.

I wasn't entirely sure where to put this new restriction, but it does seem like the UA should parse the domain attribute list and only reject the cookie if the final domain attribute contains invalid characters (as opposed to, say, reject if any domain attribute contains invalid characters). So I went with that.