### PR TITLE
RFC6265bis: Offload Service Worker SFC computation to spec

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1084,20 +1084,8 @@ Service Workers are more complicated, as they act as a completely separate
 execution context with only tangential relationship to the Document which
 registered them.
 
-Requests which simply pass through a Service Worker will be handled as described
-above: the request's client will be the Document or Worker which initiated the
-request, and its "site for cookies" will be those defined in
-{{document-requests}} and {{dedicated-and-shared-requests}}
-
-Requests which are initiated by the Service Worker itself (via a direct call to
-`fetch()`, for instance), on the other hand, will have a client which is a
-ServiceWorkerGlobalScope. Its "site for cookies" will be the Service Worker's
-URI's origin.
-
-Given a ServiceWorkerGlobalScope (`worker`), the following algorithm returns its
-"site for cookies":
-
-1.  Return `worker`'s origin.
+How user agents handle Service Workers may differ, but user agents SHOULD
+match the {{SERVICE-WORKERS}} specification.
 
 ## Ignoring Set-Cookie Header Fields {#ignoring-cookies}
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2500,6 +2500,9 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 * Add note not to send invalid cookies due to public suffix list changes:
   <https://github.com/httpwg/http-extensions/pull/2215>
 
+* Add note regarding Service Worker's computation of "site for cookies":
+  <https://github.com/httpwg/http-extensions/pull/2217>
+
 # Acknowledgements
 {:numbered="false"}
 RFC 6265 was written by Adam Barth. This document is an update of RFC 6265,

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2467,7 +2467,37 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 ## draft-ietf-httpbis-rfc6265bis-10
 
 * Standardize Max-Age/Expires upper bound:
-  <https://github.com/httpwg/http-extensions/pull/1732>
+  <https://github.com/httpwg/http-extensions/pull/1732>,
+  <https://github.com/httpwg/http-extensions/pull/1980>.
+
+* Expand on privacy considerations and third-party cookies:
+  <https://github.com/httpwg/http-extensions/pull/1878>
+
+* Specify that no decoding of Set-Cookie line should occur:
+  <https://github.com/httpwg/http-extensions/pull/1902>
+
+* Require ASCII for domain attributes:
+  <https://github.com/httpwg/http-extensions/pull/1969>
+
+* Typos, formatting and editorial fixes:
+  <https://github.com/httpwg/http-extensions/pull/1789>,
+  <https://github.com/httpwg/http-extensions/pull/1858>,
+  <https://github.com/httpwg/http-extensions/pull/2069>.
+
+## draft-ietf-httpbis-rfc6265bis-11
+
+* Remove note to ignore Domain attribute with trailing dot:
+  <https://github.com/httpwg/http-extensions/pull/2087>,
+  <https://github.com/httpwg/http-extensions/pull/2092>.
+
+* Remove an inadvertant change to cookie-octet:
+  <https://github.com/httpwg/http-extensions/pull/2090>
+
+* Remove note regarding cookie serialization:
+  <https://github.com/httpwg/http-extensions/pull/2165>
+
+* Add case insensitivity note to Set-Cookie Syntax:
+  <https://github.com/httpwg/http-extensions/pull/2167>
 
 # Acknowledgements
 {:numbered="false"}


### PR DESCRIPTION
Closes #1288

This changes how 6265bis computes the Site for Cookies for Service Workers by referring to their spec instead of spelling it out locally.

It's been some time since this was [last discussed](https://notes.ietf.org/notes-httpbis-21-09#Issue-1288---Service-Workers) so while I think this was the agreed upon change I may be mistaken.