### PR TITLE
[compression-dictionary] Moved the dictionary hash into the body

### DIFF
--- a/draft-ietf-httpbis-compression-dictionary.md
+++ b/draft-ietf-httpbis-compression-dictionary.md
@@ -53,6 +53,10 @@ informative:
   Origin: RFC6454
   STRUCTURED-FIELDS: RFC8941
   RFC7932:  # Brotli
+  SHARED-BROTLI:
+    title: Shared Brotli Compressed Data Format
+    date: 28 September 2022
+    target: https://datatracker.ietf.org/doc/draft-vandevenne-shared-brotli-format/
   RFC8878:  # Zstandard
 
 --- abstract
@@ -310,10 +314,10 @@ The "dcb" content encoding identifies a resource that is a
 "Dictionary-Compressed Brotli" stream.
 
 A "Dictionary-Compressed Brotli" stream has a fixed header that is followed by
-a Brotli {{RFC7932}} stream. The header consists of a fixed 4 byte sequence
-and a 32 byte hash of the external dictionary that was used.  The Brotli stream
-is created using the referenced external dictionary and a compression window
-that is at most 16 MB in size.
+a Shared Brotli {{SHARED-BROTLI}} stream. The header consists of a fixed 4 byte
+sequence and a 32 byte hash of the external dictionary that was used.  The
+Shared Brotli stream is created using the referenced external dictionary and a
+compression window that is at most 16 MB in size.
 
 The 36-byte fixed header is as follows:
 
@@ -455,9 +459,9 @@ be used in secure contexts (HTTPS).
 
 # Security Considerations
 
-The security considerations for Brotli {{RFC7932}} and Zstandard
-{{RFC8878}} apply to the dictionary-based versions of the respective
-algorithms.
+The security considerations for Brotli {{RFC7932}}, Shared Brotli
+{{SHARED-BROTLI}} and Zstandard {{RFC8878}} apply to the
+dictionary-based versions of the respective algorithms.
 
 ## Changing content
 

--- a/draft-ietf-httpbis-compression-dictionary.md
+++ b/draft-ietf-httpbis-compression-dictionary.md
@@ -340,18 +340,22 @@ The "dcz" content encoding identifies a resource that is a
 "Dictionary-Compressed Zstandard" stream.
 
 A "Dictionary-Compressed Zstandard" stream is a binary stream that starts with a
-36-byte fixed header and is followed by a Zstandard {{RFC8878}} stream
+40-byte fixed header and is followed by a Zstandard {{RFC8878}} stream
 of the response that has been compressed with an external dictionary.
 
-The 36-byte stream header consists of a 4-byte signature followed by the
+The 40-byte header consists of a fixed 8-byte sequence followed by the
 32-byte SHA-256 hash of the external dictionary that was used to compress the
 resource:
 
 Magic_Number:
-: 4 fixed bytes: 0xff, 0x44, 0x45, 0x5a.
+: 8 fixed bytes: 0x5e, 0x2a, 0x4d, 0x18, 0x20, 0x00, 0x00, 0x00.
 
 SHA_256_Hash:
 : 32 Bytes. SHA-256 hash digest of the dictionary {{SHA-256}}.
+
+The 40-byte header is a Zstandard skippable frame (little-endian 0x184D2A5E)
+with a 32-byte length (little-endian 0x00000020) that is compatible with existing
+Zstandard decoders.
 
 Clients that announce support for dcz content encoding MUST be able to
 decompress resources that were compressed with a window size of at least 8 MB

--- a/draft-ietf-httpbis-compression-dictionary.md
+++ b/draft-ietf-httpbis-compression-dictionary.md
@@ -309,22 +309,19 @@ Link: <https://example.org/dict.dat>; rel="compression-dictionary"
 The "dcb" content encoding identifies a resource that is a
 "Dictionary-Compressed Brotli" stream.
 
