### PR TITLE
Resumable upload: Problem Types

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -434,7 +434,9 @@ The `application/partial-upload` media type describes a contiguous block of data
 
 ## Mismatching Offset
 
-This section defines the "https://iana.org/assignments/http-problem-types#mismatching-upload-offset" problem type {{PROBLEM}}. An upload resource MAY use this problem type in a response to an upload append request ({{upload-appending}}) to indicate that the `Upload-Offset` header field in the request does not match the upload resource's offset. The resource SHOULD provide its offset in the `expected-offset` member and the offset from the upload append request in the `provided-offset` member.
+This section defines the "https://iana.org/assignments/http-problem-types#mismatching-upload-offset" problem type {{PROBLEM}}. A server MAY use this problem type when responding to an upload append request ({{upload-appending}}) to indicate that the `Upload-Offset` header field in the request does not match the upload resource's offset.
+
+Two problem type extension members are defined: the `expected-offset` and `provided-offset` members. A response using this problem type SHOULD populate both members, with the value of `expected-offset` taken from the upload resource and the value of `provided-offset` taken from the upload append request.
 
 The following example shows an example response, where the resource's offset was 100, but the client attempted to append at offset 200:
 
@@ -452,9 +454,9 @@ Content-Type: application/problem+json
 
 ## Completed Upload
 
-This section defines the `https://iana.org/assignments/http-problem-types#completed-upload` problem type {{PROBLEM}}. An server MAY use this problem type in a response to an upload append request ({{upload-appending}}) to indicate that the upload has already been completed and cannot be modified.
+This section defines the "https://iana.org/assignments/http-problem-types#completed-upload" problem type {{PROBLEM}}. A server MAY use this problem type when responding to an upload append request ({{upload-appending}}) to indicate that the upload has already been completed and cannot be modified.
 
-The following example shows an example response, where the resource's offset was 100, but the client attempted to append at offset 200:
+The following example shows an example response:
 
 ~~~ http-message
 HTTP/1.1 400 Bad Request

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -464,6 +464,7 @@ Content-Type: application/problem+json
   "type":"https://iana.org/assignments/http-problem-types#completed-upload",
   "title": "upload is already completed"
 }
+
 ~~~
 
 # Redirection
@@ -586,6 +587,7 @@ Recommended HTTP status code:
 : 400
 Reference:
 : This document
+
 --- back
 
 # Informational Response

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -661,6 +661,7 @@ The authors would like to thank Mark Nottingham for substantive contributions to
 * Add note about `Content-Location` for referring to subsequent resources.
 * Require `application/partial-upload` for appending to uploads.
 * Explain handling of content and transfer codings.
+* Add problem types for mismatching offsets and completed uploads.
 
 ## Since draft-ietf-httpbis-resumable-upload-02
 {:numbered="false"}

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -349,7 +349,7 @@ If the server does not consider the upload associated with the upload resource a
 
 The client MUST NOT perform multiple upload transfers for the same upload resource in parallel. This helps avoid race conditions, and data loss or corruption. The server is RECOMMENDED to take measures to avoid parallel upload transfers: The server MAY terminate any creation ({{upload-creation}}) or append for the same upload URL. Since the client is not allowed to perform multiple transfers in parallel, the server can assume that the previous attempt has already failed. Therefore, the server MAY abruptly terminate the previous HTTP connection or stream.
 
-If the offset indicated by the `Upload-Offset` field value does not match the offset provided by the immediate previous offset retrieval ({{offset-retrieving}}), or the end offset of the immediate previous incomplete successful transfer, the server MUST respond with a `409 (Conflict)` status code. The server MAY use the corresponding problem type ({{mismatching-offset}}) for the response.
+If the offset indicated by the `Upload-Offset` field value does not match the offset provided by the immediate previous offset retrieval ({{offset-retrieving}}), or the end offset of the immediate previous incomplete successful transfer, the server MUST respond with a `409 (Conflict)` status code. The server MAY use the problem type {{PROBLEM}} of "https://iana.org/assignments/http-problem-types#mismatching-upload-offset" in the response; see {{mismatching-offset}}.
 
 The server applies the patch document of the `application/partial-upload` media type by appending the request content to the targeted upload resource. If the server does not receive the entire patch document, for example because of canceled requests or dropped connections, it SHOULD append as much of the patch document starting at its beginning and without discontinuities as possible. Appending a continuous section starting at the patch document's beginning constitutes a successful PATCH as defined in {{Section 2 of RFC5789}}. If the server did not receive and apply the entire patch document, the upload MUST NOT be considered complete.
 
