### PR TITLE
RFC6265bis: Compare cookie name prefixes case-insensitively

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2589,6 +2589,9 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 * Add note regarding Service Worker's computation of "site for cookies":
   <https://github.com/httpwg/http-extensions/pull/2217>
 
+* Compare cookie name prefixes case-insensitively:
+  <https://github.com/httpwg/http-extensions/pull/2236>
+
 # Acknowledgements
 {:numbered="false"}
 RFC 6265 was written by Adam Barth. This document is an update of RFC 6265,

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1106,8 +1106,8 @@ SHOULD be processed unless ignored according to the user agent's cookie policy.
 
 ## Cookie Name Prefixes {#ua-name-prefixes}
 
-User agents' requirements for cookie name prefixes differ slightly than
-servers' ({{server-name-prefixes}}) in that UAs MST match the prefix string
+User agents' requirements for cookie name prefixes differ slightly from
+servers' ({{server-name-prefixes}}) in that UAs MUST match the prefix string
 case-insensitively.
 
 The normative requirements for the prefixes are detailed in the storage model


### PR DESCRIPTION
Closes #2231

Some servers are case-insensitive with cookie names which can lead to
security problems when a server assumes that cookie prefixes are too.

This PR instructs UAs to process prefixes case-insensitively to
compensate.