### PR TITLE
RFC6265bis: Advise the reader which section to implement

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -462,25 +462,25 @@ Cookie: SID=31d4d96e407aad42
 
 ## Which Requirements to Implement
 
-This section helps guide implementors in determining which requirements and
+This section helps guide implementers in determining which requirements and
 syntax they should implement. Choosing the wrong set of requirements could
 result in a lack of compatibility with other cookie implementations.
 
 It's important to note that being compatible means different things
-depending on the implementor's goals. These differences have built up over time
+depending on the implementer's goals. These differences have built up over time
 due to both intentional and unintentional spec changes, spec interpretations,
 and historical implementation differences.
 
 ### Cookie Producing Implementations
 
-An implementor should choose {{sane-profile}} whenever cookies are created and
+An implementer should choose {{sane-profile}} whenever cookies are created and
 will be sent to a user agent, such as a web browser. These implementations are
 frequently referred to as Servers by the spec but that term includes anything
 which primarily produces cookies. Some potential examples:
 
 * Server applications hosting a website
 
-* Programming languages or software frameworks that supports cookies
+* Programming languages or software frameworks that support cookies
 
 * Website add-ons, such as a business management suite
 
@@ -490,12 +490,12 @@ software framework and is later sent back to a server application which needs
 to read it. {{sane-profile}} advises best practices that help maximize this
 sense of compatibility.
 
-See the latter section for more details on programming languages and software
+See {{languages-frameworks}} for more details on programming languages and software
 frameworks.
 
-### Cookies Consuming Implementations
+### Cookie Consuming Implementations
 
-An implementor should choose {{ua-requirements}} whenever cookies are primarily
+An implementer should choose {{ua-requirements}} whenever cookies are primarily
 received from another source. These implementations are referred to as user
 agents. Some examples:
 
@@ -511,10 +511,10 @@ implement a more lenient set of requirements and to accept some things that
 servers are warned against producing. {{ua-requirements}} advises best
 practices that help maximize this sense of compatibility.
 
-See the latter section for more details on programming languages and software
+See {{languages-frameworks}} for more details on programming languages and software
 frameworks.
 
-#### Programming Languages & Software Frameworks
+#### Programming Languages & Software Frameworks {#languages-frameworks}
 
 A programming language or software framework with support for cookies could
 reasonably be used as a cookie producer, cookie consumer, or both. Because
@@ -523,6 +523,10 @@ or consumer these languages or frameworks should strongly consider supporting
 both sets of requirements. It is also strongly recommended that they default to
 the "safer" server requirements and require the user to explicitly activate the
 more lenient user agent requirements.
+
+Doing so will reduce the chances that a user's application can inadvertently
+create cookies that cannot be read by other servers but will still allow the
+application to behave as a user agent if desired.
 
 # Server Requirements {#sane-profile}
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -471,6 +471,10 @@ depending on the implementer's goals. These differences have built up over time
 due to both intentional and unintentional spec changes, spec interpretations,
 and historical implementation differences.
 
+This section roughly divides implementers of the cookie spec into two types,
+producers and consumers. These are not official terms and are only used here to
+help readers develop an intuitive understanding of the use cases.
+
 ### Cookie Producing Implementations
 
 An implementer should choose {{sane-profile}} whenever cookies are created and

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -460,6 +460,70 @@ Set-Cookie: lang=; Expires=Sun, 06 Nov 1994 08:49:37 GMT
 Cookie: SID=31d4d96e407aad42
 ~~~
 