@@ -434,7 +434,7 @@ The `application/partial-upload` media type describes a contiguous block of data
 
 ## Mismatching Offset
 
-This section defines the `https://iana.org/assignments/http-problem-types#mismatching-upload-offset` problem type {{PROBLEM}}. An upload resource MAY use this problem type in a response to an upload append request ({{upload-appending}}) to indicate that the `Upload-Offset` header field in the request does not match the upload resource's offset. The resource SHOULD provide its offset in the `expected-offset` member and the offset from the upload append request in the `provided-offset` member.
+This section defines the "https://iana.org/assignments/http-problem-types#mismatching-upload-offset" problem type {{PROBLEM}}. An upload resource MAY use this problem type in a response to an upload append request ({{upload-appending}}) to indicate that the `Upload-Offset` header field in the request does not match the upload resource's offset. The resource SHOULD provide its offset in the `expected-offset` member and the offset from the upload append request in the `provided-offset` member.
 
 The following example shows an example response, where the resource's offset was 100, but the client attempted to append at offset 200:
 
@@ -452,7 +452,7 @@ Content-Type: application/problem+json
 
 ## Completed Upload
 
-This section defines the `https://iana.org/assignments/http-problem-types#completed-upload` problem type {{PROBLEM}}. An upload resource MAY use this problem type in a response to an upload append request ({{upload-appending}}) to indicate that the upload has already been completed and cannot be modified.
+This section defines the `https://iana.org/assignments/http-problem-types#completed-upload` problem type {{PROBLEM}}. An server MAY use this problem type in a response to an upload append request ({{upload-appending}}) to indicate that the upload has already been completed and cannot be modified.
 
 The following example shows an example response, where the resource's offset was 100, but the client attempted to append at offset 200:
 

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -46,6 +46,7 @@ author:
 normative:
   HTTP: RFC9110
   RFC5789:
+  PROBLEM: RFC9457
 
 informative:
 
@@ -348,7 +349,7 @@ If the server does not consider the upload associated with the upload resource a
 
 The client MUST NOT perform multiple upload transfers for the same upload resource in parallel. This helps avoid race conditions, and data loss or corruption. The server is RECOMMENDED to take measures to avoid parallel upload transfers: The server MAY terminate any creation ({{upload-creation}}) or append for the same upload URL. Since the client is not allowed to perform multiple transfers in parallel, the server can assume that the previous attempt has already failed. Therefore, the server MAY abruptly terminate the previous HTTP connection or stream.
 
-If the offset indicated by the `Upload-Offset` field value does not match the offset provided by the immediate previous offset retrieval ({{offset-retrieving}}), or the end offset of the immediate previous incomplete successful transfer, the server MUST respond with a `409 (Conflict)` status code.
+If the offset indicated by the `Upload-Offset` field value does not match the offset provided by the immediate previous offset retrieval ({{offset-retrieving}}), or the end offset of the immediate previous incomplete successful transfer, the server MUST respond with a `409 (Conflict)` status code. The server MAY use the corresponding problem type ({{mismatching-offset}}) for the response.
 
 The server applies the patch document of the `application/partial-upload` media type by appending the request content to the targeted upload resource. If the server does not receive the entire patch document, for example because of canceled requests or dropped connections, it SHOULD append as much of the patch document starting at its beginning and without discontinuities as possible. Appending a continuous section starting at the patch document's beginning constitutes a successful PATCH as defined in {{Section 2 of RFC5789}}. If the server did not receive and apply the entire patch document, the upload MUST NOT be considered complete.
 
