### PR TITLE
Proposal of server-generated upload URLs

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -75,7 +75,7 @@ The terms byte sequence, Item, string, sf-binary, sf-boolean, sf-integer, sf-str
 
 The terms client and server are imported from {{HTTP}}.
 
-Upload: A sequence of one or more procedures, uniquely identified by a token chosen by a client.
+Upload: A sequence of one or more procedures, uniquely identified by an upload URL chosen by a server.
 
 Procedure: An HTTP message exchange for that can be used for resumable uploads.
 
@@ -88,8 +88,7 @@ The Resumable Uploads Protocol consists of several procedures that rely on HTTP 
 * Upload Appending Procedure ({{upload-appending}})
 * Upload Cancellation Procedure ({{upload-cancellation}})
 
-A single upload is a sequence of one or more procedures. Each upload is uniquely
-identified by a token chosen by a client. The token is carried in the Upload-Token header field; see {{upload-token}}.
+A single upload is a sequence of one or more procedures. Each upload is uniquely identified by an upload URL chosen by a server.
 
 The remainder of this section uses examples of a file upload to illustrate permutations of procedure sequence. Note, however, that HTTP message exchanges use representation data (see {{Section 8.1 of HTTP}}), which means that procedures can apply to many forms of content.
 
@@ -97,21 +96,22 @@ The remainder of this section uses examples of a file upload to illustrate permu
 
 In this example, the client first attempts to upload a file with a known size in a single HTTP request. An interruption occurs and the client then attempts to resume the upload using subsequent HTTP requests.
 
-1) The Upload Creation Procedure ({{upload-creation}}) can be used to notify the server that the client wants to begin an upload. The server should then reserve the required resources to accept the upload from the client. The client also begins transferring the entire file in the request body. The request includes the Upload-Token header, which is used for identifying future requests related to this upload. An informational response can be sent to the client to signal the support of resumable upload on the server.
+1) The Upload Creation Procedure ({{upload-creation}}) can be used to notify the server that the client wants to begin an upload. The server should then reserve the required resources to accept the upload from the client. The client also begins transferring the entire file in the request body. An informational response can be sent to the client to signal the support of resumable upload on the server and transmit the upload URL in the Location header, which is used for identifying future requests related to this upload.
 
 ~~~
 Client                                  Server
 |                                            |
-| POST with Upload-Token                     |
+| POST                                       |
 |------------------------------------------->|
 |                                            |
 |                                            | Reserve resources
-|                                            | for Upload-Token
+|                                            | for upload
 |                                            |------------------
 |                                            |                 |
 |                                            |<-----------------
 |                                            |
 |            104 Upload Resumption Supported |
+|            with upload URL                 |
 |<-------------------------------------------|
 |                                            |
 | Flow Interrupted                           |
@@ -120,12 +120,12 @@ Client                                  Server
 ~~~
 {: #fig-upload-creation-procedure title="Upload Creation Procedure"}
 
-2) If the connection to the server gets interrupted during the Upload Creation Procedure, the client may want to resume the upload. Before this is possible, the client must know the amount of data that the server was able to receive before the connection got interrupted. To achieve this, the client uses the Offset Retrieving Procedure ({{offset-retrieving}}) to obtain the upload's offset.
+2) If the connection to the server gets interrupted during the Upload Creation Procedure, the client may want to resume the upload. Before this is possible, the client must know the amount of data that the server was able to receive before the connection got interrupted. To achieve this, the client uses the Offset Retrieving Procedure ({{offset-retrieving}}) to obtain the upload's offset using the upload URL.
 
 ~~~
 Client                                      Server
 |                                                |
-| HEAD with Upload-Token                         |
+| HEAD to upload URL                             |
 |----------------------------------------------->|
 |                                                |
 |              204 No Content with Upload-Offset |
@@ -139,7 +139,7 @@ Client                                      Server
 ~~~
 Client                                      Server
 |                                                |
-| PATCH with Upload-Token and Upload-Offset      |
+| PATCH to upload URL with Upload-Offset         |
 |----------------------------------------------->|
 |                                                |
 |                      201 Created on completion |
@@ -153,7 +153,7 @@ Client                                      Server
 ~~~
 Client                                      Server
 |                                                |
-| DELETE with Upload-Token                       |
+| DELETE to upload URL                           |
 |----------------------------------------------->|
 |                                                |
 |                   204 No Content on completion |
