### PR TITLE
compression-dictionary: remome abbreviated title

### DIFF
--- a/draft-ietf-httpbis-compression-dictionary.md
+++ b/draft-ietf-httpbis-compression-dictionary.md
@@ -1,6 +1,5 @@
 ---
 title: Compression Dictionary Transport
-abbrev: compression-dictionary
 docname: draft-ietf-httpbis-compression-dictionary-latest
 category: std
 


### PR DESCRIPTION
1. Not needed
2. Would need to be at title, not label-like