### PR TITLE
RFC6265bis: Add note not to send invalid cookies due to PSL changes

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1716,7 +1716,7 @@ cookie-string from a given cookie store.
          host of the retrieval's URI domain-matches the cookie's domain.
 
      NOTE: (For user agents configured to reject "public suffixes") It's
-     possible that the public suffic list was changed since a cookie was
+     possible that the public suffix list was changed since a cookie was
      created. If this change results in a cookie's domain becoming a public
      suffix then that cookie is considered invalid as it would have been
      rejected during creation (See {{storage-model}} step 9). User agents
@@ -2507,7 +2507,7 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 * Add case insensitivity note to Set-Cookie Syntax:
   <https://github.com/httpwg/http-extensions/pull/2167>
 
-* Add note not to send invalid cookies due to PSL changes:
+* Add note not to send invalid cookies due to public suffix list changes:
   <https://github.com/httpwg/http-extensions/pull/2215>
 
 # Acknowledgements

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1715,6 +1715,12 @@ cookie-string from a given cookie store.
      *   The cookie's host-only-flag is false and the canonicalized
          host of the retrieval's URI domain-matches the cookie's domain.
 
+     NOTE: It's possible that the {{PSL}} has changed since a cookie was
+     created, potentially rendering the cookie now invalid if the
+     cookie's domain was added to the {{PSL}}. User agents should be
+     careful to avoid retrieving these invalid cookies even if they
+     domain match the host of the retrieval's URI.
+
    * The retrieval's URI's path path-matches the cookie's path.
 
    * If the cookie's secure-only-flag is true, then the retrieval's URI's

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2505,6 +2505,9 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 * Add case insensitivity note to Set-Cookie Syntax:
   <https://github.com/httpwg/http-extensions/pull/2167>
 
+* Add note not to send invalid cookies due to PSL changes:
+  <https://github.com/httpwg/http-extensions/pull/2215>
+
 # Acknowledgements
 {:numbered="false"}
 RFC 6265 was written by Adam Barth. This document is an update of RFC 6265,

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1719,7 +1719,7 @@ cookie-string from a given cookie store.
      created, potentially rendering the cookie now invalid if the
      cookie's domain was added to the {{PSL}}. User agents should be
      careful to avoid retrieving these invalid cookies even if they
-     domain match the host of the retrieval's URI.
+     domain-match the host of the retrieval's URI.
 
    * The retrieval's URI's path path-matches the cookie's path.
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1715,10 +1715,12 @@ cookie-string from a given cookie store.
      *   The cookie's host-only-flag is false and the canonicalized
          host of the retrieval's URI domain-matches the cookie's domain.
 
-     NOTE: It's possible that the {{PSL}} has changed since a cookie was
-     created, potentially rendering the cookie now invalid if the
-     cookie's domain was added to the {{PSL}}. User agents should be
-     careful to avoid retrieving these invalid cookies even if they
+     NOTE: (For user agents configured to reject "public suffixes") It's
+     possible that the public suffic list was changed since a cookie was
+     created. If this change results in a cookie's domain becoming a public
+     suffix then that cookie is considered invalid as it would have been
+     rejected during creation (See {{storage-model}} step 9). User agents
+     should be careful to avoid retrieving these invalid cookies even if they
      domain-match the host of the retrieval's URI.
 
    * The retrieval's URI's path path-matches the cookie's path.


### PR DESCRIPTION
Closes #1418

This adds a note clarifying that cookies whose domain was added to the PSL should not be sent even if they domain match the URI's host.

For example.
`Set-Cookie: foo=bar; Domain=example.com`
If example.com is added to the PSL then `foo` should not be sent to sub.example.com nor example.com