### PR TITLE
Specify the compression window sizes for zstd-d and br-d

### DIFF
--- a/draft-ietf-httpbis-compression-dictionary.md
+++ b/draft-ietf-httpbis-compression-dictionary.md
@@ -300,12 +300,12 @@ negotiating content encoding in HTTP.
 
 This document introduces two new content encoding algorithms:
 
-|------------------|----------------------------------------------------|
-| Content-Encoding | Description                                        |
-|------------------|----------------------------------------------------|
-| br-d             | Brotli using an external compression dictionary    |
-| zstd-d           | Zstandard using an external compression dictionary |
-|------------------|----------------------------------------------------|
+|------------------|--------------------------------------------------------------------------------------------|
+| Content-Encoding | Description                                                                                |
+|------------------|--------------------------------------------------------------------------------------------|
+| br-d             | Brotli using an external compression dictionary and a compression window of up to 16 MB.   |
+| zstd-d           | Zstandard using an external compression dictionary and a compression window of up to 8 MB. |
+|------------------|--------------------------------------------------------------------------------------------|
 
 The dictionary to use is negotiated separately and advertised in the
 "Available-Dictionary" request header.
@@ -345,12 +345,12 @@ Vary: accept-encoding, available-dictionary
 IANA is asked to update the "HTTP Content Coding Registry" registry
 ({{HTTP}}) according to the table below:
 
-|--------|---------------------------------------------------------------------------------------|-------------|
-| Name   | Description                                                                           | Reference   |
-|--------|---------------------------------------------------------------------------------------|-------------|
-| br-d   | A stream of bytes compressed using the Brotli protocol with an external dictionary    | {{RFC7932}} |
-| zstd-d | A stream of bytes compressed using the Zstandard protocol with an external dictionary | {{RFC8878}} |
-|--------|---------------------------------------------------------------------------------------|-------------|
+|--------|--------------------------------------------------------------------------------------------------------------------------------|-------------|
+| Name   | Description                                                                                                                    | Reference   |
+|--------|--------------------------------------------------------------------------------------------------------------------------------|-------------|
+| br-d   | A stream of bytes compressed using the Brotli protocol with an external dictionary and a compression window of up to 16 MB.    | {{RFC7932}} |
+| zstd-d | A stream of bytes compressed using the Zstandard protocol with an external dictionary and a compression window of up to 8 MB.  | {{RFC8878}} |
+|--------|--------------------------------------------------------------------------------------------------------------------------------|-------------|
 
 ## Header Field Registration
 

--- a/draft-ietf-httpbis-compression-dictionary.md
+++ b/draft-ietf-httpbis-compression-dictionary.md
@@ -298,17 +298,14 @@ When a compression dictionary is available for use for a given request, the
 algorithm to be used is negotiated through the regular mechanism for
 negotiating content encoding in HTTP.
 
-This document introduces two new content encoding algorithms:
-
-|------------------|--------------------------------------------------------------------------------------------|
-| Content-Encoding | Description                                                                                |
-|------------------|--------------------------------------------------------------------------------------------|
-| br-d             | Brotli using an external compression dictionary and a compression window of up to 16 MB.   |
-| zstd-d           | Zstandard using an external compression dictionary and a compression window of up to 8 MB. |
-|------------------|--------------------------------------------------------------------------------------------|
-
 The dictionary to use is negotiated separately and advertised in the
 "Available-Dictionary" request header.
+
+## Compression Algorithms
+This document introduces two new content encoding algorithms:
+
+- br-d: Brotli {{RFC7932}} using an external compression dictionary and a compression window of not more than 16 MB.
+- zstd-d: Zstandard {{RFC8878}} using an external compression dictionary and a compression window of not more than 8 MB.
 
 ## Accept-Encoding
 
@@ -342,15 +339,19 @@ Vary: accept-encoding, available-dictionary
 
 ## Content Encoding
 
-IANA is asked to update the "HTTP Content Coding Registry" registry
-({{HTTP}}) according to the table below:
+IANA is asked to enter the following into the "HTTP Content Coding Registry" registry ({{HTTP}}):
 
-|--------|--------------------------------------------------------------------------------------------------------------------------------|-------------|
-| Name   | Description                                                                                                                    | Reference   |
-|--------|--------------------------------------------------------------------------------------------------------------------------------|-------------|
-| br-d   | A stream of bytes compressed using the Brotli protocol with an external dictionary and a compression window of up to 16 MB.    | {{RFC7932}} |
-| zstd-d | A stream of bytes compressed using the Zstandard protocol with an external dictionary and a compression window of up to 8 MB.  | {{RFC8878}} |
-|--------|--------------------------------------------------------------------------------------------------------------------------------|-------------|
+- Name: br-d
+- Description: A stream of bytes compressed using the Brotli protocol with an external dictionary.
+- Reference: This document
+- Notes: {{compression-algorithms}}
+
+IANA is asked to enter the following into the "HTTP Content Coding Registry" registry ({{HTTP}}):
+
+- Name: zstd-d
+- Description: A stream of bytes compressed using the Zstandard protocol with an external dictionary.
+- Reference: This document
+- Notes: {{compression-algorithms}}
 
 ## Header Field Registration
 

--- a/draft-ietf-httpbis-compression-dictionary.md
+++ b/draft-ietf-httpbis-compression-dictionary.md
@@ -342,14 +342,14 @@ Vary: accept-encoding, available-dictionary
 IANA is asked to enter the following into the "HTTP Content Coding Registry" registry ({{HTTP}}):
 
 - Name: br-d
-- Description: A stream of bytes compressed using the Brotli protocol with an external dictionary.
+- Description: A stream of bytes compressed using the Brotli protocol with an external dictionary of not more than 16 MB.
 - Reference: This document
 - Notes: {{compression-algorithms}}
 
 IANA is asked to enter the following into the "HTTP Content Coding Registry" registry ({{HTTP}}):
 
 - Name: zstd-d
-- Description: A stream of bytes compressed using the Zstandard protocol with an external dictionary.
+- Description: A stream of bytes compressed using the Zstandard protocol with an external dictionary of not more than 8 MB.
 - Reference: This document
 - Notes: {{compression-algorithms}}
 


### PR DESCRIPTION
This change makes it explicit that the `zstd-d` content encoding is `Zstandard with up to a 8 MB compression window` (same as `zstd`) and `br-d` is `Brotli with up to a 16 MB compression window` (same as `br`).

See the discussion in #2754 for why larger ZStandard values were not selected.

This carries some nuance for what encoding to use when compressing for maximum benefit as the resource size crosses beyond 8 MB but that is more of an editorial discussion about the individual compression algorithms and probably better laid out in blog posts or explainers than in the spec.

Fix #2754