### PR TITLE
Fix references in binary messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,4 @@ http-lint: $(drafts_xml) http-lint-install
 
 .PHONY: http-lint-install
 http-lint-install:
-	@hash $(rfc-http-validate) 2>/dev/null || pip3 install rfc-http-validate
+	@hash $(rfc-http-validate) 2>/dev/null || pip3 install rfc-http-validate typing_extensions

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean::
 
 lint:: http-lint
 
-rfc-http-validate ?= rfc-http-validate.py
+rfc-http-validate ?= rfc-http-validate
 .SECONDARY: $(drafts_xml)
 .PHONY: http-lint
 http-lint: $(drafts_xml) http-lint-install
@@ -33,4 +33,4 @@ http-lint: $(drafts_xml) http-lint-install
 
 .PHONY: http-lint-install
 http-lint-install:
-	@hash rfc-http-validate.py 2>/dev/null || pip3 install rfc-http-validate
+	@hash $(rfc-http-validate) 2>/dev/null || pip3 install rfc-http-validate

--- a/draft-ietf-httpbis-binary-message.md
+++ b/draft-ietf-httpbis-binary-message.md
@@ -3,7 +3,6 @@ title: "Binary Representation of HTTP Messages"
 abbrev: Binary HTTP Messages
 docname: draft-ietf-httpbis-binary-message-latest
 category: std
-ipr: trust200902
 area: ART
 workgroup: HTTP
 venue:
@@ -14,9 +13,8 @@ venue:
   arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/binary-messages
 github-issue-label: binary-messages
-
-stand_alone: yes
-pi: [toc, sortrefs, symrefs, docmapping]
+submissionType: IETF
+v: 3
 
 author:
   -
@@ -32,12 +30,18 @@ author:
 
 normative:
   HTTP: I-D.ietf-httpbis-semantics
-  MESSAGING: I-D.ietf-httpbis-messaging
-  H2: I-D.ietf-httpbis-http2bis
-  H3: I-D.ietf-quic-http
   QUIC: RFC9000
 
 informative:
+  MESSAGING:
+    =: I-D.ietf-httpbis-messaging
+    display: HTTP/1.1
+  H2:
+    =: I-D.ietf-httpbis-http2bis
+    display: HTTP/2
+  H3:
+    =: I-D.ietf-quic-http
+    display: HTTP/3
 
 
 --- abstract


### PR DESCRIPTION
Make HTTP/* informative references; fix their display.
Also, suppress some noise from xml2rfc.