### PR TITLE
HTTP/1.1(and older)

### DIFF
--- a/draft-ietf-httpbis-priority.md
+++ b/draft-ietf-httpbis-priority.md
@@ -852,10 +852,10 @@ header fields:
 It is common for content delivery network (CDN) infrastructure to support
 different HTTP versions on the front end and back end. For instance, the
 client-facing edge might support HTTP/2 and HTTP/3 while communication to
-backend servers is done using HTTP/1.1. Unlike connection coalescing, the
-CDN will "demux" requests into discrete connections to the back end. HTTP/1.1
-and older do not support response multiplexing in a single connection, so there
-is not a fairness problem. However, backend servers MAY still use client
+backend servers is done using HTTP/1.1. Unlike connection coalescing, the CDN
+will "demux" requests into discrete connections to the back end. Response
+multiplexing in a single connection is not supported by HTTP/1.1 (or older), so
+there is not a fairness problem. However, backend servers MAY still use client
 headers for request scheduling. Backend servers SHOULD only schedule based on
 client priority information where that information can be scoped to individual
 end clients. Authentication and other session information might provide this


### PR DESCRIPTION
Closes #2048 

rephrase multiplexing speak on H1.1 and older