@@ -173,11 +173,11 @@ This example shows how the client, with prior knowledge about the server's resum
 ~~~
 Client                                      Server
 |                                                |
-| POST with Upload-Token and Upload-Incomplete   |
+| POST with Upload-Incomplete                    |
 |----------------------------------------------->|
 |                                                |
 |             201 Created with Upload-Incomplete |
-|              on completion                     |
+|              and Location on completion        |
 |<-----------------------------------------------|
 |                                                |
 ~~~
@@ -188,7 +188,7 @@ Client                                      Server
 ~~~
 Client                                      Server
 |                                                |
-| PATCH with Upload-Token and Upload-Offset      |
+| PATCH to upload URL and Upload-Offset          |
 |----------------------------------------------->|
 |                                                |
 |                      201 Created on completion |
@@ -203,11 +203,11 @@ The Upload Creation Procedure is intended for starting a new upload. A limited f
 
 This procedure is designed to be compatible with a regular upload. Therefore all methods are allowed with the exception of `GET`, `HEAD`, `DELETE`, and `OPTIONS`. All response status codes are allowed. The client is RECOMMENDED to use the `POST` method if not otherwise intended. The server MAY only support a limited number of methods.
 
-The request MUST include the `Upload-Token` header field ({{upload-token}}) which uniquely identifies an upload. The client MUST NOT reuse the token for a different upload. The request MUST NOT include the `Upload-Offset` header.
+The request MUST include the `Upload-Incomplete` header field ({{upload-incomplete}}). It MUST be set to true if the end of the request body is not the end of the upload. Otherwise, it MUST be set to false. This header field can be used for request identification by a server. The request MUST NOT include the `Upload-Offset` header.
 
-If the end of the request body is not the end of the upload, the `Upload-Incomplete` header field ({{upload-incomplete}}) MUST be set to true.
+If the request is valid, the server SHOULD create an upload resource. If so, the server MUST include the `Location` header in the response and set to the upload URL, which points to the created upload resource. The client MAY use this upload URL to execute the Offset Retrieving Procedure ({{offset-retrieving}}), Upload Appending Procedure ({{upload-appending}}), or Upload Cancellation Procedure ({{upload-cancellation}}).
 
-If the server already has an active upload with the same token in the `Upload-Token` header field, it MUST respond with `409 (Conflict)` status code.
+As soon as the upload resource is available, the server MAY send an informational response with `104 (Upload Resumption Supported)` status to the client while the request body is being uploaded. In this informational response, the `Location` header field MSUT be set to the upload URL.
 
 The server MUST send the `Upload-Offset` header in the response if it considers the upload active, either when the response is a success (e.g. `201 (Created)`), or when the response is a failure (e.g. `409 (Conflict)`). The value MUST be equal to the end offset of the entire upload, or the begin offset of the next chunk if the upload is still incomplete. The client SHOULD consider the upload failed if the response status code indicates a success but the offset in the `Upload-Offset` header field in the response does not equal to the begin offset plus the number of bytes uploaded in the request.
 
@@ -220,15 +220,16 @@ If the request completes successfully but the entire upload is not yet complete 
 :scheme: https
 :authority: example.com
 :path: /upload
-upload-token: :SGVs…SGU=:
-upload-draft-interop-version: 2
+upload-draft-interop-version: 3
 content-length: 100
 [content (100 bytes)]
 
 :status: 104
-upload-draft-interop-version: 2
+upload-draft-interop-version: 3
+location: https://example.com/upload/b530ce8ff
 
 :status: 201
+location: https://example.com/upload/b530ce8ff
 upload-offset: 100
 ~~~
 
@@ -237,26 +238,26 @@ upload-offset: 100
 :scheme: https
 :authority: example.com
 :path: /upload
-upload-token: :SGVs…SGU=:
-upload-draft-interop-version: 2
+upload-draft-interop-version: 3
 upload-incomplete: ?1
 content-length: 25
 [partial content (25 bytes)]
 
 :status: 201
+location: https://example.com/upload/b530ce8ff
 upload-incomplete: ?1
 upload-offset: 25
 ~~~
 
