### PR TITLE
Be explicit about the name of a shared group

### DIFF
--- a/draft-ietf-httpbis-cache-groups.md
+++ b/draft-ietf-httpbis-cache-groups.md
@@ -91,11 +91,10 @@ Implementations MUST support at least 128 groups in a field value, with up to at
 
 ## Identifying Grouped Responses {#identify}
 
-Two responses stored in the same cache are considered to have the same group when all of the following conditions are met:
+Two responses stored in the same cache are considered to belong to the same group, identified by the String _group_, when all of the following conditions are met:
 
-1. They both contain a Cache-Groups response header field that contains the same String (in any position in the List), when compared character-by-character.
+1. They both contain a Cache-Groups response header field that contains _group_ (in any position in the List), when compared character-by-character.
 2. The both share the same URI origin (per {{Section 4.3.1 of HTTP}}).
-
 
 ## Cache Behaviour
 


### PR DESCRIPTION
Make the calculation of group responses more explicit with respect to the name of a shared group.