### PR TITLE
Add missing Upload-Incomplete header

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -221,6 +221,7 @@ If the request completes successfully but the entire upload is not yet complete 
 :authority: example.com
 :path: /upload
 upload-draft-interop-version: 3
+upload-incomplete: ?0
 content-length: 100
 [content (100 bytes)]
 


### PR DESCRIPTION
The Upload-Incomplete header is now required for all Upload Creation Procedures and was missing from this example. It is not mandatory for Upload Appending Procedure requests, so I didn't add it to its example of a PATCH request. @guoye-zhang do you still think the header is missing somewhere else?