+## Which Requirements to Implement
+
+This section helps to guide implementors in determining which requirements and
+syntax they should implement. Choosing the wrong set of requirements could
+result in a lack of compatibility with other cookie implementations.
+
+It's important to note that being compatible means different things
+depending on the implementor's goals. These differences have built up over time
+due to both intentional and unintentional spec changes, spec interpretations,
+and historical implementation differences.
+
+### Cookie Producing Implementations
+
+An implementor should choose {{sane-profile}} whenever cookies are created and
+will be sent to a user agent, such as a web browser. These implementations are
+frequently referred to as Servers by the spec but that term includes anything
+which primarily produces cookies. Some potential examples:
+
+* Server applications hosting a website
+
+* Programming languages or software frameworks that supports cookies
+
+* Website add-ons, such as a business management suite
+
+All these benefit from not only supporting as many user agents as possible but
+also supporting other servers. This is useful if a cookie is produced by a
+software framework and is later sent back to a server application which needs
+to read it. {{sane-profile}} advises best practices that help maximize this
+sense of compatibility.
+
+See the latter section for more details on programming languages and software
+frameworks.
+
+### Cookies Consuming Implementations
+
+An implementor should choose {{ua-requirements}} whenever cookies are primarily
+received from another source. These implementations are referred to as user
+agents. Some examples:
+
+* Web browsers
+
+* Tools that support stateful http
+
+* Programming languages or software frameworks that support cookies
+
+Because user agents don't know which servers a user will access, and whether
+or not that server is following best practices, users agents are advised to
+implement a more lenient set of requirements and to accept some things that
+servers are warned against producing. {{ua-requirements}} advises best
+practices that help maximize this sense of compatibility.
+
+See the latter section for more details on programming languages and software
+frameworks.
+
+#### Programming Languages & Software Frameworks
+
+A programming language or software framework with support for cookies could
+reasonably be used as a cookie producer, cookie consumer, or both. Because
+a user of these may want to maximize their compatibility as either a producer
+or consumer these languages or frameworks should strongly consider supporting
+both sets of requirements. It is also strongly recommended that they default to
+the "safer" server requirements and require the user to explicitly activate the
+more lenient user agent requirements.
+
 # Server Requirements {#sane-profile}
 
 This section describes the syntax and semantics of a well-behaved profile of the

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -462,9 +462,11 @@ Cookie: SID=31d4d96e407aad42
 
 ## Which Requirements to Implement
 
-This section helps guide implementers in determining which requirements and
-syntax they should implement. Choosing the wrong set of requirements could
-result in a lack of compatibility with other cookie implementations.
+The upcoming two sections, {{sane-profile}} and {{ua-requirements}}, discuss
+the set of requirements for two distinct types of implementations. This section
+is meant to help guide implementers in determining which set of requirements
+best fits their goals. Choosing the wrong set of requirements could result in a
+lack of compatibility with other cookie implementations.
 
 It's important to note that being compatible means different things
 depending on the implementer's goals. These differences have built up over time
@@ -505,7 +507,7 @@ agents. Some examples:
 
 * Web browsers
 
-* Tools that support stateful http
+* Tools that support stateful HTTP
 
 * Programming languages or software frameworks that support cookies
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -462,7 +462,7 @@ Cookie: SID=31d4d96e407aad42
 
 ## Which Requirements to Implement
 
-This section helps to guide implementors in determining which requirements and
+This section helps guide implementors in determining which requirements and
 syntax they should implement. Choosing the wrong set of requirements could
 result in a lack of compatibility with other cookie implementations.
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2665,6 +2665,9 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 * Prevent nameless cookies with prefixed values
   <https://github.com/httpwg/http-extensions/pull/2251>
 
+* Advise the reader which section to implement
+  <https://github.com/httpwg/http-extensions/pull/2478>
+
 ## draft-ietf-httpbis-rfc6265bis-12
 
 * None. Yet!

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -478,11 +478,11 @@ will be sent to a user agent, such as a web browser. These implementations are
 frequently referred to as Servers by the spec but that term includes anything
 which primarily produces cookies. Some potential examples:
 
-* Server applications hosting a website
+* Server applications hosting a website or API
 
 * Programming languages or software frameworks that support cookies
 
-* Website add-ons, such as a business management suite
+* Integrated third-party web applications, such as a business management suite
 
 All these benefit from not only supporting as many user agents as possible but
 also supporting other servers. This is useful if a cookie is produced by a
@@ -517,16 +517,15 @@ frameworks.
 #### Programming Languages & Software Frameworks {#languages-frameworks}
 
 A programming language or software framework with support for cookies could
-reasonably be used as a cookie producer, cookie consumer, or both. Because
-a user of these may want to maximize their compatibility as either a producer
-or consumer these languages or frameworks should strongly consider supporting
-both sets of requirements. It is also strongly recommended that they default to
-the "safer" server requirements and require the user to explicitly activate the
-more lenient user agent requirements.
+reasonably be used to create an application that acts as a cookie producer,
+cookie consumer, or both. Because a developer may want to maximize their
+compatibility as either a producer or consumer, these languages or frameworks
+should strongly consider supporting both sets of requirements, {{sane-profile}}
+and {{ua-requirements}}, behind a compatibility mode toggle. This toggle should
+default to {{sane-profile}}'s requirements.
 
-Doing so will reduce the chances that a user's application can inadvertently
-create cookies that cannot be read by other servers but will still allow the
-application to behave as a user agent if desired.
+Doing so will reduce the chances that a developer's application can
+inadvertently create cookies that cannot be read by other servers.
 
 # Server Requirements {#sane-profile}
 


### PR DESCRIPTION
Closes #2289

As mentioned in #2289, I've seen a few instances where an implementer chose the wrong section for their needs which caused compatibility issues down the line.

This PR adds a section that will (hopefully) grab the reader's attention and direct them to the correct section.