### PR TITLE
Resumable Upload: Bump interop version

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -230,7 +230,7 @@ The following example shows an upload creation. The client transfers the entire 
 ~~~ http-message
 POST /upload HTTP/1.1
 Host: example.com
-Upload-Draft-Interop-Version: 5
+Upload-Draft-Interop-Version: 6
 Upload-Complete: ?1
 Content-Length: 100
 
@@ -239,11 +239,11 @@ Content-Length: 100
 
 ~~~ http-message
 HTTP/1.1 104 Upload Resumption Supported
-Upload-Draft-Interop-Version: 5
+Upload-Draft-Interop-Version: 6
 Location: https://example.com/upload/b530ce8ff
 
 HTTP/1.1 104 Upload Resumption Supported
-Upload-Draft-Interop-Version: 5
+Upload-Draft-Interop-Version: 6
 Upload-Offset: 50
 
 HTTP/1.1 201 Created
@@ -256,7 +256,7 @@ The next example shows an upload creation, where only the first 25 bytes are tra
 ~~~ http-message
 POST /upload HTTP/1.1
 Host: example.com
-Upload-Draft-Interop-Version: 5
+Upload-Draft-Interop-Version: 6
 Upload-Complete: ?0
 Content-Length: 25
 
@@ -286,7 +286,7 @@ Clients MUST NOT attempt to resume an upload unless they receive `104 (Upload Re
 
 > **RFC Editor's Note:**  Please remove this section and `Upload-Draft-Interop-Version` from all examples prior to publication of a final version of this document.
 
-The current interop version is 5.
+The current interop version is 6.
 
 Client implementations of draft versions of the protocol MUST send a header field `Upload-Draft-Interop-Version` with the interop version as its value to its requests. The `Upload-Draft-Interop-Version` field value is an Integer.
 
@@ -325,7 +325,7 @@ The following example shows an offset retrieval request. The server indicates th
 ~~~ http-message
 HEAD /upload/b530ce8ff HTTP/1.1
 Host: example.com
-Upload-Draft-Interop-Version: 5
+Upload-Draft-Interop-Version: 6
 ~~~
 
 ~~~ http-message
@@ -375,7 +375,7 @@ The following example shows an upload append. The client transfers the next 100 
 PATCH /upload/b530ce8ff HTTP/1.1
 Host: example.com
 Upload-Offset: 100
-Upload-Draft-Interop-Version: 5
+Upload-Draft-Interop-Version: 6
 Content-Length: 100
 Content-Type: application/partial-upload
 
@@ -410,7 +410,7 @@ The following example shows an upload cancellation:
 ~~~ http-message
 DELETE /upload/b530ce8ff HTTP/1.1
 Host: example.com
-Upload-Draft-Interop-Version: 5
+Upload-Draft-Interop-Version: 6
 ~~~
 
 ~~~ http-message
@@ -674,6 +674,7 @@ The authors would like to thank Mark Nottingham for substantive contributions to
 * Add problem types for mismatching offsets and completed uploads.
 * Clarify that completed uploads must not be appended to.
 * Describe interaction with Digest Fields from RFC9530.
+* Increase the draft interop version.
 
 ## Since draft-ietf-httpbis-resumable-upload-02
 {:numbered="false"}


### PR DESCRIPTION
https://github.com/httpwg/http-extensions/pull/2743 made the use of `application/partial-upload` media type mandatory for appending to an upload. This warrants a new interop version.