### PR TITLE
RFC6265bis: Prevent nameless cookies with prefixed values

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1671,10 +1671,10 @@ user agent MUST process the cookie as follows:
     true, abort these steps and ignore the cookie:
 
     * the cookie-value begins with a case-insensitive match for the string
-    "__Secure-"
+      "__Secure-"
 
     * the cookie-value begins with a case-insensitive match for the string
-    "__Host-"
+      "__Host-"
 
 23. If the cookie store contains a cookie with the same name, domain,
     host-only-flag, and path as the newly-created cookie:
@@ -2597,6 +2597,9 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 
 * Update editors and the acknowledgements
   <https://github.com/httpwg/http-extensions/pull/2244>
+  
+* Prevent nameless cookies with prefixed values
+  <https://github.com/httpwg/http-extensions/pull/2251>
 
 # Acknowledgements
 {:numbered="false"}

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1667,7 +1667,16 @@ user agent MUST process the cookie as follows:
     3.  The cookie-attribute-list contains an attribute with an attribute-name
         of "Path", and the cookie's path is `/`.
 
-22. If the cookie store contains a cookie with the same name, domain,
+22. If the cookie-name is empty and either of the following conditions are
+    true, abort these steps and ignore the cookie:
+
+    * the cookie-value begins with a case-insensitive match for the string
+    "__Secure-"
+
+    * the cookie-value begins with a case-insensitive match for the string
+    "__Host-"
+
+23. If the cookie store contains a cookie with the same name, domain,
     host-only-flag, and path as the newly-created cookie:
 
     1.  Let old-cookie be the existing cookie with the same name, domain,
@@ -1684,7 +1693,7 @@ user agent MUST process the cookie as follows:
 
     4.  Remove the old-cookie from the cookie store.
 
-23. Insert the newly-created cookie into the cookie store.
+24. Insert the newly-created cookie into the cookie store.
 
 A cookie is "expired" if the cookie has an expiry date in the past.
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2597,7 +2597,7 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 
 * Update editors and the acknowledgements
   <https://github.com/httpwg/http-extensions/pull/2244>
-  
+
 * Prevent nameless cookies with prefixed values
   <https://github.com/httpwg/http-extensions/pull/2251>
 


### PR DESCRIPTION
Modify the cookie storage algorithm to reject cookies that:

- Do not have a name
- Have values that look like cookie prefixes

As mentioned in #2229, malicious servers can exploit nameless cookies to impersonate prefix'd cookies.