### PR TITLE
Add signature context

### DIFF
--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -480,7 +480,7 @@ The signature parameters component value is the serialization of the signature p
 * `nonce`: A random unique value generated for this signature as a String value.
 * `alg`: The HTTP message signature algorithm from the HTTP Message Signature Algorithm Registry, as a String value.
 * `keyid`: The identifier for the key material as a String value.
-* `context`: A context for the signature as a String value. This value is used by applications to help identify relevant signatures.
+* `context`: A context for the signature as a String value. This value is used by applications to help identify the signature's validity in specific applications or protocols. Context is often needed for avoiding cross-protocol attacks.
 
 Additional parameters can be defined in the [HTTP Signature Parameters Registry](#iana-param-contents). Note that there is no general ordering to the parameters, but once an ordering is chosen for a given set of parameters, it cannot be changed without altering the signature parameters value.
 

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -2482,6 +2482,7 @@ Jeffrey Yasskin.
 
   - -12
      * Added "context" parameter.
+     * Added set of safe transformation examples.
 
   - -11
      * Added ABNF references, coalesced ABNF rules.

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -480,6 +480,7 @@ The signature parameters component value is the serialization of the signature p
 * `nonce`: A random unique value generated for this signature as a String value.
 * `alg`: The HTTP message signature algorithm from the HTTP Message Signature Algorithm Registry, as a String value.
 * `keyid`: The identifier for the key material as a String value.
+* `context`: A context for the signature as a String value. This value is used by applications to help identify relevant signatures.
 
 Additional parameters can be defined in the [HTTP Signature Parameters Registry](#iana-param-contents). Note that there is no general ordering to the parameters, but once an ordering is chosen for a given set of parameters, it cannot be changed without altering the signature parameters value.
 
@@ -1173,7 +1174,8 @@ Some non-normative examples of additional requirements an application might defi
 - Ensuring successful dereferencing of the `keyid` parameter to valid and appropriate key material.
 - Prohibiting the use of certain algorithms, or mandating the use of a specific algorithm.
 - Requiring keys to be of a certain size (e.g., 2048 bits vs. 1024 bits).
-- Enforcing uniqueness of a `nonce` value.
+- Enforcing uniqueness of the `nonce` parameter.
+- Requiring an application-specific value for the `context` parameter.
 
 Application-specific requirements are expected and encouraged. When an application defines additional requirements, it MUST enforce them during the signature verification process, and signature verification MUST fail if the signature does not conform to the application's requirements.
 
@@ -1579,6 +1581,7 @@ The table below contains the initial contents of the HTTP Signature Metadata Par
 |`expires`|Timestamp of proposed signature expiration| {{signature-params}} of {{&SELF}}|
 |`keyid`|Key identifier for the signing and verification keys used to create this signature| {{signature-params}} of {{&SELF}}|
 |`nonce`|A single-use nonce value| {{signature-params}} of {{&SELF}}|
+|`context`|An application-specific context for a signature| {{signature-params}} of {{&SELF}}|
 {: title="Initial contents of the HTTP Signature Metadata Parameters Registry." }
 
 ## HTTP Signature Derived Component Names Registry {#content-registry}

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -2158,7 +2158,7 @@ Note that the RSA PSS algorithm in use here is non-deterministic, meaning a diff
 
 ### Selective Covered Components using rsa-pss-sha512
 
-This example covers additional components (the authority, the Content-Digest header field, and a single named query parameter) in `test-request` using the `rsa-pss-sha512` algorithm.
+This example covers additional components (the authority, the Content-Digest header field, and a single named query parameter) in `test-request` using the `rsa-pss-sha512` algorithm. This example also adds a `context` parameter with the application-specific value of `header-example`.
 
 The corresponding signature base is:
 
@@ -2171,7 +2171,8 @@ NOTE: '\' line wrapping per RFC 8792
 "@query-param";name="Pet": dog
 "@signature-params": ("@authority" "content-digest" \
   "@query-param";name="Pet")\
-  ;created=1618884473;keyid="test-key-rsa-pss"
+  ;created=1618884473;keyid="test-key-rsa-pss"\
+  ;context="header-example"
 ~~~
 
 
@@ -2183,13 +2184,13 @@ NOTE: '\' line wrapping per RFC 8792
 
 Signature-Input: sig-b22=("@authority" "content-digest" \
   "@query-param";name="Pet");created=1618884473\
-  ;keyid="test-key-rsa-pss"
-Signature: sig-b22=:W2kxR52X0tXN9u7yjyPeWa0T3D0SVG8KkPo+lOWyb2TGdLz\
-  ixWjUlbehjnNhzA+wFWnE6+hdKH8KR6Z9FvsxCc+44XrqxzT7Vcsror5SjMyfx6Nq\
-  tELklj1u2L4JovANI80BSoVobSoc+v9NRVWJZU7WAVow8H2CucCcv2cy1tKFCTMyc\
-  m9LQrIz63Tg5tcGWj64b12nmwj9TwwkCygfz0MTyIytjYLVzKw7mXpL4jGFZ5lsw2\
-  VT2eB3qpF2d/Psy0p1heKhrkz9uvKeCoj+P5QjLMS4eirHDqpKqe9YmCaMsJAUYSU\
-  M86qC8qO6vMQhTMegTkEe25DquVcTiOAEAw==:
+  ;keyid="test-key-rsa-pss";context="header-example"
+Signature: sig-b22=:SW3AKyCPY7PQSARlOEg8+tb43JD4uYGBrt6G+RWKgrOZ9ZJ\
+  Wq8VnVM1qTcdjChi6HGZI4xDwKZteoQH8mj2HT1cWdUTxu2JaUvcJDINpa0m20NYy\
+  wRu/HLXmh/FfeefGIUpkAneT/X/sWL/ShiTtp7REtxdJaiLCjQidY9eUpFmBXPMdR\
+  /FiYI3hGWarGGiGmTpgbjI713ywhKoGPm7Q8lpfhz5T59tOsZVPxlqdpwPD0RVGOw\
+  ZMzI5VzoY4YaGrB2fqvPOxNUNuh5bveYQOYAmzmpDaLfgkQB/C4AHzKWAYs9yV6Wf\
+  78u4en7AP1Y+iM0G6MviZvX1/lcgC2n1bDg==:
 ~~~
 
 Note that the RSA PSS algorithm in use here is non-deterministic, meaning a different signature value will be created every time the algorithm is run. The signature value provided here can be validated against the given keys, but newly-generated signature values are not expected to match the example. See {{security-nondeterministic}}.

--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -208,7 +208,7 @@ We can identify these types of transformations as ones that should not prevent s
 
 HTTP Message Signatures are designed to be a general-purpose security mechanism applicable in a wide variety of circumstances and applications. In order to properly and safely apply HTTP Message Signatures, an application or profile of this specification MUST specify all of the following items:
 
-- The set of [component identifiers](#covered-content) that are expected and required to be included in the covered components list. For example, an authorization protocol could mandate that the Authorization field be covered to protect the authorization credentials and mandate the signature parameters contain a `created` parameter, while an API expecting semantically relevant HTTP message content could require the Content-Digest header to be present and covered.
+- The set of [component identifiers](#covered-content) and [signature parameters](#signature-params) that are expected and required to be included in the covered components list. For example, an authorization protocol could mandate that the Authorization field be covered to protect the authorization credentials and mandate the signature parameters contain a `created` parameter, while an API expecting semantically relevant HTTP message content could require the Content-Digest header to be present and covered as well as mandate a value for `context` that is specific to the API being protected.
 - A means of retrieving the key material used to verify the signature. An application will usually use the `keyid` parameter of the signature parameters ({{signature-params}}) and define rules for resolving a key from there, though the appropriate key could be known from other means such as pre-registration of a signer's key.
 - A means of determining the signature algorithm used to verify the signature is appropriate for the key material. For example, the process could use the `alg` parameter of the signature parameters ({{signature-params}}) to state the algorithm explicitly, derive the algorithm from the key material, or use some pre-configured algorithm agreed upon by the signer and verifier.
 - A means of determining that a given key and algorithm presented in the request are appropriate for the request being made. For example, a server expecting only ECDSA signatures should know to reject any RSA signatures, or a server expecting asymmetric cryptography should know to reject any symmetric cryptography.
@@ -480,7 +480,7 @@ The signature parameters component value is the serialization of the signature p
 * `nonce`: A random unique value generated for this signature as a String value.
 * `alg`: The HTTP message signature algorithm from the HTTP Message Signature Algorithm Registry, as a String value.
 * `keyid`: The identifier for the key material as a String value.
-* `context`: A context for the signature as a String value. This value is used by applications to help identify the signature's validity in specific applications or protocols. Context is often needed for avoiding cross-protocol attacks.
+* `context`: An application-specific context for the signature as a String value. This value is used by applications to help identify signatures relevant for specific applications or protocols.
 
 Additional parameters can be defined in the [HTTP Signature Parameters Registry](#iana-param-contents). Note that there is no general ordering to the parameters, but once an ordering is chosen for a given set of parameters, it cannot be changed without altering the signature parameters value.
 
@@ -1898,6 +1898,10 @@ In most circumstances, this causes the signature validation to fail as expected,
 
 To counter this, an application needs to validate the content of the fields covered in the signature in addition to ensuring that the signature itself validates. With such protections, the attacker's padding attack would be rejected by the field value processor, even in the case where the attacker could force a signature collision.
 
+## Cross-Application Signature Context {#security-signature-context}
+
+Multiple applications and protocols could apply HTTP signatures on the same message simultaneously. A naive verifier could become confused in processing multiple signatures, either accepting or rejecting a message based on an unrelated or irrelevant signature. In order to help an application select which signatures apply to its own processing, the application can declare a specific value for the `context` signature parameter. For example, a signature targeting an application gateway could require `context="app-gateway"` as part of the signature parameters for that application.
+
 # Privacy Considerations {#privacy}
 
 ## Identification through Keys {#privacy-identify-keys}
@@ -2474,6 +2478,9 @@ Jeffrey Yasskin.
 *RFC EDITOR: please remove this section before publication*
 
 - draft-ietf-httpbis-message-signatures
+
+  - -12
+     * Added "context" parameter.
 
   - -11
      * Added ABNF references, coalesced ABNF rules.


### PR DESCRIPTION
Adds an optional `context` parameter to signatures, to allow applications to signal specific usage between the signer and verifier.

Closes #2133

This PR does not add this to any examples yet, but we probably should if accepted.
