### PR TITLE
Expand on how integrity preferences can be ignored

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -417,6 +417,14 @@ If `Want-Content-Digest` or `Want-Repr-Digest` are used in a response, it
 indicates that the server would like the client to provide the respective
 Integrity field on future requests.
 
+Integrity preference fields are only a hint. The receiver of the field can
+ignore it and send an Integrity field using any algorithm or omit the field
+entirely, for example see {{ex-server-selects-unsupported-algorithm}}. It is not
+a protocol error if preferences are ignored. Applications that use Integrity
+fields and Integrity preferences can define expectations or constraints that
+operate in addition to this specification. How to deal with an ignored
+preferences is a scenario that should be considered.
+
 `Want-Content-Digest` and `Want-Repr-Digest` are of type `Dictionary`
 where each:
 


### PR DESCRIPTION
And how users of digests are the ones responsible for deciding what to
do if something is ignore.

Fixes #2382
