### PR TITLE
[optimistic-upgrade] Clearly limit recommendations to HTTP/1.1

### DIFF
--- a/draft-ietf-httpbis-optimistic-upgrade.md
+++ b/draft-ietf-httpbis-optimistic-upgrade.md
@@ -158,9 +158,9 @@ Future specifications for Upgrade Tokens should restrict their use to "GET" requ
 
 # Guidance for HTTP CONNECT
 
-Clients that send HTTP CONNECT requests on behalf of untrusted TCP clients MUST wait for a 2xx (Successful) response before sending any TCP payload data.
+In HTTP/1.1, clients that send CONNECT requests on behalf of untrusted TCP clients MUST wait for a 2xx (Successful) response before sending any TCP payload data.
 
-To mitigate vulnerabilities from any clients that do not conform to this requirement, proxy servers MAY close the underlying connection when rejecting an HTTP CONNECT request, without processing any further data sent to the proxy server on that connection.  Note that this behavior may impair performance, especially when returning a "407 (Proxy Authentication Required)" response.
+To mitigate vulnerabilities from any clients that do not conform to this requirement, proxy servers MAY close the underlying connection when rejecting an HTTP/1.1 CONNECT request, without processing any further data sent to the proxy server on that connection.  Note that this behavior may impair performance, especially when returning a "407 (Proxy Authentication Required)" response.
 
 # IANA Considerations
 


### PR DESCRIPTION
Fixes #2941