### PR TITLE
Auth48: Change references from HTTP2 => HTTP/2 and HTTP3 => HTTP/3

### DIFF
--- a/draft-ietf-httpbis-h3-websockets.md
+++ b/draft-ietf-httpbis-h3-websockets.md
@@ -26,8 +26,8 @@ author:
     email: rch@google.com
 
 normative:
-  HTTP3: I-D.draft-ietf-quic-http-34
-  HTTP2: I-D.draft-ietf-httpbis-http2bis-07
+  HTTP/3: I-D.draft-ietf-quic-http-34
+  HTTP/2: I-D.draft-ietf-httpbis-http2bis-07
   HTTP: I-D.draft-ietf-httpbis-semantics-19
 
 informative:
@@ -45,8 +45,8 @@ how the mechanism is adapted for HTTP/3.
 # Introduction
 
 "Bootstrapping WebSockets with HTTP/2" {{!RFC8441}} defines an extension
-to HTTP/2 {{HTTP2}} which is also useful in HTTP/3 {{HTTP3}}.
-This extension makes use of an HTTP/2 setting.  {{Appendix A.3 of HTTP3}}
+to HTTP/2 {{HTTP/2}} which is also useful in HTTP/3 {{HTTP/3}}.
+This extension makes use of an HTTP/2 setting.  {{Appendix A.3 of HTTP/3}}
 gives some guidance on what changes (if any) are appropriate when porting
 settings from HTTP/2 to HTTP/3.
 
@@ -65,7 +65,7 @@ pseudo-header fields. It also defines a new HTTP/2 setting sent by a server to
 allow the client to use  Extended CONNECT.
 
 The semantics of the pseudo-header fields and setting are identical to those
-in HTTP/2 as defined {{!RFC8441}}. {{Appendix A.3 of HTTP3}} requires that
+in HTTP/2 as defined {{!RFC8441}}. {{Appendix A.3 of HTTP/3}} requires that
 HTTP/3 settings be registered separately for HTTP/3. The
 SETTINGS_ENABLE_CONNECT_PROTOCOL value is 0x08 (decimal 8), as in HTTP/2.
 
@@ -77,9 +77,9 @@ provide more information via a Problem Details response {{!RFC7807}}.
 
 The HTTP/3 stream closure is also analogous to the TCP connection
 closure of {{!RFC6455}}. Orderly TCP-level closures are represented as
-a FIN bit on the stream ({{Section 4.2 of HTTP3}}). RST exceptions are
-represented with a stream error ({{Section 8 of HTTP3}}) of type
-H3_REQUEST_CANCELLED ({{Section 8.1 of HTTP3}}).
+a FIN bit on the stream ({{Section 4.2 of HTTP/3}}). RST exceptions are
+represented with a stream error ({{Section 8 of HTTP/3}}) of type
+H3_REQUEST_CANCELLED ({{Section 8.1 of HTTP/3}}).
 
 # Security Considerations
 
@@ -89,7 +89,7 @@ discussed in {{!RFC8441}}.
 # IANA Considerations
 
 This document registers a new setting in the "HTTP/3 Settings"
-registry ({{Section 11.2.2 of HTTP3}}).
+registry ({{Section 11.2.2 of HTTP/3}}).
 
 Value:
 : 0x08


### PR DESCRIPTION
Fixes #2038