### PR TITLE
Correction of URLPattern URL

### DIFF
--- a/draft-ietf-httpbis-compression-dictionary.md
+++ b/draft-ietf-httpbis-compression-dictionary.md
@@ -112,7 +112,7 @@ for an invalid pattern that MUST NOT be used:
 1. Let PATTERN be a URLPattern constructed by setting input=MATCH,
 and baseURL=URL (https://urlpattern.spec.whatwg.org/).
 1. If PATTERN has regexp groups then return FALSE
-(https://urlpattern.spec.whatwg.org/#urlpattern-has-regexp-groups).
+(https://urlpattern.spec.whatwg.org/#url-pattern-has-regexp-groups).
 1. Return True.
 
 The "match" value is required and MUST be included in the


### PR DESCRIPTION
A very ironic URL to be incorrect, but the anchor as given doesn't exist in the document.