### PR TITLE
Correct changelog in resumable-upload

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -447,11 +447,15 @@ Specification: This document
 
 --- back
 
-## Since draft-tus-httpbis-resumable-uploads-protocol-02
+## Since draft-ietf-httpbis-resumable-upload-00
 
 * Remove Upload-Token and instead use Server-generated upload URL for upload identification.
 * Require the Upload-Incomplete header field in Upload Creation Procedure.
 * Increase the draft interop version.
+
+## Since draft-tus-httpbis-resumable-uploads-protocol-02
+
+None
 
 ## Since draft-tus-httpbis-resumable-uploads-protocol-01
 


### PR DESCRIPTION
I think this PR corrects the changelog a bit, which was missing the entry for draft-ietf-httpbis-resumable-upload-00. This version was the same as draft-tus-httpbis-resumable-uploads-protocol-02 but published under a new name (with no changes to the content).