### PR TITLE
Clarify that hashing bytes are base-64 encoded and give examples

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -257,8 +257,8 @@ where each:
 * key conveys the hashing algorithm (see {{algorithms}})
   used to compute the digest;
 * value is a `Byte Sequence` ({{Section 3.3.5 of STRUCTURED-FIELDS}}), that
-  conveys the base64 encoding of the byte output produced by the digest
-  calculation, delimited by colons.
+  conveys an encoded version of the byte output produced by the digest
+  calculation.
 
 For example:
 
@@ -319,8 +319,8 @@ STRUCTURED-FIELDS}}) where each:
 
 * key conveys the hashing algorithm (see {{algorithms}})
   used to compute the digest;
-* value is a `Byte Sequence`, that conveys the base64 encoding of the byte
-  output produced by the digest calculation, delimited by colons.
+* value is a `Byte Sequence`, that conveys an encoded version of the byte
+  output produced by the digest calculation.
 
 For example:
 
@@ -1270,10 +1270,10 @@ Content-Type: application/problem+json
 # Sample Digest Values
 
 This section shows examples of digest values for different hashing algorithms.
-The input value is the JSON object `{"hello": "world"}`. By virtue of using
-`Byte Sequence` ({{Section 3.3.5 of STRUCTURED-FIELDS}}) serialization, the
-digest value is the base64 encoding of the bytes calculated using the indicated
-hashing algorithm, delimited by colons.
+The input value is the JSON object `{"hello": "world"}`. The digest values are
+each produced by running the relevant hashing algorithm over the input and
+running the output bytes through `Byte Sequence` serialization; see {{Section
+4.1.8 of STRUCTURED-FIELDS}}.
 
 ~~~
 NOTE: '\' line wrapping per RFC 8792

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -256,8 +256,9 @@ where each:
 
 * key conveys the hashing algorithm (see {{algorithms}})
   used to compute the digest;
-* value is a `Byte Sequence` ({{Section 3.3.5 of STRUCTURED-FIELDS}}),
-  that contains the output of the digest calculation.
+* value is a `Byte Sequence` ({{Section 3.3.5 of STRUCTURED-FIELDS}}), that
+  conveys the base64 encoding of the byte output produced by the digest
+  calculation, delimited by colons.
 
 For example:
 
@@ -318,8 +319,8 @@ STRUCTURED-FIELDS}}) where each:
 
 * key conveys the hashing algorithm (see {{algorithms}})
   used to compute the digest;
-* value is a `Byte Sequence` that
-  contains the output of the digest calculation.
+* value is a `Byte Sequence`, that conveys the base64 encoding of the byte
+  output produced by the digest calculation, delimited by colons.
 
 For example:
 
@@ -1266,6 +1267,35 @@ Content-Type: application/problem+json
 ~~~
 {: title="Response advertising the supported algorithms"}
 
+# Sample Digest Values
+
+This section shows examples of digest values for different hashing algorithms.
+The input value is the JSON object `{"hello": "world"}`. By virtue of using
+`Byte Sequence` ({{Section 3.3.5 of STRUCTURED-FIELDS}}) serialization, the
+digest value is the base64 encoding of the bytes calculated using the indicated
+hashing algorithm, delimited by colons.
+
+~~~
+NOTE: '\' line wrapping per RFC 8792
+
+sha-512 -   :WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrI\
+            iYllu7BNNyealdVLvRwEmTHWXvJwew==:
+
+sha-256 -   :X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+
+md5 -       :Sd/dVLAcvNLSq16eXua5uQ==:
+
+sha -       :07CavjDP4u3/TungoUHJO/Wzr4c=:
+
+unixsum -   :jIw=:
+
+unixcksum - :rF3+Zw==:
+
+adler -     :OZkGFw==:
+
+crc32c -    :Q3lHIA==:
+~~~
+
 
 # Migrating from RFC 3230
 
@@ -1290,6 +1320,11 @@ see {{state-changing-requests}}, {{security}} and {{usage-in-signatures}}.
 RFC 3230 could never communicate
 the digest of HTTP message content in the Digest field;
 Content-Digest now provides that capability.
+
+RFC 3230 allowed algorithms to define their output encoding format for use with
+the Digest field. This resulted in a mixed of formats such as base64, hex or
+decimal. By virtue of using Structured fields, Content-Digest and Repr-Digest
+use only a single encoding format. Further explanation and examples is provided in {{sample-digest-values}}.
 
 # Acknowledgements
 {:numbered="false"}

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1324,7 +1324,7 @@ Content-Digest now provides that capability.
 RFC 3230 allowed algorithms to define their output encoding format for use with
 the Digest field. This resulted in a mixed of formats such as base64, hex or
 decimal. By virtue of using Structured fields, Content-Digest and Repr-Digest
-use only a single encoding format. Further explanation and examples is provided in {{sample-digest-values}}.
+use only a single encoding format. Further explanation and examples are provided in {{sample-digest-values}}.
 
 # Acknowledgements
 {:numbered="false"}

--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -1287,9 +1287,9 @@ md5 -       :Sd/dVLAcvNLSq16eXua5uQ==:
 
 sha -       :07CavjDP4u3/TungoUHJO/Wzr4c=:
 
-unixsum -   :jIw=:
+unixsum -   :GQU=:
 
-unixcksum - :rF3+Zw==:
+unixcksum - :7zsHAA==:
 
 adler -     :OZkGFw==:
 


### PR DESCRIPTION
With Digest, the encoding of the digest value was based on the digest
algorithm. For different algorithms, this varied between base64, hex
encoding or decimal encoding.

In this spec, we removed the variablilty by using SF Byte Sequence,
which is always serialized as a base-64 encoding of the input bytes. All
algorithms are now expected to use this format.

This change tries to make it more clear that we expect the input of the
Byte Sequence to be. For example, we really don't want people accidentally
base-64'ing the textual hex represenation output of cksum - that can
lead to interop pain.

To help implementers further, add a new appendix with some samples that
can be used as test vectors.

Closes #2385
