### PR TITLE
Add boilerplate

### DIFF
--- a/draft-ietf-httpbis-origin-h3.md
+++ b/draft-ietf-httpbis-origin-h3.md
@@ -27,6 +27,8 @@ normative:
     RFC9114
 
 informative:
+  QUIC-TRANSPORT:
+    RFC9000
 
 
 --- abstract
@@ -50,6 +52,9 @@ type.
 ## Notational Conventions
 
 {::boilerplate bcp14-tagged}
+
+Frame diagrams in this document use the format defined in {{Section 1.3 of
+QUIC-TRANSPORT}} to illustrate the order and size of fields.
 
 # The ORIGIN HTTP/3 Frame {#frame-origin}
 

--- a/draft-ietf-httpbis-origin-h3.md
+++ b/draft-ietf-httpbis-origin-h3.md
@@ -47,6 +47,10 @@ frames to be used with HTTP/3.
 origins are available on a given connection.  It defines a single HTTP/2 frame
 type.
 
+## Notational Conventions
+
+{::boilerplate bcp14-tagged}
+
 # The ORIGIN HTTP/3 Frame {#frame-origin}
 
 The ORIGIN HTTP/3 frame allows a server to indicate what origin(s)


### PR DESCRIPTION
@fpalombini

Adds the BCP14 boilerplate in a Notation Conventions section. As part of that, I noticed we don't reference any explanation of the frame layout language used -- it's the same used in QUIC and HTTP/3 -- so I added an RFC 9000 ref to pick that up in the same section.