-The client MAY automatically attempt upload resumption when the connection is terminated unexpectedly, or if a server error status code between 500 and 599 (inclusive) is received. The client SHOULD NOT automatically retry if a client error status code between 400 and 499 (inclusive) is received.
+If the client received an informational repsonse with the upload URL, it MAY automatically attempt upload resumption when the connection is terminated unexpectedly, or if a server error status code between 500 and 599 (inclusive) is received. The client SHOULD NOT automatically retry if a client error status code between 400 and 499 (inclusive) is received.
 
 File metadata can affect how servers might act on the uploaded file. Clients can send Representation Metadata (see {{Section 8.3 of HTTP}}) in the Upload Creation Procedure request that starts an upload. Servers MAY interpret this metadata or MAY ignore it. The `Content-Type` header can be used to indicate the MIME type of the file. The `Content-Disposition` header can be used to transmit a filename. If included, the parameters SHOULD be either `filename`, `filename*` or `boundary`.
 
 ## Feature Detection
 
-If the client has no knowledge of whether the server supports resumable upload, the Upload Creation Procedure MAY be used with some additional constraints. In particular, the `Upload-Incomplete` header field ({{upload-incomplete}}) MUST NOT be sent in the request if the server support is unclear. This allows the upload to function as if it is a regular upload.
+If the client has no knowledge of whether the server supports resumable upload, the Upload Creation Procedure MAY be used with some additional constraints. In particular, the `Upload-Incomplete` header field ({{upload-incomplete}}) MUST NOT be set to true if the server support is unclear. This allows the upload to function as if it is a regular upload.
 
-If the server detects the Upload Creation Procedure and it supports resumable upload, an informational response with `104 (Upload Resumption Supported)` status MAY be sent to the client while the request body is being uploaded.
+The server SHOULD send the `104 (Upload Resumption Supported)` informational response to the client, to indicate its support for a resumable upload.
 
 The client MUST NOT attempt to resume an upload if it did not receive the `104 (Upload Resumption Supported)` informational response, and it does not have other signals of whether the server supporting resumable upload.
 
