### PR TITLE
priority: update author name

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -25,7 +25,7 @@ github-issue-label: priorities
 
 author:
   -
-    name:
+    fullname:
       :: 奥一穂
       ascii: Kazuho Oku
     org: Fastly

--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -25,8 +25,9 @@ github-issue-label: priorities
 
 author:
   -
-    ins: K. Oku
-    name: Kazuho Oku
+    name:
+      :: 奥一穂
+      ascii: Kazuho Oku
     org: Fastly
     email: kazuhooku@gmail.com
   -


### PR DESCRIPTION
Note: this is a test of the GitHub CI as much as anything.

kramdown-rfc2629 v 1.5.26 added the ability for non-ascii names in markdown that don't generate XML that xml2rfc would reject.

If you try this locally and see issues, try to update your tools at https://github.com/martinthomson/i-d-template/blob/main/doc/SETUP.md#update
