### PR TITLE
Add multiple cookie header tolerance suggestions & length limit warnings

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -854,7 +854,7 @@ cookie        = cookie-string
 cookie-string = cookie-pair *( ";" SP cookie-pair )
 ~~~
 
-While Section 5.4 of {{RFC9110}} does not define a length limit for header
+While {{Section 5.4 of RFC9110}} does not define a length limit for header
 fields it is likely that the web server's implementation does impose a limit;
 many popular implementations have default limits of 8K. Server SHOULD avoid
 setting a large number of large cookies such that the final cookie-string
@@ -1845,6 +1845,12 @@ the cookie-string following the algorithm defined in {{retrieval-algorithm}},
 where the retrieval's URI is the request-uri, the retrieval's same-site status
 is computed for the HTTP request as defined in {{same-site-requests}}, and the
 retrieval's type is "HTTP".
+
+Note: Previous versions of this specification required that only one Cookie
+header field be sent in requests. This is no longer a requirement. While this
+specification requires that a single cookie-string be produced, some user agents
+may split that string across multiple cookie header fields. For examples, see
+{{Section 8.2.3 of RFC9113}} and {{Section 4.2.1 of RFC9114}}.
 
 ### Non-HTTP APIs {#non-http}
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2740,6 +2740,9 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 * Update HTTPSEM to RFC9110
   <https://github.com/httpwg/http-extensions/pull/2795>
 
+* Add multiple cookie header tolerance suggestions & length limit warnings
+  <https://github.com/httpwg/http-extensions/pull/2804>
+
 # Acknowledgements
 {:numbered="false"}
 RFC 6265 was written by Adam Barth. This document is an update of RFC 6265,

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -871,8 +871,8 @@ any header field limits when deciding which approach to take.
 
 Note: Since intermediaries can modify cookie headers they should also be
 mindful of common server header field limits in order to avoid sending servers
-headers that they cannot process. For example, by concatenating multiple cookie
-headers into a single header larger than a server's limit.
+headers that they cannot process. For example, concatenating multiple cookie
+headers into a single header might exceed a server's size limit.
 
 
 ### Semantics

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -856,18 +856,24 @@ cookie-string = cookie-pair *( ";" SP cookie-pair )
 
 While {{Section 5.4 of RFC9110}} does not define a length limit for header
 fields it is likely that the web server's implementation does impose a limit;
-many popular implementations have default limits of 8K. Server SHOULD avoid
+many popular implementations have default limits of 8K. Servers SHOULD avoid
 setting a large number of large cookies such that the final cookie-string
 would exceed their header field limit. Not doing so could result in requests
 to the server failing.
 
 Servers MUST be tolerant of multiple cookie headers. For example, an HTTP/2
-{{RFC9113}} or HTTP/3 {{RFC9114}} connection might split a cookie header to
-improve compression. Servers are free to determine what form this tolerance
-takes. For example, the server could process each cookie header individually
-or the server could concatenate all the cookie headers into one and then
-process that final, single, header. The server should be mindful of any
-header field limits when deciding which approach to take.
+{{RFC9113}} or HTTP/3 {{RFC9114}} client or intermediary might split a cookie
+header to improve compression. Servers are free to determine what form this
+tolerance takes. For example, the server could process each cookie header
+individually or the server could concatenate all the cookie headers into one
+and then process that final, single, header. The server should be mindful of
+any header field limits when deciding which approach to take.
+
+Note: Since intermediaries can modify cookie headers they should also be
+mindful of common server header field limits in order to avoid sending servers
+headers that they cannot process. For example, by concatenating multiple cookie
+headers into a single header larger than a server's limit.
+
 
 ### Semantics
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1846,12 +1846,6 @@ where the retrieval's URI is the request-uri, the retrieval's same-site status
 is computed for the HTTP request as defined in {{same-site-requests}}, and the
 retrieval's type is "HTTP".
 
