### PR TITLE
[6265bis] Removing an inadvertant change to `cookie-octet`.

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -491,7 +491,6 @@ cookie-pair       = cookie-name BWS "=" BWS cookie-value
 cookie-name       = 1*cookie-octet
 cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
 cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
-                    / %x80-FF
                       ; octets excluding CTLs,
                       ; whitespace DQUOTE, comma, semicolon,
                       ; and backslash

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -491,7 +491,7 @@ cookie-pair       = cookie-name BWS "=" BWS cookie-value
 cookie-name       = 1*cookie-octet
 cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
 cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
-                      ; octets excluding CTLs,
+                      ; US-ASCII characters excluding CTLs,
                       ; whitespace DQUOTE, comma, semicolon,
                       ; and backslash
 


### PR DESCRIPTION
https://github.com/httpwg/http-extensions/commit/efaa468e6af574e88152cc365deb32e262444844
introduced a change to the `cookie-octet` grammar that's completely unrelated to what the PR
actually aimed to do. This was a mistake on my part that I'll now (2 years later!) resolve.

Oops!

This addresses a portion of https://github.com/httpwg/http-extensions/issues/1073.