### PR TITLE
query: switch Accept-Query to SF (closes #2934)

### DIFF
--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -340,8 +340,8 @@ q=foo&amp;limit=10&amp;sort=-published
       <li>Media types do not exactly map to Tokens, for instance they
       allow a leading digit. In cases like these, the String format needs to
       be used.</li>
-      <li>The use of wildcards for anything except "*/*" or "type/*" is invalid
-      and will never match an actual media type.</li>
+      <li>The only supported uses of wildcards are "*/*", which matches any type, 
+      or "xxxx/*", which matches any subtype of the indicated type.</li>
       <li>The order of types listed in the field value is not significant.</li>
       <li>The only allowed format for parameters is String.</li>
     </ul>

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -357,7 +357,7 @@ q=foo&amp;limit=10&amp;sort=-published
     <artwork type="example">
 Accept-Query: "application/jsonpath", application/sql;charset="UTF-8"</artwork>
     <t>
-      Note that although the syntax appears to be similar to other
+      Although the syntax for this field appears to be similar to other
       fields, such as "Accept" (<xref target="HTTP" section="12.5.1"/>),
       it is a Structured Field and thus &MUST; be processed as specified in
       <xref target="STRUCTURED-FIELDS" section="4"/>.

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -337,7 +337,7 @@ q=foo&amp;limit=10&amp;sort=-published
     </t>
     <ul>
       <li>The choice of Token vs. String is semantically insignificant.</li>
-      <li>Media types do not exactly map to Tokens, for instance they do
+      <li>Media types do not exactly map to Tokens, for instance they
       allow a leading digit. In cases like these, the String format needs to
       be used.</li>
       <li>The use of wildcards for anything except "*/*" or "type/*" is invalid

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -336,7 +336,9 @@ q=foo&amp;limit=10&amp;sort=-published
       Note:
     </t>
     <ul>
-      <li>The choice of Token vs. String is semantically insignificant.</li>
+      <li>The choice of Token vs. String is semantically insignificant. That is,
+      recipients &MAY; convert Tokens to Strings, but &MUST-NOT; process them
+      differently based on the received type.</li>
       <li>Media types do not exactly map to Tokens, for instance they
       allow a leading digit. In cases like these, the String format needs to
       be used.</li>

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -329,24 +329,36 @@ q=foo&amp;limit=10&amp;sort=-published
       the specific query format media type(s) that may be used.
     </t>
     <t>
-      "Accept-Query" contains a list of media types (<xref target="HTTP" section="8.3.1"/>),
-      represented by a List Structured Header Field, containing
-      Token Items, optionally parameterized (<xref target="STRUCTURED-FIELDS" section="3"/>).
+      "Accept-Query" contains a list of media ranges (<xref target="HTTP" section="12.5.1"/>)
+      using "Structured Fields" syntax (<xref target="STRUCTURED-FIELDS"/>).
+      Media ranges are represented by a List Structured Header Field of either Tokens or
+      Strings, containing the media range value without parameters. Parameters,
+      if any, are mapped to Parameters of type String.
     </t>
     <t>
-      The order of types listed in the field value is not significant.
+      Note:
     </t>
+    <ul>
+      <li>The choice of Token vs. String is semantically insignificant.</li>
+      <li>Media types do not exactly map to Tokens, for instance they do
+      allow a leading digit. In cases like these, the String format needs to
+      be used.</li>
+      <li>The use of wildcards for anything except "*/*" or "type/*" is invalid
+      and will never match an actual media type.</li>
+      <li>The order of types listed in the field value is not significant.</li>
+      <li>The only allowed format for parameters is String.</li>
+    </ul>
     <t>
       Accept-Query's value applies to every URI on the server that shares the same path; in
       other words, the query component is ignored. If requests to the same resource return
-      different Accept-Query values, the most recently received fresh (per
-      <xref target="HTTP-CACHING" section="4.2"/>) value is used.
+      different Accept-Query values, the most recently received fresh value (per
+      <xref target="HTTP-CACHING" section="4.2"/>) is used.
     </t>
     <t>
       Example:
     </t>
     <artwork type="example">
-Accept-Query: application/jsonpath, application/sql;charset="UTF-8"</artwork>
+Accept-Query: "application/jsonpath", application/sql;charset="UTF-8"</artwork>
     <t>
       Note that although the syntax appears to be similar to other
       fields, such as "Accept" (<xref target="HTTP" section="12.5.1"/>),

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -340,7 +340,7 @@ q=foo&amp;limit=10&amp;sort=-published
       <li>Media types do not exactly map to Tokens, for instance they
       allow a leading digit. In cases like these, the String format needs to
       be used.</li>
-      <li>The only supported uses of wildcards are "*/*", which matches any type, 
+      <li>The only supported uses of wildcards are "*/*", which matches any type,
       or "xxxx/*", which matches any subtype of the indicated type.</li>
       <li>The order of types listed in the field value is not significant.</li>
       <li>The only allowed format for parameters is String.</li>

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -333,20 +333,25 @@ q=foo&amp;limit=10&amp;sort=-published
       if any, are mapped to Parameters of type String.
     </t>
     <t>
-      Note:
-    </t>
-    <ul>
-      <li>The choice of Token vs. String is semantically insignificant. That is,
+      The choice of Token vs. String is semantically insignificant. That is,
       recipients &MAY; convert Tokens to Strings, but &MUST-NOT; process them
-      differently based on the received type.</li>
-      <li>Media types do not exactly map to Tokens, for instance they
+      differently based on the received type.
+    </t>
+    <t>
+      Media types do not exactly map to Tokens, for instance they
       allow a leading digit. In cases like these, the String format needs to
-      be used.</li>
-      <li>The only supported uses of wildcards are "*/*", which matches any type,
-      or "xxxx/*", which matches any subtype of the indicated type.</li>
-      <li>The order of types listed in the field value is not significant.</li>
-      <li>The only allowed format for parameters is String.</li>
-    </ul>
+      be used.
+    </t>
+    <t>
+      The only supported uses of wildcards are "*/*", which matches any type,
+      or "xxxx/*", which matches any subtype of the indicated type.
+    </t>
+    <t>
+      The order of types listed in the field value is not significant.
+    </t>
+    <t>
+      The only allowed format for parameters is String.
+    </t>
     <t>
       Accept-Query's value applies to every URI on the server that shares the same path; in
       other words, the query component is ignored. If requests to the same resource return

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -292,7 +292,7 @@ q=foo&amp;limit=10&amp;sort=-published
     <t>
       "Accept-Query" contains a list of media types (<xref target="HTTP" section="8.3.1"/>),
       represented by a List Structured Header Field, containing
-      Token Items, optionally parametrized (<xref target="STRUCTURED-FIELDS" section="3"/>).
+      Token Items, optionally parameterized (<xref target="STRUCTURED-FIELDS" section="3"/>).
     </t>
     <t>
       The order of types listed in the field value is not significant.

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -464,6 +464,19 @@ Accept-Query: application/jsonpath, application/sql;charset="UTF-8"</artwork>
       <seriesInfo name="STD" value="98"/>
       <seriesInfo name="RFC" value="9111"/>
     </reference>
+    <reference anchor="STRUCTURED-FIELDS">
+      <front>
+        <title>Structured Field Values for HTTP</title>
+        <author initials="M." surname="Nottingham" fullname="Mark Nottingham">
+          <organization>Cloudflare</organization>
+        </author>
+        <author initials="P-H." surname="Kamp" fullname="Poul-Henning Kamp">
+          <organization>The Varnish Cache Project</organization>
+        </author>
+        <date year="2024" month="September"/>
+      </front>
+      <seriesInfo name="RFC" value="9651"/>
+    </reference>
   </references>
   <references title="Informative References">
     <reference anchor="FETCH" target="https://fetch.spec.whatwg.org">
@@ -641,138 +654,6 @@ Dubois, Camille, camille.dubois@example.net
 
     </section>
   </section>
-
-  <section title="Security Considerations">
-    <t>
-      The QUERY method is subject to the same general security
-      considerations as all HTTP methods as described in
-      <xref target="HTTP"/>.
-    </t>
-    <t>
-      It can be used as an alternative to passing request
-      information in the URI (e.g., in the query section). This is preferred in some
-      cases, as the URI is more likely to be logged or otherwise processed
-      by intermediaries than the request content.
-      If a server creates a temporary resource to represent the results of a QUERY
-      request (e.g., for use in the Location or Content-Location field) and the request
-      contains sensitive information that cannot be logged, then the URI of this
-      resource &SHOULD; be chosen such that it does not include any sensitive
-      portions of the original request content.
-    </t>
-    <t>
-      A QUERY request from user agents implementing CORS (Cross-Origin Resource Sharing)
-      will require a "preflight" request,
-      as QUERY does not belong to the set of CORS-safelisted methods
-      (see "<eref target="https://fetch.spec.whatwg.org/#methods">Methods</eref>" in
-      <xref target="FETCH"/>).
-    </t>
-  </section>
-
-  <section title="IANA Considerations" anchor="iana.considerations">
-
-    <section title="Registration of QUERY method" anchor="method.registration">
-      <t>
-        IANA is requested to add the QUERY method to the HTTP
-        Method Registry at <eref brackets="angle" target="http://www.iana.org/assignments/http-methods"/>
-        (see <xref target="HTTP" section="16.3.1"/>).
-      </t>
-      <table>
-        <thead>
-          <tr>
-            <th>Method Name</th>
-            <th>Safe</th>
-            <th>Idempotent</th>
-            <th>Specification</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>QUERY</td>
-            <td>Yes</td>
-            <td>Yes</td>
-            <td><xref target="query"/></td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-
-    <section title="Registration of Accept-Query field" anchor="field.registration">
-      <t>
-        IANA is requested to add the Accept-Query field to the HTTP Field Name
-        Registry at <eref brackets="angle" target="https://www.iana.org/assignments/http-fields"/>
-        (see <xref target="HTTP" section="16.1.1"/>).
-      </t>
-      <table>
-        <thead>
-          <tr>
-            <th>Field Name</th>
-            <th>Status</th>
-            <th>Structured Type</th>
-            <th>Reference</th>
-            <th>Comments</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Accept-Query</td>
-            <td>permanent</td>
-            <td>List</td>
-            <td><xref target="field.accept-query"/> of this document.</td>
-            <td/>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-</section>
-</middle>
-<back>
-  <references title="Normative References">
-    <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2119.xml"/>
-    <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8174.xml"/>
-    <reference anchor="HTTP">
-      <front>
-        <title>HTTP Semantics</title>
-        <author fullname="Roy T. Fielding" initials="R." surname="Fielding" role="editor"/>
-        <author fullname="Mark Nottingham" initials="M." surname="Nottingham" role="editor"/>
-        <author fullname="Julian Reschke" initials="J." surname="Reschke" role="editor"/>
-        <date year="2022" month="June"/>
-      </front>
-      <seriesInfo name="STD" value="97"/>
-      <seriesInfo name="RFC" value="9110"/>
-    </reference>
-    <reference anchor="HTTP-CACHING">
-      <front>
-        <title>HTTP Caching</title>
-        <author fullname="Roy T. Fielding" initials="R." surname="Fielding" role="editor"/>
-        <author fullname="Mark Nottingham" initials="M." surname="Nottingham" role="editor"/>
-        <author fullname="Julian Reschke" initials="J." surname="Reschke" role="editor"/>
-        <date year="2022" month="June"/>
-      </front>
-      <seriesInfo name="STD" value="98"/>
-      <seriesInfo name="RFC" value="9111"/>
-    </reference>
-    <reference anchor="STRUCTURED-FIELDS">
-      <front>
-        <title>Structured Field Values for HTTP</title>
-        <author initials="M." surname="Nottingham" fullname="Mark Nottingham">
-          <organization>Cloudflare</organization>
-        </author>
-        <author initials="P-H." surname="Kamp" fullname="Poul-Henning Kamp">
-          <organization>The Varnish Cache Project</organization>
-        </author>
-        <date year="2024" month="September"/>
-      </front>
-      <seriesInfo name="RFC" value="9651"/>
-    </reference>
-  </references>
-  <references title="Informative References">
-    <reference anchor="FETCH" target="https://fetch.spec.whatwg.org">
-      <front>
-        <title>FETCH</title>
-        <author><organization>WHATWG</organization></author>
-      </front>
-    </reference>
-  </references>
 
 <section title="Change Log" anchor="change.log" removeInRFC="true">
 <section title="Since draft-ietf-httpbis-safe-method-w-body-00" anchor="changes.since.00">

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -285,26 +285,34 @@ q=foo&amp;limit=10&amp;sort=-published
 
   <section title="The &quot;Accept-Query&quot; Header Field" anchor="field.accept-query">
     <t>
-      The "Accept-Query" response header field &MAY; be used by a resource to
+      The "Accept-Query" response header field can be used by a resource to
       directly signal support for the QUERY method while identifying
       the specific query format media type(s) that may be used.
     </t>
-<sourcecode type="abnf">
-Accept-Query = 1#media-type
-</sourcecode>
     <t>
-      The Accept-Query header field specifies a comma-separated listing of media
-      types (with optional parameters) as defined by
-      <xref target="HTTP" section="8.3.1"/>. <cref>field syntax currently discussed in <eref target="https://github.com/httpwg/http-extensions/issues/2860"/></cref>
+      "Accept-Query" contains a list of media types (<xref target="HTTP" section="8.3.1"/>),
+      represented by a List Structured Header Field, containing
+      Token Items, optionally parametrized (<xref target="STRUCTURED-FIELDS" section="3"/>).
     </t>
     <t>
-      The order of types listed by the Accept-Query header field is not significant.
+      The order of types listed in the field value is not significant.
     </t>
     <t>
       Accept-Query's value applies to every URI on the server that shares the same path; in
       other words, the query component is ignored. If requests to the same resource return
       different Accept-Query values, the most recently received fresh (per
       <xref target="HTTP-CACHING" section="4.2"/>) value is used.
+    </t>
+    <t>
+      Example:
+    </t>
+    <artwork type="example">
+Accept-Query: application/jsonpath, application/sql;charset="UTF-8"</artwork>
+    <t>
+      Note that although the syntax appears to be similar to other
+      fields, such as "Accept" (<xref target="HTTP" section="12.5.1"/>),
+      it is a Structured Field and thus &MUST; be processed as specified in
+      <xref target="STRUCTURED-FIELDS" section="4"/>.
     </t>
   </section>
 
@@ -543,9 +551,9 @@ Dubois, Camille, camille.dubois@example.net
           <tr>
             <td>Accept-Query</td>
             <td>permanent</td>
-            <td></td>
+            <td>List</td>
             <td><xref target="field.accept-query"/> of this document.</td>
-            <td><cref>field syntax currently discussed in <eref target="https://github.com/httpwg/http-extensions/issues/2860"/></cref></td>
+            <td/>
           </tr>
         </tbody>
       </table>
@@ -577,6 +585,19 @@ Dubois, Camille, camille.dubois@example.net
       </front>
       <seriesInfo name="STD" value="98"/>
       <seriesInfo name="RFC" value="9111"/>
+    </reference>
+    <reference anchor="STRUCTURED-FIELDS">
+      <front>
+        <title>Structured Field Values for HTTP</title>
+        <author initials="M." surname="Nottingham" fullname="Mark Nottingham">
+          <organization>Cloudflare</organization>
+        </author>
+        <author initials="P-H." surname="Kamp" fullname="Poul-Henning Kamp">
+          <organization>The Varnish Cache Project</organization>
+        </author>
+        <date year="2024" month="September"/>
+      </front>
+      <seriesInfo name="RFC" value="9651"/>
     </reference>
   </references>
 
@@ -628,6 +649,7 @@ Dubois, Camille, camille.dubois@example.net
 <section title="Since draft-ietf-httpbis-safe-method-w-body-06" anchor="changes.since.06">
 <ul>
   <li>Editorial changes to Introduction (ack Will Hawkins, <eref target="https://github.com/httpwg/http-extensions/pull/2859"/>)</li>
+  <li>Make Accept-Query a Structured Field (<eref target="https://github.com/httpwg/http-extensions/issues/2934"/>)</li>
 </ul>
 </section>
 </section>


### PR DESCRIPTION
Summary:

- use list of Tokens holding "type/subtype" media types (not Strings @mnot) - not that if we'd use HTTP's definition of type/subtype as tokes, this would allow "*" in both places (is this a problem in HTTP spec???)
- allows parameters

TODO:

- clarify that the Tokens do not hold full media types, which would include parameters
- clarity that these are not media ranges, thus no wildcards (but see above)