### PR TITLE
[6265bis] Improved Max-Age attribute parsing (fixes #1757)

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1251,24 +1251,26 @@ user agent MUST process the cookie-av as follows.
 If the attribute-name case-insensitively matches the string "Max-Age", the
 user agent MUST process the cookie-av as follows.
 
-1.  If the first character of the attribute-value is not a DIGIT or a "-"
-    character, ignore the cookie-av.
+1.  If the attribute-value is empty, ignore the cookie-av.
 
-2.  If the remainder of attribute-value contains a non-DIGIT character, ignore
+2.  If the first character of the attribute-value is neither a DIGIT, nor a "-"
+    character followed by a DIGIT, ignore the cookie-av.
+
+3.  If the remainder of attribute-value contains a non-DIGIT character, ignore
     the cookie-av.
 
-3.  Let delta-seconds be the attribute-value converted to an integer.
+4.  Let delta-seconds be the attribute-value converted to a base 10 integer.
 
-4.  Let cookie-age-limit be the maximum age of the cookie (which SHOULD be 400 days
+5.  Let cookie-age-limit be the maximum age of the cookie (which SHOULD be 400 days
     or less, see {{attribute-max-age}}).
 
-5.  Set delta-seconds to the smaller of its present value and cookie-age-limit.
+6.  Set delta-seconds to the smaller of its present value and cookie-age-limit.
 
-6.  If delta-seconds is less than or equal to zero (0), let expiry-time be
+7.  If delta-seconds is less than or equal to zero (0), let expiry-time be
     the earliest representable date and time. Otherwise, let the expiry-time
     be the current date and time plus delta-seconds seconds.
 
-7.  Append an attribute to the cookie-attribute-list with an attribute-name
+8.  Append an attribute to the cookie-attribute-list with an attribute-name
     of Max-Age and an attribute-value of expiry-time.
 
 ### The Domain Attribute


### PR DESCRIPTION
Contains the following changes:

- Skip parsing the attribute on empty value.
- Skip parsing the attribute when given Max-Age=-
- Add mention of "base 10" as guidance for implementers parsing integers
  from Max-Age.

Regarding browser interop:
Skip parsing aligns on Safari behavior and against Chrome and Firefox,
which will default to session lifetime when *any* invalid Max-Age
attribute is found (based on manual testing, it's difficult to test this
with WPT at the moment, see #1757).