### PR TITLE
h3-websockets: title assignment "HTTP" is redundant

### DIFF
--- a/draft-ietf-httpbis-h3-websockets.md
+++ b/draft-ietf-httpbis-h3-websockets.md
@@ -33,7 +33,6 @@ author:
 normative:
 
   HTTP:
-    display: HTTP
     title: "HTTP Semantics"
     date: 2022-04
     seriesinfo:


### PR DESCRIPTION
...and causes invalid XML to be generated as "HTTP" now appears twice as ID in the XML