### PR TITLE
Remove consideration of same-site redirect chain

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2690,6 +2690,7 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 ## draft-ietf-httpbis-rfc6265bis-14
 
 * Remove consideration of same-site redirect chain
+  <https://github.com/httpwg/http-extensions/pull/2750>
 
 
 # Acknowledgements

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -17,7 +17,7 @@ venue:
   type: Working Group
   home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
-  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  arch: https://lists.w3.org/Archives/Publi5.7.1. The Cookie Header Fieldc/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/6265bis
 github-issue-label: 6265bis
 
@@ -1053,15 +1053,11 @@ following conditions holds:
 Two origins are same-site if they satisfy the "same site" criteria defined in
 {{SAMESITE}}. A request is "same-site" if the following criteria are true:
 
-1.  The request is not the result of a cross-site redirect. That is,
-    the origin of every url in the request's url list is same-site with the
-    request's current url's origin.
-
-2.  The request is not the result of a reload navigation triggered through a
+1.  The request is not the result of a reload navigation triggered through a
     user interface element (as defined by the user agent; e.g., a request
     triggered by the user clicking a refresh button on a toolbar).
 
-3.  The request's current url's origin is same-site with the request's
+2.  The request's current url's origin is same-site with the request's
     client's "site for cookies" (which is an origin), or if the request has no
     client or the request's client is null.
 
@@ -2690,6 +2686,11 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 
 * Use navigables concept
   <https://github.com/httpwg/http-extensions/pull/2478>
+
+## draft-ietf-httpbis-rfc6265bis-14
+
+* Remove consideration of same-site redirect chain
+  <Issue url>
 
 
 # Acknowledgements

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2690,7 +2690,6 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 ## draft-ietf-httpbis-rfc6265bis-14
 
 * Remove consideration of same-site redirect chain
-  <Issue url>
 
 
 # Acknowledgements

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -17,7 +17,7 @@ venue:
   type: Working Group
   home: https://httpwg.org/
   mail: ietf-http-wg@w3.org
-  arch: https://lists.w3.org/Archives/Publi5.7.1. The Cookie Header Fieldc/ietf-http-wg/
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
   repo: https://github.com/httpwg/http-extensions/labels/6265bis
 github-issue-label: 6265bis
 


### PR DESCRIPTION
Closes #2104

This PR removes the requirement of checking the request's redirect chain during the computation of same-site-ness.

This is being done because RFC6265bis is blocked by this work but we have yet to find a way to implement it in a web compatible way. In the interest of moving RFC6265bis forward the requirement is being removed.