### PR TITLE
Update cookie-value definition to reflect browser behavior

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2587,6 +2587,9 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 * Update editors and the acknowledgements
   <https://github.com/httpwg/http-extensions/pull/2244>
 
+* Update cookie-value definition to reflect browser behavior
+  <https://github.com/httpwg/http-extensions/pull/2270>
+
 # Acknowledgements
 {:numbered="false"}
 RFC 6265 was written by Adam Barth. This document is an update of RFC 6265,

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -483,10 +483,8 @@ set-cookie-string = BWS cookie-pair *( BWS ";" OWS cookie-av )
 cookie-pair       = cookie-name BWS "=" BWS cookie-value
 cookie-name       = 1*cookie-octet
 cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
-cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
-                      ; US-ASCII characters excluding CTLs,
-                      ; whitespace DQUOTE, comma, semicolon,
-                      ; and backslash
+cookie-octet      = %x20-3A / %x3C-7E / %x80-FF
+                      ; octets excluding CTLs and semicolon
 
 cookie-av         = expires-av / max-age-av / domain-av /
                     path-av / secure-av / httponly-av /


### PR DESCRIPTION
I recently ran into a problem where browsers were allowing cookies to be set containing values that standard libraries were failing to parse. These libraries are mostly following the relatively obsolete published RFC6265 (with tweaks), which limits a lot of characters that browsers allow and frequently appear inside cookies.

As such, this updates section 4.1.1 to reflect the characters that browsers allow to be set inside cookie values: any 8-bit octet except for control characters and semicolons.

For reference as to how browsers handle cookie setting:

* Chromium: [any octet except control characters and semicolons](https://source.chromium.org/chromium/chromium/src/+/main:net/cookies/parsed_cookie.cc;drc=796d9f7be35cc8f766fabc6e84df424046460890;l=495)
* Firefox: [any octet except control characters and semicolons, but allowing 0x09 (htab) and 0x7F (del)](https://searchfox.org/mozilla-central/source/netwerk/cookie/CookieCommons.cpp#210)
* Safari: seems to be any ASCII (7-bit) character except control characters (which includes htab) and semicolons

I was led down this rabbit hole by Golang:
* Golang: [any ASCII (7-bit) character except control characters, double quotes, semicolons, and backslashes](https://cs.opensource.google/go/go/+/master:src/net/http/cookie.go;l=414)
* Python: too many regular expressions for me to read through, but seems to behave the same as Golang

As for servers:
* nginx: lets you set a `Set-Cookie` with the characters listed above, so every browser accepts commas, semicolons, and backslashes, Firefox and Chromium allow unicode, etc.