### PR TITLE
Refactor cookie header text

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -862,7 +862,7 @@ cookie        = cookie-string
 cookie-string = cookie-pair *( ";" SP cookie-pair )
 ~~~
 
-Servers SHOULD be tolerant to potentially receiving multiple cookie
+Servers MUST be tolerant to potentially receiving multiple cookie
 headers. For example, if an HTTP/2 {{RFC9113}} or HTTP/3 {{RFC9114}} connection
 splits a cookie header to improve compression.
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -862,9 +862,9 @@ cookie        = cookie-string
 cookie-string = cookie-pair *( ";" SP cookie-pair )
 ~~~
 
-Servers MUST be tolerant to potentially receiving multiple cookie
-headers. For example, if an HTTP/2 {{RFC9113}} or HTTP/3 {{RFC9114}} connection
-splits a cookie header to improve compression.
+Servers MUST be tolerant of multiple cookie headers. For example, an HTTP/2
+{{RFC9113}} or HTTP/3 {{RFC9114}} connection might split a cookie header to
+improve compression.
 
 ### Semantics
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2695,6 +2695,11 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 * Use navigables concept
   <https://github.com/httpwg/http-extensions/pull/2478>
 
+## draft-ietf-httpbis-rfc6265bis-14
+
+* Refactor cookie header text
+  <https://github.com/httpwg/http-extensions/pull/2753>
+
 
 # Acknowledgements
 {:numbered="false"}

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -139,6 +139,8 @@ informative:
   RFC5895:
   RFC6265:
   RFC7034:
+  RFC9113:
+  RFC9114:
   UTS46:
     target: http://unicode.org/reports/tr46/
     title: "Unicode IDNA Compatibility Processing"
@@ -859,6 +861,10 @@ header field that conforms to the following grammar:
 cookie        = cookie-string
 cookie-string = cookie-pair *( ";" SP cookie-pair )
 ~~~
+
+Servers SHOULD be tolerant to potentially receiving multiple cookie
+headers. For example, if an HTTP/2 {{RFC9113}} or HTTP/3 {{RFC9114}} connection
+splits a cookie header to improve compression.
 
 ### Semantics
 
@@ -1821,18 +1827,16 @@ are defined below depending on the type of retrieval.
 
 The user agent includes stored cookies in the Cookie HTTP request header field.
 
-When the user agent generates an HTTP request, the user agent MUST NOT attach
-more than one Cookie header field.
-
 A user agent MAY omit the Cookie header field in its entirety.  For example, the
 user agent might wish to block sending cookies during "third-party" requests
 from setting cookies (see {{third-party-cookies}}).
 
 If the user agent does attach a Cookie header field to an HTTP request, the
-user agent MUST compute the cookie-string following the algorithm defined in
-{{retrieval-algorithm}}, where the retrieval's URI is the request-uri, the
-retrieval's same-site status is computed for the HTTP request as defined in
-{{same-site-requests}}, and the retrieval's type is "HTTP".
+user agent MUST generate a single cookie-string and the user agent MUST compute
+the cookie-string following the algorithm defined in {{retrieval-algorithm}},
+where the retrieval's URI is the request-uri, the retrieval's same-site status
+is computed for the HTTP request as defined in {{same-site-requests}}, and the
+retrieval's type is "HTTP".
 
 ### Non-HTTP APIs {#non-http}
 


### PR DESCRIPTION
Fixes #2541

Technologies such as HTTP/2 will split the `cookie` header into multiple fields. This PR modifies the spec to no longer expressly forbid this and instructs servers to be aware and capable of handling multiple incoming `cookie` headers.