### PR TITLE
[connect-tcp] Define syntax more precisely

### DIFF
--- a/draft-ietf-httpbis-connect-tcp.md
+++ b/draft-ietf-httpbis-connect-tcp.md
@@ -80,20 +80,34 @@ host-value = ip-addr / reg-name
 
 The "target_host" variable is permitted to contain either a `host-value` or a list of `ip-addr`.  The value of the "tcp_port" variable MUST match the `port` rule from {{!RFC3986}}.
 
-Note that IPv6 scoped addressing zone identifiers are not supported, and the colons in IPv6 addresses will normally be percent-encoded by the URI Template expansion process (see {{substitution-example}}).
+Note that IPv6 scoped addressing zone identifiers are not supported, and the colons in IPv6 addresses will normally be percent-encoded by the URI Template expansion process (see {{substitution-examples}}).
 
 ~~~~
-URI template:
-    https://a.example/{?target_host,tcp_port}
+Example URI Templates:
+  A: https://a.example{/target_host,tcp_port}
+  B: https://b.example/{?target_host*,tcp_port}
 
-Variable assignments in RFC 6570 syntax:
-    target_host := ("192.0.2.1", "2001:db8::1")
+Example variable assignments in RFC 6570 syntax:
+  1:
+    target_host := "one.example"
     tcp_port    := "443"
+  2:
+    target_host := ("192.0.2.2", "2001:db8::2")
+    tcp_port    := "80"
 
-Resulting URI:
-https://a.example/?target_host=192.0.2.1,2001%3Adb8%3A%3A1&tcp_port=443
+
+Resulting URIs:
+  A + 1:
+    https://a.example/one.example/443
+  B + 1:
+    https://b.example/?target_host=one.example&tcp_port=443
+  A + 2:
+    https://a.example/192.0.2.2,2001%3Adb8%3A%3A2/80
+  B + 2:
+    https://b.example/
+    ?target_host=192.0.2.2&target_host=2001%3Adb8%3A%3A2&tcp_port=443
 ~~~~
