### PR TITLE
Clean up editorial issues

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -1,6 +1,7 @@
 ---
 title: "Cookies: HTTP State Management Mechanism"
 docname: draft-ietf-httpbis-rfc6265bis-latest
+submissiontype: IETF
 date: {DATE}
 category: std
 obsoletes: 6265
@@ -120,7 +121,6 @@ normative:
       org: WHATWG
 
 informative:
-  RFC2818:
   RFC3986:
   RFC6265:
   RFC4648:
@@ -198,9 +198,6 @@ informative:
     -
       ins: C. Bentzel
       name: Chris Bentzel
-  I-D.ietf-httpbis-cookie-alone:
-  I-D.ietf-httpbis-cookie-prefixes:
-  I-D.ietf-httpbis-cookie-same-site:
   PSL:
     target: https://publicsuffix.org/list/
     title: "Public Suffix List"
@@ -584,14 +581,14 @@ cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
                       ; US-ASCII characters excluding CTLs,
                       ; whitespace, DQUOTE, comma, semicolon,
                       ; and backslash
-token             = <token, defined in [RFC9110], Section 5.6.2>
+token             = <token, defined in [HTTP], Section 5.6.2>
 
 cookie-av         = expires-av / max-age-av / domain-av /
                     path-av / secure-av / httponly-av /
                     samesite-av / extension-av
 expires-av        = "Expires" BWS "=" BWS sane-cookie-date
 sane-cookie-date  =
-    <IMF-fixdate, defined in [RFC9110], Section 5.6.7>
+    <IMF-fixdate, defined in [HTTP], Section 5.6.7>
 max-age-av        = "Max-Age" BWS "=" BWS non-zero-digit *DIGIT
 non-zero-digit    = %x31-39
                       ; digits 1 through 9
@@ -757,7 +754,7 @@ The Secure attribute limits the scope of the cookie to "secure" channels
 (where "secure" is defined by the user agent). When a cookie has the Secure
 attribute, the user agent will include the cookie in an HTTP request only if
 the request is transmitted over a secure channel (typically HTTP over Transport
-Layer Security (TLS) {{RFC2818}}).
+Layer Security (TLS) {{RFC9110}}).
 
 #### The HttpOnly Attribute {#attribute-httponly}
 


### PR DESCRIPTION
Clean up leftover, incorrect, and obsolete references.

Also adds `submissiontype: IETF` explicitly, this was previously automatically applied.