### PR TITLE
Update IANA note on old registry

### DIFF
--- a/draft-ietf-httpbis-digest-headers.md
+++ b/draft-ietf-httpbis-digest-headers.md
@@ -656,7 +656,16 @@ new registrations is provided in {{algorithms}}.
 
 IANA is requested to deprecate the "Hypertext Transfer Protocol (HTTP) Digest
 Algorithm Values" registry at
-<https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml>.
+<https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml> and replace the note on this registry with the following text:
+
+
+> "This registry is deprecated since it lists the algorithms that can be used
+with the Digest and Want-Digest fields defined in
+[RFC3230]<https://www.iana.org/>, which has been obsoleted by
+[rfc-to-be-this-document]. While registration is not closed, new registrations
+are encouraged to use the [Hash Algorithms for HTTP Digest
+Fields]<https://www.iana.org/assignments/http-digest-hash-alg/> registry
+instead.
 
 
 --- back


### PR DESCRIPTION
Follow up to the IANA review of the digest spec. We asked them to deprectae the old registry, so lets add a note to it to clarify what the new expectations of that registry are.