### PR TITLE
Remove note to ignore Domain attribute with trailing .

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1465,8 +1465,7 @@ user agent MUST process the cookie as follows:
         attribute-name of "Domain" and an attribute-value whose
         length is no more than 1024 octets. (Note that a leading %x2E
         ("."), if present, is ignored even though that character is not
-        permitted, but a trailing %x2E ("."), if present, will cause
-        the user agent to ignore the attribute.)
+        permitted.)
 
     Otherwise:
 


### PR DESCRIPTION
Closes #1758

The spec had a note to handle trailing `.`s in the `Domain`'s value by ignoring the attribute. Since `example.com` and `example.com.` are considered distinct domains a trailing `.` should instead result in a rejected cookie. By removing this note the spec will rely on the domain matching algorithm to (correctly) reject the cookie.