-{: #substitution-example title="Template substitution example"}
+{: #substitution-examples title="Template substitution examples"}
 
 ## In HTTP/1.1
 

--- a/draft-ietf-httpbis-connect-tcp.md
+++ b/draft-ietf-httpbis-connect-tcp.md
@@ -70,23 +70,21 @@ The "target_host" variable MUST be a domain name, an IP address literal, or a li
 
 The "tcp_port" variable MUST represent a single integer between 1 and 65535 inclusive.  Both the "target_host" and "tcp_port" values MUST NOT be empty or undefined when using the template for TCP proxying.
 
-Using the terms `IPv6address`, `IPv4address`, `reg-name`, and `port` from {{!RFC3986}} and notation from {{!RFC5234}} and {{!RFC6570}}, the "target_host" and "tcp_port" values MUST adhere to the format in {{abnf}}:
+The syntax rules for these variables can be specified using ABNF {{!RFC5234}}.  Using the terms `IPv6address`, `IPv4address`, and `reg-name` from {{!RFC3986}}, we first define some additional ABNF rules in {{abnf}}:
 
 ~~~~ abnf
-ip-addr = IPv6address / IPv4address
-single-host-str = DQUOTE ( ip-addr / reg-name ) DQUOTE
-ip-addr-str = DQUOTE ip-addr DQUOTE
-ip-addr-list = "(" ( ip-addr-str ", " )* ip-addr-str ")"
-target_host = single-host-str / ip-addr-list
-target_port = DQUOTE port DQUOTE
+ip-addr    = IPv6address / IPv4address
+host-value = ip-addr / reg-name
 ~~~~
-{: #abnf title="ABNF syntax for \"target_host\" and \"target_port\" as URI Template string or list values."}
+{: #abnf title="Additional ABNF definitions."}
 
-Note that IPv6 scoped addressing zone identifiers are not supported, and the colons in IPv6 addresses will be percent-encoded by the URI Template expansion process (e.g., "2001%3Adb8%3A%3A42").
+The "target_host" variable is permitted to contain either a `host-value` or a list of `ip-addr`.  The value of the "tcp_port" variable MUST match the `port` rule from {{!RFC3986}}.
+
+Note that IPv6 scoped addressing zone identifiers are not supported, and the colons in IPv6 addresses will normally be percent-encoded by the URI Template expansion process (see {{substitution-example}}).
 
 ~~~~
 URI template:
-    https://a.example/{/target_host,tcp_port}
+    https://a.example/{?target_host,tcp_port}
 
 Variable assignments in RFC 6570 syntax:
     target_host := ("192.0.2.1", "2001:db8::1")
@@ -95,7 +93,7 @@ Variable assignments in RFC 6570 syntax:
 Resulting URI:
 https://a.example/?target_host=192.0.2.1,2001%3Adb8%3A%3A1&tcp_port=443
 ~~~~
-{: title="Template substitution example"}
+{: #substitution-example title="Template substitution example"}
 
 ## In HTTP/1.1
 

--- a/draft-ietf-httpbis-connect-tcp.md
+++ b/draft-ietf-httpbis-connect-tcp.md
@@ -66,7 +66,23 @@ This specification describes an alternative mechanism for proxying TCP in HTTP. 
 
 A template-driven TCP transport proxy for HTTP is identified by a URI Template {{!RFC6570}} containing variables named "target_host" and "tcp_port".  The client substitutes the destination host and port number into these variables to produce the request URI.
 
-The "target_host" variable MUST be a domain name, an IP address literal, or a list of IP addresses.  The "tcp_port" variable MUST be a single integer.  If "target_host" is a list (as in {{Section 3.2.1 of !RFC6570}}), the server SHOULD perform the same connection procedure as if these IP addresses had been returned in response to A and AAAA queries for a domain name.
+The "target_host" variable MUST be a domain name, an IP address literal, or a list of IP addresses.  If "target_host" is a list (as in {{Section 3.2.1 of !RFC6570}}), the server SHOULD perform the same connection procedure as if these IP addresses had been returned in response to A and AAAA queries for a domain name.
+
+The "tcp_port" variable MUST represent a single integer between 1 and 65535 inclusive.  Both the "target_host" and "tcp_port" values MUST NOT be empty or undefined when using the template for TCP proxying.
+
+Using the terms `IPv6address`, `IPv4address`, `reg-name`, and `port` from {{!RFC3986}} and notation from {{!RFC5234}} and {{!RFC6570}}, the "target_host" and "tcp_port" values MUST adhere to the format in {{abnf}}:
+
+~~~~ abnf
+ip-addr = IPv6address / IPv4address
+single-host-str = DQUOTE ( ip-addr / reg-name ) DQUOTE
+ip-addr-str = DQUOTE ip-addr DQUOTE
+ip-addr-list = "(" ( ip-addr-str ", " )* ip-addr-str ")"
+target_host = single-host-str / ip-addr-list
+target_port = DQUOTE port DQUOTE
+~~~~
+{: #abnf title="ABNF syntax for \"target_host\" and \"target_port\" as URI Template string or list values."}
+
+Note that IPv6 scoped addressing zone identifiers are not supported, and the colons in IPv6 addresses will be percent-encoded by the URI Template expansion process (e.g., "2001%3Adb8%3A%3A42").
 
 ## In HTTP/1.1
 
@@ -120,7 +136,7 @@ HEADERS
 :method = CONNECT
 :scheme = https
 :authority = request-proxy.example
-:path = /proxy?target_host=192.0.2.1,2001:db8::1&tcp_port=443
+:path = /proxy?target_host=192.0.2.1,2001%3Adb8%3A%3A1&tcp_port=443
 :protocol = connect-tcp
 ...
 ~~~

--- a/draft-ietf-httpbis-connect-tcp.md
+++ b/draft-ietf-httpbis-connect-tcp.md
@@ -84,6 +84,19 @@ target_port = DQUOTE port DQUOTE
 
 Note that IPv6 scoped addressing zone identifiers are not supported, and the colons in IPv6 addresses will be percent-encoded by the URI Template expansion process (e.g., "2001%3Adb8%3A%3A42").
 
+~~~~
+URI template:
+    https://a.example/{/target_host,tcp_port}
+
+Variable assignments in RFC 6570 syntax:
+    target_host := ("192.0.2.1", "2001:db8::1")
+    tcp_port    := "443"
+
+Resulting URI:
+https://a.example/?target_host=192.0.2.1,2001%3Adb8%3A%3A1&tcp_port=443
+~~~~
+{: title="Template substitution example"}
+
 ## In HTTP/1.1
 
 In HTTP/1.1, the client uses the proxy by issuing a request as follows:


### PR DESCRIPTION
The language here is adapted from RFC 9298.

Fixes #2714