-Note: While this spec requires that a single cookie-string be produced, a user
-agent may consider splitting large request headers within their {{RFC9110}}
-implementation. This is due to potential server header length limits (See
-{{server-syntax}}) being exceeded due to servers setting too many large
-cookies.
-
 ### Non-HTTP APIs {#non-http}
 
 The user agent MAY implement "non-HTTP" APIs that can be used to access

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -855,11 +855,11 @@ cookie-string = cookie-pair *( ";" SP cookie-pair )
 ~~~
 
 While Section 5.4 of {{RFC9110}} does not define a length limit for header
-fields it is likely that the web server's implementation does impose a limit,
+fields it is likely that the web server's implementation does impose a limit;
 many popular implementations have default limits of 8K. Server SHOULD avoid
 setting a large number of large cookies such that the final cookie-string
-would exceed their header field limit. Not doing so could result in the request
-failing.
+would exceed their header field limit. Not doing so could result in requests
+to server failing.
 
 Servers MUST be tolerant of multiple cookie headers. For example, an HTTP/2
 {{RFC9113}} or HTTP/3 {{RFC9114}} connection might split a cookie header to

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -842,7 +842,7 @@ Set-Cookie: __Host-SID=12345; Secure; Path=/
 
 ## Cookie {#sane-cookie}
 
-### Syntax
+### Syntax {#server-syntax}
 
 The user agent sends stored cookies to the origin server in the Cookie header field.
 If the server conforms to the requirements in {{sane-set-cookie}} (and the user agent
@@ -854,9 +854,20 @@ cookie        = cookie-string
 cookie-string = cookie-pair *( ";" SP cookie-pair )
 ~~~
 
+While Section 5.4 of {{RFC9110}} does not define a length limit for header
+fields it is likely that the web server's implementation does impose a limit,
+many popular implementations have default limits of 8K. Server SHOULD avoid
+setting a large number of large cookies such that the final cookie-string
+would exceed their header field limit. Not doing so could result in the request
+failing.
+
 Servers MUST be tolerant of multiple cookie headers. For example, an HTTP/2
 {{RFC9113}} or HTTP/3 {{RFC9114}} connection might split a cookie header to
-improve compression.
+improve compression. Servers are free to determine what form this tolerance
+takes. For example, the server could process each cookie header individually
+or the server could concatenate all the cookie headers into one and then
+process that final, single, header. The server should be mindful of any
+header field limits when deciding which approach to take.
 
 ### Semantics
 
@@ -1834,6 +1845,12 @@ the cookie-string following the algorithm defined in {{retrieval-algorithm}},
 where the retrieval's URI is the request-uri, the retrieval's same-site status
 is computed for the HTTP request as defined in {{same-site-requests}}, and the
 retrieval's type is "HTTP".
+
+Note: While this spec requires that a single cookie-string be produced, a user
+agent may consider splitting large request headers within their {{RFC9110}}
+implementation. This is due to potential server header length limits (See
+{{server-syntax}}) being exceeded due to servers setting too many large
+cookies.
 
 ### Non-HTTP APIs {#non-http}
 

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -859,7 +859,7 @@ fields it is likely that the web server's implementation does impose a limit;
 many popular implementations have default limits of 8K. Server SHOULD avoid
 setting a large number of large cookies such that the final cookie-string
 would exceed their header field limit. Not doing so could result in requests
-to server failing.
+to the server failing.
 
 Servers MUST be tolerant of multiple cookie headers. For example, an HTTP/2
 {{RFC9113}} or HTTP/3 {{RFC9114}} connection might split a cookie header to


### PR DESCRIPTION
Closes #2796
Closes #2797 

Adds suggestions for how servers could fulfill the `MUST be tolerant of multiple cookie headers` requirement

Adds suggestion that servers be mindful of the number and size of the cookies they set to avoid hitting their own header length limits. Also mention that UA should consider splitting longer fields.