### PR TITLE
RFC6265bis: Add case insensitivity note to Set-Cookie Syntax

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -522,10 +522,9 @@ Note that some of the grammatical terms above reference documents that use
 different grammatical notations than this document (which uses ABNF from
 {{RFC5234}}).
 
-NOTE: The name of an attribute-value pair is not case sensitive (which differs
-from ABNF). So while they are presented here in CamelCase, such as "HttpOnly"
-or "SameSite", any case is accepted. E.x.: "httponly", "Httponly", "hTTPoNLY",
-etc.
+NOTE: The name of an attribute-value pair is not case sensitive. So while they
+are presented here in CamelCase, such as "HttpOnly" or "SameSite", any case is
+accepted. E.x.: "httponly", "Httponly", "hTTPoNLY", etc.
 
 The semantics of the cookie-value are not defined by this document.
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -522,6 +522,11 @@ Note that some of the grammatical terms above reference documents that use
 different grammatical notations than this document (which uses ABNF from
 {{RFC5234}}).
 
+NOTE: The name of an attribute-value pair is not case sensitive (which differs
+from ABNF). So while they are presented here in CamelCase, such as "HttpOnly"
+or "SameSite", any case is accepted. E.x.: "httponly", "Httponly", "hTTPoNLY",
+etc.
+
 The semantics of the cookie-value are not defined by this document.
 
 To maximize compatibility with user agents, servers that wish to store arbitrary


### PR DESCRIPTION
Closes #1881

Cookie attribute names are case insensitive, this PR adds a note saying as much.