### PR TITLE
sfbis: abnf for displaytring too wide - wrap it (fixes #2677)

### DIFF
--- a/draft-ietf-httpbis-sfbis.md
+++ b/draft-ietf-httpbis-sfbis.md
@@ -1132,7 +1132,8 @@ sf-token         = ( ALPHA / "*" ) *( tchar / ":" / "/" )
 sf-binary        = ":" base64 ":"
 sf-boolean       = "?" ( "0" / "1" )
 sf-date          = "@" sf-integer
-sf-displaystring = "%" DQUOTE *( unescaped / "\" / pct-encoded ) DQUOTE
+sf-displaystring = "%" DQUOTE *( unescaped / "\" / pct-encoded )
+                   DQUOTE
 
 base64       = *( ALPHA / DIGIT / "+" / "/" ) *"="
 


### PR DESCRIPTION
Not pretty, but alternatives do not look better (maybe create an extra production for the stuff between DQUOTEs?)