### PR TITLE
Document Style updates for Signatures

### DIFF
--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -113,7 +113,7 @@ This document also provides a mechanism for a potential verifier to signal to a 
 
 HTTP permits and sometimes requires intermediaries to transform messages in a variety of ways.  This may result in a recipient receiving a message that is not bitwise equivalent to the message that was originally sent.  In such a case, the recipient will be unable to verify a signature over the raw bytes of the sender's HTTP message, as verifying digital signatures or MACs requires both signer and verifier to have the exact same signature base.  Since the exact raw bytes of the message cannot be relied upon as a reliable source for a signature base, the signer and verifier must independently create the signature base from their respective versions of the message, via a mechanism that is resilient to safe changes that do not alter the meaning of the message.
 
-For a variety of reasons, it is impractical to strictly define what constitutes a safe change versus an unsafe one.  Applications use HTTP in a wide variety of ways, and may disagree on whether a particular piece of information in a message (e.g., the body, or the getDate` header field) is relevant.  Thus a general purpose solution must provide signers with some degree of control over which message components are signed.
+For a variety of reasons, it is impractical to strictly define what constitutes a safe change versus an unsafe one.  Applications use HTTP in a wide variety of ways, and may disagree on whether a particular piece of information in a message (e.g., the body, or the Date header field) is relevant.  Thus a general purpose solution must provide signers with some degree of control over which message components are signed.
 
 HTTP applications may be running in environments that do not provide complete access to or control over HTTP messages (such as a web browser's JavaScript environment), or may be using libraries that abstract away the details of the protocol (such as [the Java HTTPClient library](https://openjdk.java.net/groups/net/httpclient/intro.html)).  These applications need to be able to generate and verify signatures despite incomplete knowledge of the HTTP message.
 
@@ -341,7 +341,7 @@ The resulting string is used as the component value in {{http-header}}.
 
 If a given field is known by the application to be a Dictionary structured field, an individual member in the value of that Dictionary is identified by using the parameter `key` and the Dictionary member key as a String value.
 
-An individual `member_value` of a Dictionary Structured Field is canonicalized by applying the serialization algorithm described in {{Section 4.1.2 of STRUCTURED-FIELDS}} on the `member_value` and its parameters, without the dictionary key. Specifically, the value is serialized as an Item or Inner List (the two possible values of a Dictionary member).
+An individual member value of a Dictionary Structured Field is canonicalized by applying the serialization algorithm described in {{Section 4.1.2 of STRUCTURED-FIELDS}} on the `member_value` and its parameters, without the dictionary key. Specifically, the value is serialized as an Item or Inner List (the two possible values of a Dictionary member).
 
 Each parameterized key for a given field MUST NOT appear more than once in the signature base. Parameterized keys MAY appear in any order in the signature base, regardless of the order they occur in the source Dictionary.
 
@@ -449,7 +449,7 @@ The signature parameters component value is serialized as a parameterized inner 
 6. The output contains the signature parameters component value.
 
 Note that the Inner List serialization from {{Section 4.1.1.1 of STRUCTURED-FIELDS}} is used for the covered component value instead of the List serialization from {{Section 4.1.1 of STRUCTURED-FIELDS}}
-in order to facilitate parallelism with this value's inclusion the Signature-Input field,
+in order to facilitate parallelism with this value's inclusion in the Signature-Input field,
 as discussed in {{signature-input-header}}.
 
 This example shows a canonicalized value for the parameters of a given signature:
@@ -1562,7 +1562,7 @@ The table below contains the initial contents of the HTTP Signature Derived Comp
 
 ## HTTP Signature Component Parameters Registry {#component-param-registry}
 
-This document defines a component identifiers, which can be parameterized in specific circumstances to provide unique modified behavior. IANA is asked to create and maintain a new registry typed "HTTP Signature Component Parameters" to record and maintain the set of non-field component names and the methods to produce their associated component values. Initial values for this registry are given in {{iana-component-param-contents}}.  Future assignments and modifications to existing assignments are to be made through the Expert Review registration policy {{?RFC8126}} and shall follow the template presented in {{iana-component-param-template}}.
+This document defines several kinds of component identifiers, some of which can be parameterized in specific circumstances to provide unique modified behavior. IANA is asked to create and maintain a new registry typed "HTTP Signature Component Parameters" to record and maintain the set of parameters names, the component identifiers they are associated with, and the modifications these parameters make to the component value. Initial values for this registry are given in {{iana-component-param-contents}}.  Future assignments and modifications to existing assignments are to be made through the Expert Review registration policy {{?RFC8126}} and shall follow the template presented in {{iana-component-param-template}}.
 
 ### Registration Template {#iana-component-param-template}
 
@@ -1572,6 +1572,9 @@ Name:
 
 Description:
 : A description of the parameter's function.
+
+Status:
+: A brief text description of the status of the parameter. The description MUST begin with one of "Active" or "Deprecated", and MAY provide further context or explanation as to the reason for the status.
 
 Target:
 : The applicable component identifiers for the parmeter. Can be one or more derived component identifiers as described in {{derived-components}}, "Field Value" meaning all HTTP fields, or a human-readable description of the target.

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -202,7 +202,7 @@ The term "Unix time" is defined by {{POSIX.1}}, [Section 4.16](http://pubs.openg
 This document contains non-normative examples of partial and complete HTTP messages. Some examples use a single trailing backslash '\' to indicate line wrapping for long values, as per {{!RFC8792}}. The `\` character and leading spaces on wrapped lines are not part of the value.
 
 This document uses the following terminology from {{Section 3 of STRUCTURED-FIELDS}}
-to specify syntax and parsing: List, Inner List, Dictionary, String, Integer, Byte Sequence, and Boolean.
+to specify syntax and parsing: List, Inner List, Dictionary, String, Integer, Byte Sequence, and Boolean. This document uses the following ABNF rules from {{STRUCTURED-FIELDS}} where applicable: `sf-string`, `key`, `parameters`.
 
 
 ## Application of HTTP Message Signatures {#application}
@@ -2367,6 +2367,7 @@ Jeffrey Yasskin.
   - -10
      * Removed "related response" and "@request-response" in favor of generic "req" parameter.
      * Editorial fixes to comply with HTTP extension style guidelines.
+     * Add security consideration on message content.
 
   - -09
      * Explained key formats better.

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -1239,8 +1239,7 @@ JWA algorithm values from the JSON Web Signature and Encryption Algorithms Regis
 
 Message signatures can be included within an HTTP message via the Signature-Input and Signature fields, both defined within this specification. When attached to a message, an HTTP message signature is identified by a label. This label MUST be unique within a given HTTP message and MUST be used in both the Signature-Input and Signature fields. The label is chosen by the signer, except where a specific label is dictated by protocol negotiations such as described in {{request-signature}}
 
-An HTTP message signature MUST use both fields and each field MUST contain the same labels.
-The Signature-Input field identifies the covered components and parameters that describe how the signature was generated, while the Signature field contains the signature value. Each field contains labeled values and MAY contain multiple labeled values. The result of this constraint is that the Signature-Input and Signature Dictionaries are parallel data structures of each other. Any key found in one field but not in the other is an error.
+An HTTP message signature MUST use both fields and each field MUST contain the same labels. The Signature-Input and Signature Dictionaries are parallel data structures of each other, and the presence of any key in one field but not in the other is an error. The Signature-Input field identifies the covered components and parameters that describe how the signature was generated, while the Signature field contains the signature value. Each field MAY contain multiple labeled values.
 
 ## The Signature-Input HTTP Field {#signature-input-header}
 
@@ -1255,7 +1254,7 @@ Signature-Input: sig1=("@method" "@target-uri" "@authority" \
 ~~~
 
 To facilitate signature validation, the Signature-Input field value MUST contain the same serialized value used
-in generating the signature base's `@signature-params` value. Note that parameter order MUST be preserved.
+in generating the signature base's `@signature-params` value. Note that in a structured field value, parameter order has to be preserved.
 
 The signer MAY include the Signature-Input field as a trailer to facilitate signing a message after its content has been processed by the signer. However, since intermediaries are allowed to drop trailers as per {{HTTP}}, it is RECOMMENDED that the Signature-Input field be included only as a header to avoid signatures being inadvertently stripped from a message.
 
@@ -1568,7 +1567,7 @@ This document defines several kinds of component identifiers, some of which can 
 
 {: vspace="0"}
 Name:
-: A name for the parameter. The name MUST be an ASCII string consisting only of lower-case characters (`"a"` - `"z"`), digits (`"0"` - `"9"`), and hyphens (`"-"`), and SHOULD NOT exceed 20 characters in length.  The name MUST be unique within the context of the registry.
+: A name for the parameter. The name MUST be an ASCII string that conforms to the `key` ABNF rule defined in {{STRUCTURED-FIELDS}} and SHOULD NOT exceed 20 characters in length.  The name MUST be unique within the context of the registry.
 
 Description:
 : A description of the parameter's function.
@@ -1577,7 +1576,7 @@ Status:
 : A brief text description of the status of the parameter. The description MUST begin with one of "Active" or "Deprecated", and MAY provide further context or explanation as to the reason for the status.
 
 Target:
-: The applicable component identifiers for the parmeter. Can be one or more derived component identifiers as described in {{derived-components}}, "Field Value" meaning all HTTP fields, or a human-readable description of the target.
+: The applicable component identifiers for the parmeter. Can be a combination of one or more derived component identifiers as described in {{derived-components}}, one or more specific HTTP field names, the special value "Field Value" meaning all HTTP fields, or a separate human-readable description of the target.
 
 Specification document(s):
 : Reference to the document(s) that specify the

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -71,8 +71,8 @@ normative:
         target: https://pubs.opengroup.org/onlinepubs/9699919799/
         title: The Open Group Base Specifications Issue 7, 2018 edition
         date: 2018
-    SEMANTICS: I-D.ietf-httpbis-semantics
-    MESSAGING: I-D.ietf-httpbis-messaging
+    HTTP: I-D.ietf-httpbis-semantics
+    HTTP1: I-D.ietf-httpbis-messaging
     HTMLURL:
         target: https://url.spec.whatwg.org/
         title: URL (Living Standard)
@@ -81,7 +81,8 @@ normative:
 informative:
     RFC7239:
     BCP195:
-    I-D.ietf-httpbis-client-cert-field:
+    CLIENT-CERT: I-D.ietf-httpbis-client-cert-field
+    DIGEST: I-D.ietf-httpbis-digest-headers
 
 --- abstract
 
@@ -117,12 +118,12 @@ HTTP applications may be running in environments that do not provide complete ac
 
 As mentioned earlier, HTTP explicitly permits and in some cases requires implementations to transform messages in a variety of ways.  Implementations are required to tolerate many of these transformations.  What follows is a non-normative and non-exhaustive list of transformations that may occur under HTTP, provided as context:
 
-- Re-ordering of header fields with different header field names ({{Section 3.2.2 of MESSAGING}}).
-- Combination of header fields with the same field name ({{Section 3.2.2 of MESSAGING}}).
-- Removal of header fields listed in the `Connection` header field ({{Section 6.1 of MESSAGING}}).
-- Addition of header fields that indicate control options ({{Section 6.1 of MESSAGING}}).
-- Addition or removal of a transfer coding ({{Section 5.7.2 of MESSAGING}}).
-- Addition of header fields such as `Via` ({{Section 5.7.1 of MESSAGING}}) and `Forwarded` ({{Section 4 of RFC7239}}).
+- Re-ordering of header fields with different header field names ({{Section 3.2.2 of HTTP1}}).
+- Combination of header fields with the same field name ({{Section 3.2.2 of HTTP1}}).
+- Removal of header fields listed in the `Connection` header field ({{Section 6.1 of HTTP1}}).
+- Addition of header fields that indicate control options ({{Section 6.1 of HTTP1}}).
+- Addition or removal of a transfer coding ({{Section 5.7.2 of HTTP1}}).
+- Addition of header fields such as `Via` ({{Section 5.7.1 of HTTP1}}) and `Forwarded` ({{Section 4 of RFC7239}}).
 
 Based on the definition of HTTP and the requirements described above, we can identify certain types of transformations that should not prevent signature verification, even when performed on message components covered by the signature.  The following list describes those transformations:
 
@@ -133,7 +134,7 @@ Based on the definition of HTTP and the requirements described above, we can ide
 - Addition or removal of leading or trailing whitespace to a header field value.
 - Addition or removal of `obs-folds`.
 - Changes to the `request-target` and `Host` header field that when applied together do not
-  result in a change to the message's effective request URI, as defined in {{Section 5.5 of MESSAGING}}.
+  result in a change to the message's effective request URI, as defined in {{Section 5.5 of HTTP1}}.
 
 Additionally, all changes to components not covered by the signature are considered safe.
 
@@ -145,9 +146,9 @@ Additionally, all changes to components not covered by the signature are conside
 The terms "HTTP message", "HTTP request", "HTTP response",
 `absolute-form`, `absolute-path`, "effective request URI",
 "gateway", "header field", "intermediary", `request-target`,
-"sender", and "recipient" are used as defined in {{MESSAGING}}.
+"sender", and "recipient" are used as defined in {{HTTP1}}.
 
-The term "method" is to be interpreted as defined in {{Section 4 of SEMANTICS}}.
+The term "method" is to be interpreted as defined in {{Section 4 of HTTP}}.
 
 For brevity, the term "signature" on its own is used in this document to refer to both digital signatures (which use asymmetric cryptography) and keyed MACs (which use symmetric cryptography). Similarly, the verb "sign" refers to the generation of either a digital signature or keyed MAC over a given input string. The qualified term "digital signature" refers specifically to the output of an asymmetric cryptographic signing operation.
 
@@ -240,13 +241,13 @@ The following sections define component identifier types, their parameters, thei
 
 The component name for an HTTP field is the lowercased form of its field name. While HTTP field names are case-insensitive, implementations MUST use lowercased field names (e.g., `content-type`, `date`, `etag`) when using them as component names.
 
-Unless overridden by additional parameters and rules, the HTTP field value MUST be canonicalized as a single combined value as defined in {{Section 5.2 of SEMANTICS}}.
+Unless overridden by additional parameters and rules, the HTTP field value MUST be canonicalized as a single combined value as defined in {{Section 5.2 of HTTP}}.
 
 If the combined value is not available for a given header, the following algorithm will produce canonicalized results for an implementation:
 
 1. Create an ordered list of the field values of each instance of the field in the message, in the order that they occur (or will occur) in the message.
 2. Strip leading and trailing whitespace from each item in the list. Note that since HTTP field values are not allowed to contain leading and trailing whitespace, this will be a no-op in a compliant implementation.
-3. Remove any obsolete line-folding within the line and replace it with a single space (" "), as discussed in {{Section 5.2 of MESSAGING}}. Note that this behavior is specific to {{MESSAGING}} and does not apply to other versions of the HTTP specification.
+3. Remove any obsolete line-folding within the line and replace it with a single space (" "), as discussed in {{Section 5.2 of HTTP1}}. Note that this behavior is specific to {{HTTP1}} and does not apply to other versions of the HTTP specification.
 4. Concatenate the list of values together with a single comma (",") and a single space (" ") between each item.
 
 The resulting string is the canonicalized component value.
@@ -364,7 +365,7 @@ Note that the value for `key="c"` has been re-serialized according to the strict
 
 In addition to HTTP fields, there are a number of different components that can be derived from the control data, processing context, or other aspects of the HTTP message being signed. Such derived components can be included in the signature base by defining a component name, possible parameters, and the derivation method for its component value.
 
-Derived component names MUST start with the "at" `@` character. This differentiates derived component names from HTTP field names, which cannot contain the `@` character as per {{Section 5.1 of SEMANTICS}}. Processors of HTTP Message Signatures MUST treat derived component names separately from field names, as discussed in {{security-lazy-header-parser}}.
+Derived component names MUST start with the "at" `@` character. This differentiates derived component names from HTTP field names, which cannot contain the `@` character as per {{Section 5.1 of HTTP}}. Processors of HTTP Message Signatures MUST treat derived component names separately from field names, as discussed in {{security-lazy-header-parser}}.
 
 This specification defines the following derived components:
 
@@ -403,10 +404,10 @@ Additional derived component names MAY be defined and registered in the HTTP Sig
 Derived component values are taken from the context of the target message for the signature. This context includes information about the message itself, such as its control data, as well as any additional state and context held by the signer. In particular, when signing a response, the signer can include any derived components from the originating request by using the [request-response signature binding parameter](#content-request-response).
 
 request:
-: Values derived from and results applied to an HTTP request message as described in {{Section 3.4 of SEMANTICS}}.
+: Values derived from and results applied to an HTTP request message as described in {{Section 3.4 of HTTP}}.
 
 response:
-: Values derived from and results applied to an HTTP response message as described in {{Section 3.4 of SEMANTICS}}.
+: Values derived from and results applied to an HTTP response message as described in {{Section 3.4 of HTTP}}.
 
 A derived component definition MUST define all targets to which it can be applied.
 
@@ -462,7 +463,7 @@ Note that an HTTP message could contain [multiple signatures](#signature-multipl
 
 ### Method {#content-request-method}
 
-The `@method` derived component refers to the HTTP method of a request message. The component value is canonicalized by taking the value of the method as a string. Note that the method name is case-sensitive as per {{SEMANTICS, Section 9.1}}, and conventionally standardized method names are uppercase US-ASCII.
+The `@method` derived component refers to the HTTP method of a request message. The component value is canonicalized by taking the value of the method as a string. Note that the method name is case-sensitive as per {{HTTP, Section 9.1}}, and conventionally standardized method names are uppercase US-ASCII.
 If used, the `@method` component identifier MUST occur only once in the covered components.
 
 For example, the following request message:
@@ -486,7 +487,7 @@ And the following signature base line:
 
 ### Target URI {#content-target-uri}
 
-The `@target-uri` derived component refers to the target URI of a request message. The component value is the full absolute target URI of the request, potentially assembled from all available parts including the authority and request target as described in {{SEMANTICS, Section 7.1}}.
+The `@target-uri` derived component refers to the target URI of a request message. The component value is the full absolute target URI of the request, potentially assembled from all available parts including the authority and request target as described in {{HTTP, Section 7.1}}.
 If used, the `@target-uri` component identifier MUST occur only once in the covered components.
 
 For example, the following message sent over HTTPS:
@@ -510,8 +511,8 @@ And the following signature base line:
 
 ### Authority {#content-request-authority}
 
-The `@authority` derived component refers to the authority component of the target URI of the HTTP request message, as defined in {{SEMANTICS, Section 7.2}}. In HTTP 1.1, this is usually conveyed using the `Host` header, while in HTTP 2 and HTTP 3 it is conveyed using the `:authority` pseudo-header. The value is the fully-qualified authority component of the request, comprised of the host and, optionally, port of the request target, as a string.
-The component value MUST be normalized according to the rules in {{SEMANTICS, Section 4.2.3}}. Namely, the host name is normalized to lowercase and the default port is omitted.
+The `@authority` derived component refers to the authority component of the target URI of the HTTP request message, as defined in {{HTTP, Section 7.2}}. In HTTP 1.1, this is usually conveyed using the `Host` header, while in HTTP 2 and HTTP 3 it is conveyed using the `:authority` pseudo-header. The value is the fully-qualified authority component of the request, comprised of the host and, optionally, port of the request target, as a string.
+The component value MUST be normalized according to the rules in {{HTTP, Section 4.2.3}}. Namely, the host name is normalized to lowercase and the default port is omitted.
 If used, the `@authority` component identifier MUST occur only once in the covered components.
 
 For example, the following request message:
@@ -537,7 +538,7 @@ The `@authority` derived component SHOULD be used instead of signing the `Host` 
 
 ### Scheme {#content-request-scheme}
 
-The `@scheme` derived component refers to the scheme of the target URL of the HTTP request message. The component value is the scheme as a string as defined in {{SEMANTICS, Section 4.2}}.
+The `@scheme` derived component refers to the scheme of the target URL of the HTTP request message. The component value is the scheme as a string as defined in {{HTTP, Section 4.2}}.
 While the scheme itself is case-insensitive, it MUST be normalized to lowercase for
 inclusion in the signature base.
 If used, the `@scheme` component identifier MUST occur only once in the covered components.
@@ -564,7 +565,7 @@ And the following signature base line:
 ### Request Target {#content-request-target}
 
 The `@request-target` derived component refers to the full request target of the HTTP request message,
-as defined in {{SEMANTICS, Section 7.1}}. The component value of the request target can take different forms,
+as defined in {{HTTP, Section 7.1}}. The component value of the request target can take different forms,
 depending on the type of request, as described below.
 If used, the `@request-target` component identifier MUST occur only once in the covered components.
 
@@ -650,7 +651,7 @@ And the following signature base line:
 
 ### Path {#content-request-path}
 
-The `@path` derived component refers to the target path of the HTTP request message. The component value is the absolute path of the request target defined by {{RFC3986}}, with no query component and no trailing `?` character. The value is normalized according to the rules in {{SEMANTICS, Section 4.2.3}}. Namely, an empty path string is normalized as a single slash `/` character, and path components are represented by their values after decoding any percent-encoded octets.
+The `@path` derived component refers to the target path of the HTTP request message. The component value is the absolute path of the request target defined by {{RFC3986}}, with no query component and no trailing `?` character. The value is normalized according to the rules in {{HTTP, Section 4.2.3}}. Namely, an empty path string is normalized as a single slash `/` character, and path components are represented by their values after decoding any percent-encoded octets.
 If used, the `@path` component identifier MUST occur only once in the covered components.
 
 For example, the following request message:
@@ -674,7 +675,7 @@ And the following signature base line:
 
 ### Query {#content-request-query}
 
-The `@query` derived component refers to the query component of the HTTP request message. The component value is the entire normalized query string defined by {{RFC3986}}, including the leading `?` character. The value is normalized according to the rules in {{SEMANTICS, Section 4.2.3}}. Namely, percent-encoded octets are decoded.
+The `@query` derived component refers to the query component of the HTTP request message. The component value is the entire normalized query string defined by {{RFC3986}}, including the leading `?` character. The value is normalized according to the rules in {{HTTP, Section 4.2.3}}. Namely, percent-encoded octets are decoded.
 If used, the `@query` component identifier MUST occur only once in the covered components.
 
 For example, the following request message:
@@ -772,7 +773,7 @@ in separate signature base lines in the order in which the parameters occur in t
 
 ### Status Code {#content-status-code}
 
-The `@status` derived component refers to the three-digit numeric HTTP status code of a response message as defined in {{SEMANTICS, Section 15}}. The component value is the serialized three-digit integer of the HTTP status code, with no descriptive text.
+The `@status` derived component refers to the three-digit numeric HTTP status code of a response message as defined in {{HTTP, Section 15}}. The component value is the serialized three-digit integer of the HTTP status code, with no descriptive text.
 If used, the `@status` component identifier MUST occur only once in the covered components.
 
 For example, the following response message:
@@ -1253,7 +1254,7 @@ Signature-Input: sig1=("@method" "@target-uri" "@authority" \
 To facilitate signature validation, the Signature-Input field value MUST contain the same serialized value used
 in generating the signature base's `@signature-params` value. Note that parameter order MUST be preserved.
 
-The signer MAY include the Signature-Input field as a trailer to facilitate signing a message after its content has been processed by the signer. However, since intermediaries are allowed to drop trailers as per {{SEMANTICS}}, it is RECOMMENDED that the Signature-Input field be included only as a header to avoid signatures being inadvertently stripped from a message.
+The signer MAY include the Signature-Input field as a trailer to facilitate signing a message after its content has been processed by the signer. However, since intermediaries are allowed to drop trailers as per {{HTTP}}, it is RECOMMENDED that the Signature-Input field be included only as a header to avoid signatures being inadvertently stripped from a message.
 
 Multiple Signature-Input fields MAY be included in a single HTTP message. The signature labels MUST be unique across all field values.
 
@@ -1272,7 +1273,7 @@ Signature: sig1=:P0wLUszWQjoi54udOtydf9IWTfNhy+r53jGFj9XZuP4uKwxyJo\
   BNFv3r5S9IXf2fYJK+eyW4AiGVMvMcOg==:
 ~~~
 
-The signer MAY include the Signature field as a trailer to facilitate signing a message after its content has been processed by the signer. However, since intermediaries are allowed to drop trailers as per {{SEMANTICS}}, it is RECOMMENDED that the Signature field be included only as a header to avoid signatures being inadvertently stripped from a message.
+The signer MAY include the Signature field as a trailer to facilitate signing a message after its content has been processed by the signer. However, since intermediaries are allowed to drop trailers as per {{HTTP}}, it is RECOMMENDED that the Signature field be included only as a header to avoid signatures being inadvertently stripped from a message.
 
 Multiple Signature fields MAY be included in a single HTTP message. The signature labels MUST be unique across all field values.
 
@@ -2136,7 +2137,7 @@ Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1\
 
 ## TLS-Terminating Proxies
 
-In this example, there is a TLS-terminating reverse proxy sitting in front of the resource. The client does not sign the request but instead uses mutual TLS to make its call. The terminating proxy validates the TLS stream and injects a `Client-Cert` header according to {{I-D.ietf-httpbis-client-cert-field}}, and then applies a signature to this field. By signing this header field, a reverse proxy can not only attest to its own validation of the initial request's TLS parameters but also authenticate itself to the backend system independently of the client's actions.
+In this example, there is a TLS-terminating reverse proxy sitting in front of the resource. The client does not sign the request but instead uses mutual TLS to make its call. The terminating proxy validates the TLS stream and injects a `Client-Cert` header according to {{CLIENT-CERT}}, and then applies a signature to this field. By signing this header field, a reverse proxy can not only attest to its own validation of the initial request's TLS parameters but also authenticate itself to the backend system independently of the client's actions.
 
 The client makes the following request to the TLS terminating proxy using mutual TLS:
 

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -1462,11 +1462,11 @@ Algorithms added to this registry MUST NOT be aliases for other entries in the r
 Algorithm Name:
 : An identifier for the HTTP Signature Algorithm. The name MUST be an ASCII string consisting only of lower-case characters (`"a"` - `"z"`), digits (`"0"` - `"9"`), and hyphens (`"-"`), and SHOULD NOT exceed 20 characters in length.  The identifier MUST be unique within the context of the registry.
 
-Status:
-: A brief text description of the status of the algorithm.  The description MUST begin with one of "Active" or "Deprecated", and MAY provide further context or explanation as to the reason for the status.
-
 Description:
 : A brief description of the algorithm used to sign the signature base.
+
+Status:
+: A brief text description of the status of the algorithm.  The description MUST begin with one of "Active" or "Deprecated", and MAY provide further context or explanation as to the reason for the status.
 
 Specification document(s):
 : Reference to the document(s) that specify the
@@ -1476,12 +1476,12 @@ Specification document(s):
 
 ### Initial Contents {#iana-hsa-contents}
 
-|Algorithm Name|Status|Description|Specification document(s)
-|`rsa-pss-sha512`|Active|RSASSA-PSS using SHA-512|{{method-rsa-pss-sha512}} of {{&SELF}}|
-|`rsa-v1_5-sha256`|Active|RSASSA-PKCS1-v1_5 using SHA-256|{{method-rsa-v1_5-sha256}} of {{&SELF}}|
-|`hmac-sha256`|Active|HMAC using SHA-256|{{method-hmac-sha256}} of {{&SELF}}|
-|`ecdsa-p256-sha256`|Active|ECDSA using curve P-256 DSS and SHA-256|{{method-ecdsa-p256-sha256}} of {{&SELF}}|
-|`ed25519`|Active|Edwards Curve DSA using curve edwards25519|{{method-ed25519}} of {{&SELF}}|
+|Algorithm Name|Description|Status|Specification document(s)
+|`rsa-pss-sha512`|RSASSA-PSS using SHA-512|Active|{{method-rsa-pss-sha512}} of {{&SELF}}|
+|`rsa-v1_5-sha256`|RSASSA-PKCS1-v1_5 using SHA-256|Active|{{method-rsa-v1_5-sha256}} of {{&SELF}}|
+|`hmac-sha256`|HMAC using SHA-256|Active|{{method-hmac-sha256}} of {{&SELF}}|
+|`ecdsa-p256-sha256`|ECDSA using curve P-256 DSS and SHA-256|Active|{{method-ecdsa-p256-sha256}} of {{&SELF}}|
+|`ed25519`|Edwards Curve DSA using curve edwards25519|Active|{{method-ed25519}} of {{&SELF}}|
 {: title="Initial contents of the HTTP Signature Algorithms Registry." }
 
 ## HTTP Signature Metadata Parameters Registry {#param-registry}
@@ -1527,6 +1527,9 @@ This document defines a method for canonicalizing HTTP message components, inclu
 Name:
 : A name for the HTTP derived component. The name MUST begin with the `"@"` character followed by an ASCII string consisting only of lower-case characters (`"a"` - `"z"`), digits (`"0"` - `"9"`), and hyphens (`"-"`), and SHOULD NOT exceed 20 characters in length.  The name MUST be unique within the context of the registry.
 
+Description:
+: A description of the derived component.
+
 Status:
 : A brief text description of the status of the algorithm.  The description MUST begin with one of "Active" or "Deprecated", and MAY provide further context or explanation as to the reason for the status.
 
@@ -1543,19 +1546,53 @@ Specification document(s):
 
 The table below contains the initial contents of the HTTP Signature Derived Component Names Registry.
 
-|Name|Status|Target|Specification document(s)|
-|--- |--- |--- |--- |
-|`@signature-params`| Active | Request, Response | {{signature-params}} of {{&SELF}}|
-|`@method`| Active | Request | {{content-request-method}} of {{&SELF}}|
-|`@authority`| Active | Request | {{content-request-authority}} of {{&SELF}}|
-|`@scheme`| Active | Request | {{content-request-scheme}} of {{&SELF}}|
-|`@target-uri`| Active | Request | {{content-target-uri}} of {{&SELF}}|
-|`@request-target`| Active | Request | {{content-request-target}} of {{&SELF}}|
-|`@path`| Active | Request | {{content-request-path}} of {{&SELF}}|
-|`@query`| Active | Request | {{content-request-query}} of {{&SELF}}|
-|`@query-param`| Active | Request | {{content-request-query-param}} of {{&SELF}}|
-|`@status`| Active | Response | {{content-status-code}} of {{&SELF}}|
+|Name|Description|Status|Target|Specification document(s)|
+|--- |--- |--- |--- |--- |
+|`@signature-params`| Signature parameters, including covered content list | Active | Request, Response | {{signature-params}} of {{&SELF}}|
+|`@method`| The HTTP request method | Active | Request | {{content-request-method}} of {{&SELF}}|
+|`@authority`| The HTTP authority, or target host | Active | Request | {{content-request-authority}} of {{&SELF}}|
+|`@scheme`| The URI scheme of the request URI | Active | Request | {{content-request-scheme}} of {{&SELF}}|
+|`@target-uri`| The full target URI of the request | Active | Request | {{content-target-uri}} of {{&SELF}}|
+|`@request-target`| The request target of the request | Active | Request | {{content-request-target}} of {{&SELF}}|
+|`@path`| The full path of the request URI | Active | Request | {{content-request-path}} of {{&SELF}}|
+|`@query`| The full query of the request URI | Active | Request | {{content-request-query}} of {{&SELF}}|
+|`@query-param`| | A single named query parameter | Active | Request | {{content-request-query-param}} of {{&SELF}}|
+|`@status`| The status code of the response | Active | Response | {{content-status-code}} of {{&SELF}}|
 {: title="Initial contents of the HTTP Signature Derived Component Names Registry." }
+
+## HTTP Signature Component Parameters Registry {#component-param-registry}
+
+This document defines a component identifiers, which can be parameterized in specific circumstances to provide unique modified behavior. IANA is asked to create and maintain a new registry typed "HTTP Signature Component Parameters" to record and maintain the set of non-field component names and the methods to produce their associated component values. Initial values for this registry are given in {{iana-component-param-contents}}.  Future assignments and modifications to existing assignments are to be made through the Expert Review registration policy {{?RFC8126}} and shall follow the template presented in {{iana-component-param-template}}.
+
+### Registration Template {#iana-component-param-template}
+
+{: vspace="0"}
+Name:
+: A name for the parameter. The name MUST be an ASCII string consisting only of lower-case characters (`"a"` - `"z"`), digits (`"0"` - `"9"`), and hyphens (`"-"`), and SHOULD NOT exceed 20 characters in length.  The name MUST be unique within the context of the registry.
+
+Description:
+: A description of the parameter's function.
+
+Target:
+: The applicable component identifiers for the parmeter. Can be one or more derived component identifiers as described in {{derived-components}}, "Field Value" meaning all HTTP fields, or a human-readable description of the target.
+
+Specification document(s):
+: Reference to the document(s) that specify the
+    derived component, preferably including a URI that can be used
+    to retrieve a copy of the document(s).  An indication of the
+    relevant sections may also be included but is not required.
+
+### Initial Contents {#iana-component-param-contents}
+
+The table below contains the initial contents of the HTTP Signature Derived Component Names Registry.
+
+|Name|Description|Status|Target|Specification document(s)|
+|--- |--- |--- |--- |
+|`key`| Dictionary structured fields | Active | {{http-header-dictionary}} of {{&SELF}}|
+|`name`| Named query parameters | Active | `@query-param` | {{content-request-query-param}} of {{&SELF}}|
+|`sf`| Strict structured field serialization | Active | Structured fields | {{http-header-structured}} of {{&SELF}}|
+|`req`| Related request indicator | Active | Derived content identifiers with a target of Request or any field | {{content-request-scheme}} of {{&SELF}}|
+{: title="Initial contents of the HTTP Signature Component Parameters Registry." }
 
 # Security Considerations {#security}
 

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -84,6 +84,9 @@ informative:
     CLIENT-CERT: I-D.ietf-httpbis-client-cert-field
     DIGEST: I-D.ietf-httpbis-digest-headers
 
+entity:
+  SELF: "RFC nnnn"
+
 --- abstract
 
 This document describes a mechanism for creating, encoding, and verifying digital signatures or message authentication codes over components of an HTTP message.  This mechanism supports use cases where the full HTTP message may not be known to the signer, and where the message may be transformed (e.g., by intermediaries) before reaching the verifier.
@@ -1473,12 +1476,13 @@ Specification document(s):
 
 ### Initial Contents {#iana-hsa-contents}
 
-|Algorithm Name|Status|Description|Specification document(s)|
-|`rsa-pss-sha512`|Active|RSASSA-PSS using SHA-512|\[\[This document\]\], {{method-rsa-pss-sha512}}|
-|`rsa-v1_5-sha256`|Active|RSASSA-PKCS1-v1_5 using SHA-256|\[\[This document\]\], {{method-rsa-v1_5-sha256}}|
-|`hmac-sha256`|Active|HMAC using SHA-256|\[\[This document\]\], {{method-hmac-sha256}}|
-|`ecdsa-p256-sha256`|Active|ECDSA using curve P-256 DSS and SHA-256|\[\[This document\]\], {{method-ecdsa-p256-sha256}}|
-|`ed25519`|Active|Edwards Curve DSA using curve edwards25519|\[\[This document\]\], {{method-ed25519}}|
+|Algorithm Name|Status|Description|Specification document(s)
+|`rsa-pss-sha512`|Active|RSASSA-PSS using SHA-512|{{method-rsa-pss-sha512}} of {{&SELF}}|
+|`rsa-v1_5-sha256`|Active|RSASSA-PKCS1-v1_5 using SHA-256|{{method-rsa-v1_5-sha256}} of {{&SELF}}|
+|`hmac-sha256`|Active|HMAC using SHA-256|{{method-hmac-sha256}} of {{&SELF}}|
+|`ecdsa-p256-sha256`|Active|ECDSA using curve P-256 DSS and SHA-256|{{method-ecdsa-p256-sha256}} of {{&SELF}}|
+|`ed25519`|Active|Edwards Curve DSA using curve edwards25519|{{method-ed25519}} of {{&SELF}}|
+{: title="Initial contents of the HTTP Signature Algorithms Registry." }
 
 ## HTTP Signature Metadata Parameters Registry {#param-registry}
 
@@ -1506,11 +1510,11 @@ The table below contains the initial contents of the HTTP Signature Metadata Par
 
 |Name|Description|Specification document(s)|
 |--- |--- |--- |
-|`alg`|Explicitly declared signature algorithm|{{signature-params}} of this document|
-|`created`|Timestamp of signature creation| {{signature-params}} of this document|
-|`expires`|Timestamp of proposed signature expiration| {{signature-params}} of this document|
-|`keyid`|Key identifier for the signing and verification keys used to create this signature| {{signature-params}} of this document|
-|`nonce`|A single-use nonce value| {{signature-params}} of this document|
+|`alg`|Explicitly declared signature algorithm|{{signature-params}} of {{&SELF}}|
+|`created`|Timestamp of signature creation| {{signature-params}} of {{&SELF}}|
+|`expires`|Timestamp of proposed signature expiration| {{signature-params}} of {{&SELF}}|
+|`keyid`|Key identifier for the signing and verification keys used to create this signature| {{signature-params}} of {{&SELF}}|
+|`nonce`|A single-use nonce value| {{signature-params}} of {{&SELF}}|
 {: title="Initial contents of the HTTP Signature Metadata Parameters Registry." }
 
 ## HTTP Signature Derived Component Names Registry {#content-registry}
@@ -1541,16 +1545,16 @@ The table below contains the initial contents of the HTTP Signature Derived Comp
 
 |Name|Status|Target|Specification document(s)|
 |--- |--- |--- |--- |
-|`@signature-params`| Active | Request, Response | {{signature-params}} of this document|
-|`@method`| Active | Request | {{content-request-method}} of this document|
-|`@authority`| Active | Request | {{content-request-authority}} of this document|
-|`@scheme`| Active | Request | {{content-request-scheme}} of this document|
-|`@target-uri`| Active | Request | {{content-target-uri}} of this document|
-|`@request-target`| Active | Request | {{content-request-target}} of this document|
-|`@path`| Active | Request | {{content-request-path}} of this document|
-|`@query`| Active | Request | {{content-request-query}} of this document|
-|`@query-param`| Active | Request | {{content-request-query-param}} of this document|
-|`@status`| Active | Response | {{content-status-code}} of this document|
+|`@signature-params`| Active | Request, Response | {{signature-params}} of {{&SELF}}|
+|`@method`| Active | Request | {{content-request-method}} of {{&SELF}}|
+|`@authority`| Active | Request | {{content-request-authority}} of {{&SELF}}|
+|`@scheme`| Active | Request | {{content-request-scheme}} of {{&SELF}}|
+|`@target-uri`| Active | Request | {{content-target-uri}} of {{&SELF}}|
+|`@request-target`| Active | Request | {{content-request-target}} of {{&SELF}}|
+|`@path`| Active | Request | {{content-request-path}} of {{&SELF}}|
+|`@query`| Active | Request | {{content-request-query}} of {{&SELF}}|
+|`@query-param`| Active | Request | {{content-request-query-param}} of {{&SELF}}|
+|`@status`| Active | Response | {{content-status-code}} of {{&SELF}}|
 {: title="Initial contents of the HTTP Signature Derived Component Names Registry." }
 
 # Security Considerations {#security}


### PR DESCRIPTION
This updates the document to comply with the style guides:

- clean up structured field references and remove ABNF
- format field names per style guide
- update semantics and messaging references
- udpate self-references
- update registry tables

This does not (yet) modify the registry initial contents from tables to dictionary lists because I'm not sure how to format those for adding multiple 
entries at once.