@@ -264,7 +265,7 @@ The client MUST NOT attempt to resume an upload if it did not receive the `104 (
 
 > **RFC Editor's Note:**  Please remove this section and `Upload-Draft-Interop-Version` from all examples prior to publication of a final version of this document.
 
-The current interop version is 2.
+The current interop version is 3.
 
 Client implementations of draft versions of the protocol MUST send a header field `Upload-Draft-Interop-Version` with the interop version as its value to its requests. Its ABNF is
 
@@ -282,21 +283,21 @@ The reason both the client and the server are sending and checking the draft ver
 
 # Offset Retrieving Procedure {#offset-retrieving}
 
-If an upload is interrupted, the client MAY attempt to fetch the offset of the incomplete upload by sending a `HEAD` request to the server with the same `Upload-Token` header field ({{upload-token}}). The client MUST NOT initiate this procedure without the knowledge of server support.
+If an upload is interrupted, the client MAY attempt to fetch the offset of the incomplete upload by sending a `HEAD` request to the upload URL, as obtained from the Upload Creation Procedure ({{upload-creation}}). The client MUST NOT initiate this procedure without the knowledge of server support.
 
-The request MUST use the `HEAD` method and include the `Upload-Token` header. The request MUST NOT include the `Upload-Offset` header or the `Upload-Incomplete` header. The server MUST reject the request with the `Upload-Offset` header or the `Upload-Incomplete` header by sending a `400 (Bad Request)` response.
+The request MUST NOT include the `Upload-Offset` header or the `Upload-Incomplete` header. The server MUST reject the request with the `Upload-Offset` header or the `Upload-Incomplete` header by sending a `400 (Bad Request)` response.
 
-If the server considers the upload associated with this token active, it MUST send back a `204 (No Content)` response. The response MUST include the `Upload-Offset` header set to the current resumption offset for the client. The response MUST include the `Upload-Incomplete` header which is set to true if and only if the upload is incomplete. An upload is considered complete if and only if the server completely and successfully received a corresponding Upload Creation Procedure ({{upload-creation}}) or Upload Appending Procedure ({{upload-appending}}) request with the `Upload-Incomplete` header being omitted or set to false.
+If the server considers the upload associated with this upload URL active, it MUST send back a `204 (No Content)` response. The response MUST include the `Upload-Offset` header set to the current resumption offset for the client. The response MUST include the `Upload-Incomplete` header which is set to true if and only if the upload is incomplete. An upload is considered complete if and only if the server completely and successfully received a corresponding Upload Creation Procedure ({{upload-creation}}) or Upload Appending Procedure ({{upload-appending}}) request with the `Upload-Incomplete` header being omitted or set to false.
 
 The client MUST NOT perform the Offset Retrieving Procedure ({{offset-retrieving}}) while the Upload Creation Procedure ({{upload-creation}}) or the Upload Appending Procedure ({{upload-appending}}) is in progress.
 
-The offset MUST be accepted by a subsequent Upload Appending Procedure ({{upload-appending}}). Due to network delay and reordering, the server might still be receiving data from an ongoing transfer for the same token, which in the client perspective has failed. The server MAY terminate any transfers for the same token before sending the response by abruptly terminating the HTTP connection or stream. Alternatively, the server MAY keep the ongoing transfer alive but ignore further bytes received past the offset.
+The offset MUST be accepted by a subsequent Upload Appending Procedure ({{upload-appending}}). Due to network delay and reordering, the server might still be receiving data from an ongoing transfer for the same upload URL, which in the client perspective has failed. The server MAY terminate any transfers for the same upload URL before sending the response by abruptly terminating the HTTP connection or stream. Alternatively, the server MAY keep the ongoing transfer alive but ignore further bytes received past the offset.
 
 The client MUST NOT start more than one Upload Appending Procedures ({{upload-appending}}) based on the resumption offset from a single Offset Retrieving Procedure ({{offset-retrieving}}).
 
 The response SHOULD include `Cache-Control: no-store` header to prevent HTTP caching.
 
-If the server does not consider the upload associated with this token active, it MUST respond with `404 (Not Found)` status code.
+If the server does not consider the upload associated with this upload URL active, it MUST respond with `404 (Not Found)` status code.
 
 The resumption offset can be less than or equal to the number of bytes the client has already sent. The client MAY reject an offset which is greater than the number of bytes it has already sent during this upload. The client is expected to handle backtracking of a reasonable length. If the offset is invalid for this upload, or if the client cannot backtrack to the offset and reproduce the same content it has already sent, the upload MUST be considered a failure. The client MAY use the Upload Cancellation Procedure ({{upload-cancellation}}) to cancel the upload after rejecting the offset.
 
@@ -304,12 +305,12 @@ The resumption offset can be less than or equal to the number of bytes the clien
 :method: HEAD
 :scheme: https
 :authority: example.com
-:path: /upload
-upload-token: :SGVs…SGU=:
-upload-draft-interop-version: 2
+:path: /upload/b530ce8ff
+upload-draft-interop-version: 3
 
 :status: 204
 upload-offset: 100
+upload-incomplete: ?1
 cache-control: no-store
 ~~~
 
@@ -319,15 +320,15 @@ The client SHOULD NOT automatically retry if a client error status code between 
 
 The Upload Appending Procedure is used for resuming an existing upload.
 
-The request MUST use the `PATCH` method and include the `Upload-Token` header. The `Upload-Offset` header field ({{upload-offset}}) MUST be set to the resumption offset.
+The request MUST use the `PATCH` method and be sent to the upload URL, as obtained from the Upload Creation Procedure ({{upload-creation}}). The `Upload-Offset` header field ({{upload-offset}}) MUST be set to the resumption offset.
 
 If the end of the request body is not the end of the upload, the `Upload-Incomplete` header field ({{upload-incomplete}}) MUST be set to true.
 
 The server SHOULD respect representation metadata received in the Upload Creation Procedure ({{upload-creation}}) and ignore any representation metadata received in the Upload Appending Procedure ({{upload-appending}}).
 
-If the server does not consider the upload associated with the token in the `Upload-Token` header field active, it MUST respond with `404 (Not Found)` status code.
+If the server does not consider the upload associated with the upload URL active, it MUST respond with `404 (Not Found)` status code.
 
-The client MUST NOT perform multiple upload transfers for the same token using Upload Creation Procedures ({{upload-creation}}) or Upload Appending Procedures ({{upload-appending}}) in parallel to avoid race conditions and data loss or corruption. The server is RECOMMENDED to take measures to avoid parallel upload transfers: The server MAY terminate any ongoing Upload Creation Procedure ({{upload-creation}}) or Upload Appending Procedure ({{upload-appending}}) for the same token. Since the client is not allowed to perform multiple transfers in parallel, the server can assume that the previous attempt has already failed. Therefore, the server MAY abruptly terminate the previous HTTP connection or stream.
+The client MUST NOT perform multiple upload transfers for the same upload URL using Upload Creation Procedures ({{upload-creation}}) or Upload Appending Procedures ({{upload-appending}}) in parallel to avoid race conditions and data loss or corruption. The server is RECOMMENDED to take measures to avoid parallel upload transfers: The server MAY terminate any ongoing Upload Creation Procedure ({{upload-creation}}) or Upload Appending Procedure ({{upload-appending}}) for the same upload URL. Since the client is not allowed to perform multiple transfers in parallel, the server can assume that the previous attempt has already failed. Therefore, the server MAY abruptly terminate the previous HTTP connection or stream.
 
 If the offset in the `Upload-Offset` header field does not match the offset provided by the immediate previous Offset Retrieving Procedure ({{offset-retrieving}}), or the end offset of the immediate previous incomplete transfer, the server MUST respond with `409 (Conflict)` status code.
 
@@ -341,10 +342,9 @@ If the request completes successfully but the entire upload is not yet complete 
 :method: PATCH
 :scheme: https
 :authority: example.com
-:path: /upload
-upload-token: :SGVs…SGU=:
+:path: /upload/b530ce8ff
 upload-offset: 100
-upload-draft-interop-version: 2
+upload-draft-interop-version: 3
 content-length: 100
 [content (100 bytes)]
 
@@ -356,15 +356,15 @@ The client MAY automatically attempt upload resumption when the connection is te
 
 # Upload Cancellation Procedure {#upload-cancellation}
 
-If the client wants to terminate the transfer without the ability to resume, it MAY send a `DELETE` request to the server along with the `Upload-Token` which is an indication that the client is no longer interested in uploading this body and the server can release resources associated with this token. The client MUST NOT initiate this procedure without the knowledge of server support.
+If the client wants to terminate the transfer without the ability to resume, it MAY send a `DELETE` request to the upload URL, as obtained from the Upload Creation Procedure ({{upload-creation}}). It is an indication that the client is no longer interested in uploading this body and the server can release resources associated with this upload URL. The client MUST NOT initiate this procedure without the knowledge of server support.
 
-The request MUST use the `DELETE` method and include the `Upload-Token` header. The request MUST NOT include the `Upload-Offset` header or the `Upload-Incomplete` header. The server MUST reject the request with the `Upload-Offset` header or the `Upload-Incomplete` header by sending a `400 (Bad Request)` response.
+The request MUST use the `DELETE` method. The request MUST NOT include the `Upload-Offset` header or the `Upload-Incomplete` header. The server MUST reject the request with the `Upload-Offset` header or the `Upload-Incomplete` header by sending a `400 (Bad Request)` response.
 
-If the server has successfully deactivated this token, it MUST send back a `204 (No Content)` response.
+If the server has successfully deactivated this upload URL, it MUST send back a `204 (No Content)` response.
 
-The server MAY terminate any ongoing Upload Creation Procedure ({{upload-creation}}) or Upload Appending Procedure ({{upload-appending}}) for the same token before sending the response by abruptly terminating the HTTP connection or stream.
+The server MAY terminate any ongoing Upload Creation Procedure ({{upload-creation}}) or Upload Appending Procedure ({{upload-appending}}) for the same upload URL before sending the response by abruptly terminating the HTTP connection or stream.
 
-If the server does not consider the upload associated with this token active, it MUST respond with `404 (Not Found)` status code.
+If the server does not consider the upload associated with this upload URL active, it MUST respond with `404 (Not Found)` status code.
 
 If the server does not support cancellation, it MUST respond with `405 (Method Not Allowed)` status code.
 
@@ -372,9 +372,8 @@ If the server does not support cancellation, it MUST respond with `405 (Method N
 :method: DELETE
 :scheme: https
 :authority: example.com
-:path: /upload
-upload-token: :SGVs…SGU=:
-upload-draft-interop-version: 2
+:path: /upload/b530ce8ff
+upload-draft-interop-version: 3
 
 :status: 204
 ~~~
@@ -383,29 +382,17 @@ upload-draft-interop-version: 2
 
 The Upload Creation Procedure ({{upload-creation}}) supports arbitrary methods including `PATCH`, therefore it is not possible to identify the procedure of a request purely by its method. The following algorithm is RECOMMENDED to identify the procedure from a request for a generic implementation:
 
-1. The `Upload-Token` header is not present: Not a resumable upload.
+1. The request URL is not an upload URL (i.e. does not point to an upload resource): Upload Creation Procedure ({{upload-creation}})
 
-2. The `Upload-Offset` header is present: Upload Appending Procedure ({{upload-appending}}).
+2. The request URL is an upload URL and the method is `HEAD`: Offset Retrieving Procedure ({{offset-retrieving}}).
 
-3. The method is `HEAD`: Offset Retrieving Procedure ({{offset-retrieving}}).
+3. The request URL is an upload URL and the method is `DELETE`: Upload Cancellation Procedure ({{upload-cancellation}}).
 
-4. The method is `DELETE`: Upload Cancellation Procedure ({{upload-cancellation}}).
+4. The request URL is an upload URL and the `Upload-Offset` header is present: Upload Appending Procedure ({{upload-appending}}).
 
-5. Otherwise: Upload Creation Procedure ({{upload-creation}}).
+5. Otherwise: Not a resumable upload.
 
 # Header Fields
-
-## Upload-Token
-
-The `Upload-Token` request header field is an Item Structured Header (see {{Section 3.3 of STRUCTURED-FIELDS}}) carrying the token used for identification of a specific upload. Its value MUST be a byte sequence. Its ABNF is
-
-~~~ abnf
-Upload-Token = sf-binary
-~~~
-
-If not otherwise specified by the server, the client is RECOMMENDED to use 256-bit (32 bytes) cryptographically-secure random binary data as the value of the `Upload-Token`, in order to ensure that it is globally unique and non-guessable.
-
-A conforming implementation MUST be able to handle a `Upload-Token` field value of at least 128 octets.
 
 ## Upload-Offset
 
@@ -429,15 +416,13 @@ The `301 (Moved Permanently)` status code and the `302 (Found)` status code MUST
 
 # Security Considerations
 
-The tokens inside the `Upload-Token` header field can be selected by the client which has no knowledge of tokens picked by other client, so uniqueness cannot be guaranteed. If the token is guessable, an attacker can append malicious data to ongoing uploads. To mitigate these issues, 256-bit cryptographically-secure random binary data is recommended for the token.
-
-It is OPTIONAL for the server to partition upload tokens based on client identity established through other channels, such as Cookie or TLS client authentication. The client MAY relax the token strength if it is aware of server-side partitioning.
+The upload URL obtained through the Upload Creation Procedure ({{upload-creation}}) is the identifier used for modifying the upload. Without further protection of this upload URL, an attacker may use the upload URL to obtain information about an upload, append data to it, or cancel it. To prevent this, the server SHOULD ensure that only authorized clients can perform the Offset Retrieving Procedure ({{offset-retrieving}}), Upload Appending Procedure ({{upload-appending}}), or Upload Cancellation Procedure ({{upload-cancellation}}) for a given upload URL and otherwise reject the procedure.
 
 # IANA Considerations
 
 This specification registers the following entry in the Permanent Message Header Field Names registry established by {{!RFC3864}}:
 
-Header field name: Upload-Token, Upload-Offset, Upload-Incomplete
+Header field name: Upload-Offset, Upload-Incomplete
 
 Applicable protocol: http
 
@@ -459,7 +444,11 @@ Specification: This document
 
 --- back
 
-# Changes
+## Since draft-tus-httpbis-resumable-uploads-protocol-02
+
+* Remove Upload-Token and instead use Server-generated upload URL for upload identification.
+* Require the Upload-Incomplete header field in Upload Creation Procedure.
+* Increase the draft interop version.
 
 ## Since draft-tus-httpbis-resumable-uploads-protocol-01
 
@@ -470,10 +459,9 @@ Specification: This document
 
 * Split the Upload Transfer Procedure into the Upload Creation Procedure and the Upload Appending Procedure.
 
-
 # Informational Response
 
-The server is allowed to respond to Upload Creation Procedure ({{upload-creation}}) requests with a `104 (Upload Resumption Supported)` intermediate response as soon as the server has validated the request. This way, the client knows that the server supports resumable uploads before the complete response for the Upload Creation Procedure is received. The benefit is the clients can defer starting the actual data transfer until the server indicates full support of the incoming Upload Creation Procedure (i.e. resumable are supported, the provided upload token is active etc).
+The server is allowed to respond to Upload Creation Procedure ({{upload-creation}}) requests with a `104 (Upload Resumption Supported)` intermediate response as soon as the server has validated the request. This way, the client knows that the server supports resumable uploads before the complete response for the Upload Creation Procedure is received. The benefit is the clients can defer starting the actual data transfer until the server indicates full support of the incoming Upload Creation Procedure (i.e. resumable are supported, the provided upload URL is active etc).
 
 On the contrary, support for intermediate responses (the `1XX` range) in existing software is limited or not at all present. Such software includes proxies, firewalls, browsers, and HTTP libraries for clients and server. Therefore, the `104 (Upload Resumption Supported)` status code is optional and not mandatory for the successful completion of an upload. Otherwise, it might be impossible in some cases to implement resumable upload servers using existing software packages. Furthermore, as parts of the current internet infrastructure currently have limited support for intermediate responses, a successful delivery of a `104 (Upload Resumption Supported)` from the server to the client should be assumed.
 

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -418,7 +418,7 @@ The `301 (Moved Permanently)` status code and the `302 (Found)` status code MUST
 
 # Security Considerations
 
-The upload URL obtained through the Upload Creation Procedure ({{upload-creation}}) is the identifier used for modifying the upload. Without further protection of this upload URL, an attacker may use the upload URL to obtain information about an upload, append data to it, or cancel it. To prevent this, the server SHOULD ensure that only authorized clients can perform the Offset Retrieving Procedure ({{offset-retrieving}}), Upload Appending Procedure ({{upload-appending}}), or Upload Cancellation Procedure ({{upload-cancellation}}) for a given upload URL and otherwise reject the procedure.
+The upload URL obtained through the Upload Creation Procedure ({{upload-creation}}) is the identifier used for modifying the upload. Without further protection of this upload URL, an attacker may use the upload URL to obtain information about an upload, append data to it, or cancel it. To prevent this, the server SHOULD ensure that only authorized clients can perform the Offset Retrieving Procedure ({{offset-retrieving}}), Upload Appending Procedure ({{upload-appending}}), or Upload Cancellation Procedure ({{upload-cancellation}}) for a given upload URL and otherwise reject the procedure. In addition, the upload URL SHOULD be generated in such a way that makes it hard to be guessed by non-authorized clients.
 
 # IANA Considerations
 

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -207,7 +207,7 @@ The request MUST include the `Upload-Incomplete` header field ({{upload-incomple
 
 If the request is valid, the server SHOULD create an upload resource. If so, the server MUST include the `Location` header in the response and set to the upload URL, which points to the created upload resource. The client MAY use this upload URL to execute the Offset Retrieving Procedure ({{offset-retrieving}}), Upload Appending Procedure ({{upload-appending}}), or Upload Cancellation Procedure ({{upload-cancellation}}).
 
-As soon as the upload resource is available, the server MAY send an informational response with `104 (Upload Resumption Supported)` status to the client while the request body is being uploaded. In this informational response, the `Location` header field MSUT be set to the upload URL.
+As soon as the upload resource is available, the server MAY send an informational response with `104 (Upload Resumption Supported)` status to the client while the request body is being uploaded. In this informational response, the `Location` header field MUST be set to the upload URL.
 
 The server MUST send the `Upload-Offset` header in the response if it considers the upload active, either when the response is a success (e.g. `201 (Created)`), or when the response is a failure (e.g. `409 (Conflict)`). The value MUST be equal to the end offset of the entire upload, or the begin offset of the next chunk if the upload is still incomplete. The client SHOULD consider the upload failed if the response status code indicates a success but the offset in the `Upload-Offset` header field in the response does not equal to the begin offset plus the number of bytes uploaded in the request.
 


### PR DESCRIPTION
The current draft -00 of the resumable upload protocol uses a client-generated token to identify which procedures belong together. There has been valid criticism of this methodology, especially that the server is not able to control this identifier, which fits badly into the typical request-response schema of HTTP APIs. There seems to be a majority supporting the use of server-generated identifiers over client-generated ones.

That being said, the original intention of these tokens was two-folded and is still desirable:

1. Allow clients to upload small files in a single request, without the need of additional roundtrips.
2. Allow clients to resume an upload before receiving a response for the server by using the client-generated token.

We believe it is possible to achieve these two goals even when using server-generated uploads URLs by utilizing the Idempotency-Key header, whose draft is currently being discussed by the httpapi working group (https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/).

This PR proposes to move from client-generated tokens to server-generated URLs. The role of Idempotency-Key is not included here and is laid out in a separate issue: https://github.com/httpwg/http-extensions/issues/2293

Any feedback is welcome!