### PR TITLE
lose the aspiration for #2282

### DIFF
--- a/draft-ietf-httpbis-client-cert-field.md
+++ b/draft-ietf-httpbis-client-cert-field.md
@@ -53,7 +53,7 @@ informative:
 
 --- abstract
 
-This document defines HTTP extension header fields that allow a TLS
+This document describes HTTP extension header fields that allow a TLS
 terminating reverse proxy to convey the client certificate information of a
 mutually-authenticated TLS connection to the origin server in a common and
 predictable manner.

--- a/draft-ietf-httpbis-client-cert-field.md
+++ b/draft-ietf-httpbis-client-cert-field.md
@@ -97,7 +97,7 @@ are exposed, or how the certificate is encoded). A well-known predictable
 approach to this commonly occurring functionality could improve and simplify
 interoperability between independent implementations.
 
-This document aspires to standardize two HTTP header fields, `Client-Cert`
+This document describes two HTTP header fields, `Client-Cert`
 and `Client-Cert-Chain`,  which a TLS terminating reverse proxy (TTRP) adds to
 requests sent to the backend origin servers. The `Client-Cert` field value
 contains the end-entity client certificate from  the mutually-authenticated TLS


### PR DESCRIPTION
and use "describes" rather than "standardize" to better align w/ the Informational intended status