-A "Dictionary-Compressed Brotli" stream is a binary stream that starts with a
-36-byte header and is followed by a Brotli {{RFC7932}} stream of the response
-that has been compressed with an external dictionary using a compression window
-not larger than 16 MB.
+A "Dictionary-Compressed Brotli" stream has a fixed header that is followed by
+a Brotli {{RFC7932}} stream. The header consists of a fixed 4 byte sequence
+and a 32 byte hash of the external dictionary that was used.  The Brotli stream
+is created using the referenced external dictionary and a compression window
+that is at most 16 MB in size.
 
-The 36-byte stream header consists of a 4-byte signature followed by the
-32-byte SHA-256 hash of the external dictionary that was used to compress the
-resource:
+The 36-byte fixed header is as follows:
 
-|  Field             | Size       |
-|--------------------|------------|
-|  Magic_Number      | 4 bytes    |
-|  SHA_256_Hash      | 32 bytes   |
+Magic_Number:
+: 4 fixed bytes: 0xff, 0x44, 0x43, 0x42.
 
-Magic_Number: 4 bytes, little-endian format.  Value: 0x424344FF
-SHA_256_Hash: 32 Bytes. SHA-256 hash digest of the dictionary {{SHA-256}}.
+SHA_256_Hash:
+: 32 Bytes. SHA-256 hash digest of the dictionary {{SHA-256}}.
 
 Clients that announce support for dcb content encoding MUST be able to
 decompress resources that were compressed with a window size of up to 16 MB.
@@ -339,20 +336,18 @@ The "dcz" content encoding identifies a resource that is a
 "Dictionary-Compressed Zstandard" stream.
 
 A "Dictionary-Compressed Zstandard" stream is a binary stream that starts with a
-36-byte header and is followed by a Zstandard {{RFC8878}} stream
+36-byte fixed header and is followed by a Zstandard {{RFC8878}} stream
 of the response that has been compressed with an external dictionary.
 
 The 36-byte stream header consists of a 4-byte signature followed by the
 32-byte SHA-256 hash of the external dictionary that was used to compress the
 resource:
 
-|  Field             | Size       |
-|--------------------|------------|
-|  Magic_Number      | 4 bytes    |
-|  SHA_256_Hash      | 32 bytes   |
+Magic_Number:
+: 4 fixed bytes: 0xff, 0x44, 0x45, 0x5a.
 
-Magic_Number: 4 bytes, little-endian format.  Value: 0x5A4344FF
-SHA_256_Hash: 32 Bytes. SHA-256 hash digest of the dictionary {{SHA-256}}.
+SHA_256_Hash:
+: 32 Bytes. SHA-256 hash digest of the dictionary {{SHA-256}}.
 
 Clients that announce support for dcz content encoding MUST be able to
 decompress resources that were compressed with a window size of at least 8 MB


### PR DESCRIPTION
This eliminates the `Content-Dictionary` response header and moves the hash of the dictionary into the payload of the response.

Specifically, it adds 36-byte header in front of the compressed stream which is a 4 or 8-byte signature followed by the 32-byte SHA-256 hash digest.

The signature is different for the two different compressions:
* Dictionary-Compressed Brotli: `\xFF\x44\x43\x42` (0xFF followed by `DCB`)
* Dictionary-Compressed Zstandard: `\x5e\x2a\x4d\x18\x20\x00\x00\x00` (32-byte skippable Zstandard frame)

This also changes the content-encoding names for the different schemes to make it clear that they are a new format and not a raw brotli or Zstandard stream (`dcb` and `dcz`).

From the cli, the stream is equivalent to:

```sh
echo -en '\xffDCB' > data.txt.dcb && \
openssl dgst -sha256 -binary dictionary.txt >> data.txt.dcb && \
brotli --stdout -D dictionary.txt data.txt >> data.txt.dcb
```

or 

```sh
echo -en '\x5e\x2a\x4d\x18\x20\x00\x00\x00' > data.txt.dcz && \
openssl dgst -sha256 -binary dictionary.txt >> data.txt.dcz && \
zstd -D dictionary.txt -f -o tmp.zstd data.txt && \
cat tmp.zstd >> data.txt.dcz
```

Fix #2770