### PR TITLE
Switch the default ttl to 14 days since last fetched

### DIFF
--- a/draft-ietf-httpbis-compression-dictionary.md
+++ b/draft-ietf-httpbis-compression-dictionary.md
@@ -144,7 +144,7 @@ limit the life of a dictionary in cases where the dictionary is updated
 frequently which can help limit the number of possible incoming dictionary
 variations.
 
-The "ttl" value is optional and defaults to 31536000 (1 year).
+The "ttl" value is optional and defaults to 1209600 (14 days).
 
 ### type
 
@@ -222,7 +222,7 @@ Available-Dictionary: \
 To be considered as a match, the dictionary must not yet be expired as a
 dictionary. When iterating through dictionaries looking for a match, the
 expiration time of the dictionary is calculated by taking the last time the
-dictionary was written and adding the "ttl" seconds from the
+dictionary was fetched and adding the "ttl" seconds from the
 "Use-As-Dictionary" response. If the current time is beyond the expiration time
 of the dictionary, it MUST be ignored.
 


### PR DESCRIPTION
Discussion at IETF 118 was that the `ttl` didn't necessarily need to be short to reduce variations (was originally planning on 7 days) but chaning it to last-fetched instead of last-written is important. This updates the default `ttl` to 14 days as a balance (can always be overridden explicitly).