### PR TITLE
Tweak the example in the explanation of "Lax-allowing-unsafe"

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2421,8 +2421,8 @@ resulting in an unrecoverable failure of the whole login flow.
 
 The "Lax-allowing-unsafe" enforcement mode described in {{lax-allowing-unsafe}}
 retains some of the protections of "Lax" enforcement (as compared to "None")
-while still allowing cookies to be sent cross-site with unsafe top-level
-requests.
+while still allowing recently created cookies to be sent cross-site with unsafe
+top-level requests.
 
 As a more permissive variant of "Lax" mode, "Lax-allowing-unsafe" mode
 necessarily provides fewer protections against CSRF. Ultimately, the provision

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2413,11 +2413,11 @@ cross-site requests with "unsafe" HTTP methods (as was the case prior to the
 introduction of the `SameSite` attribute).
 
 For example, the concluding step of a login flow may involve a cross-site top-level
-`POST` request to an endpoint which expects a cookie with transactional state
-information necessary to securely complete the login. For such a cookie, "Lax"
-enforcement is not appropriate, as it would cause the cookie to be excluded due
-to the unsafe HTTP request method, resulting in an unrecoverable failure of the
-whole login flow.
+`POST` request to an endpoint; this endpoint expects a recently created cookie
+containing transactional state information, necessary to securely complete the
+login. For such a cookie, "Lax" enforcement is not appropriate, as it would
+cause the cookie to be excluded due to the unsafe HTTP request method,
+resulting in an unrecoverable failure of the whole login flow.
 
 The "Lax-allowing-unsafe" enforcement mode described in {{lax-allowing-unsafe}}
 retains some of the protections of "Lax" enforcement (as compared to "None")

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2754,6 +2754,11 @@ The "Cookie Attribute Registry" should be created with the registrations below:
 * Add multiple cookie header tolerance suggestions & length limit warnings
   <https://github.com/httpwg/http-extensions/pull/2804>
 
+## draft-ietf-httpbis-rfc6265bis-15
+
+* Update example in the explanation of "Lax-allowing-unsafe"
+  <https://github.com/httpwg/http-extensions/pull/2812>
+
 # Acknowledgements
 {:numbered="false"}
 RFC 6265 was written by Adam Barth. This document is an update of RFC 6265,

--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2412,12 +2412,12 @@ not explicitly specifying a `SameSite` attribute being included on top-level
 cross-site requests with "unsafe" HTTP methods (as was the case prior to the
 introduction of the `SameSite` attribute).
 
-For example, a login flow may involve a cross-site top-level `POST` request to
-an endpoint which expects a cookie with login information. For such a cookie,
-"Lax" enforcement is not appropriate, as it would cause the cookie to be
-excluded due to the unsafe HTTP request method. On the other hand, "None"
-enforcement would allow the cookie to be sent with all cross-site requests,
-which may not be desirable due to the cookie's sensitive contents.
+For example, the concluding step of a login flow may involve a cross-site top-level
+`POST` request to an endpoint which expects a cookie with transactional state
+information necessary to securely complete the login. For such a cookie, "Lax"
+enforcement is not appropriate, as it would cause the cookie to be excluded due
+to the unsafe HTTP request method, resulting in an unrecoverable failure of the
+whole login flow.
 
 The "Lax-allowing-unsafe" enforcement mode described in {{lax-allowing-unsafe}}
 retains some of the protections of "Lax" enforcement (as compared to "None")


### PR DESCRIPTION
minimalist attempt at a fix for #2791 