### PR TITLE
[RFC6265bis] Clarify IANA considerations.

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -2450,11 +2450,11 @@ Author/Change controller:
 Specification document:
 : this specification ({{set-cookie}})
 
-## Cookie Attribute Registry
+## "Cookie Attributes" Registry
 
-IANA is requested to create the "Cookie Attribute" registry, defining the
-name space of attribute used to control cookies' behavior.
-The registry should be maintained at
+IANA is requested to create the "Cookie Attributes" registry, defining the name space of
+attributes used to control cookies' behavior. The registry should be maintained in a new
+registry group called "Hypertext Transfer Protocol (HTTP) Cookie Attributes" at
 <https://www.iana.org/assignments/cookie-attribute-names>.
 
 ### Procedure
@@ -2469,7 +2469,7 @@ defined in CamelCase, but technically accepted case-insensitively.
 
 ### Registration
 
-The "Cookie Attribute Registry" should be created with the registrations below:
+The "Cookie Attributes" registry should be created with the registrations below:
 
 | Name     | Reference                               |
 |----------:+----------------------------------------|


### PR DESCRIPTION
We used two different names for the attribute name registry this document asks IANA to create. This PR normalizes them to "Cookie Attributes" and clarifies the name.