### PR TITLE
[message-signatures] fix wrong Content-Digest field value in example

### DIFF
--- a/draft-ietf-httpbis-message-signatures.md
+++ b/draft-ietf-httpbis-message-signatures.md
@@ -2556,8 +2556,8 @@ NOTE: '\' line wrapping per RFC 8792
 HTTP/1.1 200 OK
 Date: Tue, 20 Apr 2021 02:07:56 GMT
 Content-Type: application/json
-Content-Digest: sha-512=:JlEy2bfUz7WrWIjc1qV6KVLpdr/7L5/L4h7Sxvh6sN\
-  HpDQWDCL+GauFQWcZBvVDhiyOnAQsxzZFYwi0wDH+1pw==:
+Content-Digest: sha-512=:mEWXIS7MaLRuGgxOBdODa3xqM1XdEvxoYhvlCFJ41Q\
+  JgJc4GTsPp29l5oGX69wWdXymyU0rjJuahq4l5aGgfLQ==:
 Content-Length: 23
 
 {"message": "good dog"}


### PR DESCRIPTION
Hello,

In section B.2, the value of the Content-Digest field in "test-response message" does not match what is actually calculated from the content body.

The same problem in section B.2.4 was fixed in commit b3fa85b44f417b0b29101e3713bd8c22bbdc0893, but not here at the beginning of section B.2.

I am not sure if it is appropriate to submit a pull request since this document seems to be in the final stages of the publication process, but I would like to let it know anyway.