@@ -428,6 +429,26 @@ The `Upload-Complete` header field MUST only be used if support by the resource 
 # Media Type `application/partial-upload`
 
 The `application/partial-upload` media type describes a contiguous block of data that should be uploaded to a resource. There is no minimum block size and the block might be empty. The start and end of the block might align with the start and end of the file that should be uploaded, but they are not required to be aligned.
+
+# Problem Types
+
+## Mismatching Offset
+
+This section defines the `https://iana.org/assignments/http-problem-types#mismatching-upload-offset` problem type {{PROBLEM}}. An upload resource MAY use this problem type in a response to an upload append request ({{upload-appending}}) to indicate that the `Upload-Offset` header field in the request does not match the upload resource's offset. The resource SHOULD provide its offset in the `expected-offset` member and the offset from the upload append request in the `provided-offset` member.
+
+The following example shows an example response, where the resource's offset was 100, but the client attempted to append at offset 200:
+
+~~~ http-message
+HTTP/1.1 409 Conflict
+Content-Type: application/problem+json
+
+{
+  "type":"https://iana.org/assignments/http-problem-types#mismatching-upload-offset",
+  "title": "offset from request does not match offset of resource",
+  "expected-offset": 100,
+  "provided-offset": 200
+}
+~~~
 
 # Redirection
 
@@ -527,6 +548,17 @@ Author:
 
 Change controller:
 : IETF
+
+IANA is asked to register the following entry in the "HTTP Problem Types" registry:
+
+Type URI:
+: https://iana.org/assignments/http-problem-types#mismatching-upload-offset
+Title:
+: Mismatching Upload Offset
+Recommended HTTP status code:
+: 409 Conflict
+Reference:
+: This document
 
 --- back
 

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -450,6 +450,22 @@ Content-Type: application/problem+json
 }
 ~~~
 
+## Completed Upload
+
+This section defines the `https://iana.org/assignments/http-problem-types#completed-upload` problem type {{PROBLEM}}. An upload resource MAY use this problem type in a response to an upload append request ({{upload-appending}}) to indicate that the upload has already been completed and cannot be modified.
+
+The following example shows an example response, where the resource's offset was 100, but the client attempted to append at offset 200:
+
+~~~ http-message
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+
+{
+  "type":"https://iana.org/assignments/http-problem-types#completed-upload",
+  "title": "upload is already completed"
+}
+~~~
+
 # Redirection
 
 The `301 (Moved Permanently)` and `302 (Found)` status codes MUST NOT be used in offset retrieval ({{offset-retrieving}}) and upload cancellation ({{upload-cancellation}}) responses. For other responses, the upload resource MAY return a `308 (Permanent Redirect)` status code and clients SHOULD use new permanent URI for subsequent requests. If the client receives a `307 (Temporary Redirect)` response to an offset retrieval ({{offset-retrieving}}) request, it MAY apply the redirection directly in an immediate subsequent upload append ({{upload-appending}}).
@@ -556,10 +572,20 @@ Type URI:
 Title:
 : Mismatching Upload Offset
 Recommended HTTP status code:
-: 409 Conflict
+: 409
 Reference:
 : This document
 
+IANA is asked to register the following entry in the "HTTP Problem Types" registry:
+
+Type URI:
+: https://iana.org/assignments/http-problem-types#completed-upload
+Title:
+: Upload Is Completed
+Recommended HTTP status code:
+: 400
+Reference:
+: This document
 --- back
 
 # Informational Response


### PR DESCRIPTION
[RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) defines a framework for problem types, which can be used as a standardized response format when errors occurs. With resumable uploads, we have a few cases where such problem types could be useful, but usage remains entirely optional.

The text in this PR has been inspired by similar sections from [RFC 9458](https://www.rfc-editor.org/rfc/rfc9458.html#name-registration-of-date-proble).