### PR TITLE
Resumable Upload: Upload Resource Section

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -375,7 +375,7 @@ Upload-Limit: max-size=1000000000
 
 ### Client Behavior
 
-If the client wants to resume the upload after an interruption, it has to know the amount of representation data received by the upload resource so far. It can fetch the offset by sending a `HEAD` request to the upload resource. Opon a successful response, the client can continue the upload by appending representation data ({{upload-appending}}) starting at the offset indicated by the `Upload-Offset` response header field.
+If the client wants to resume the upload after an interruption, it has to know the amount of representation data received by the upload resource so far. It can fetch the offset by sending a `HEAD` request to the upload resource. Upon a successful response, the client can continue the upload by appending representation data ({{upload-appending}}) starting at the offset indicated by the `Upload-Offset` response header field.
 
 The offset can be less than or equal to the number of bytes of representation data that the client has already sent. The client MAY reject an offset which is greater than the number of bytes it has already sent during this upload. The client is expected to handle backtracking of a reasonable length. If the offset is invalid for this upload, or if the client cannot backtrack to the offset and reproduce the same representation data it has already sent, the upload MUST be considered a failure. The client MAY cancel the upload ({{upload-cancellation}}) after rejecting the offset.
 
@@ -412,7 +412,7 @@ Cache-Control: no-store
 
 ### Client Behavior
 
-A client can continue the upload and append representation data by sending a `PATCH` reqeust with the `application/partial-upload` media type to the upload resource. The request content is the representation data to append.
+A client can continue the upload and append representation data by sending a `PATCH` request with the `application/partial-upload` media type to the upload resource. The request content is the representation data to append.
 
 The client MUST indicate the offset of the request content inside the representation data by including the `Upload-Offset` request header field. To ensure that the upload resource will accept request, the offset SHOULD be taken from an immediate previous response for retrieving the offset ({{offset-retrieving}}) or appending representation data ({{upload-appending}}).
 
@@ -432,7 +432,7 @@ If the `Upload-Offset` request header field value does not match the current off
 
 If the upload is already complete ({{upload-complete}}), the server MUST NOT modify the upload resource and MUST reject the request. The server MAY use the problem type {{PROBLEM}} of "https://iana.org/assignments/http-problem-types#completed-upload" in the response ({{completed-upload}}).
 
-If the `Upload-Complete` request header field is set to true, the client intents to transfer the remaining representation data in one request. If the request content was fully received, the upload is marked as complete and the resource targeted by the initial upload creation proceeds to process the entire representation and generate a response (see {{upload-creation}}). Its response MUST include the final offset in the `Upload-Complete` header field.
+If the `Upload-Complete` request header field is set to true, the client intents to transfer the remaining representation data in one request. If the request content was fully received, the upload is marked as complete and the resource targeted by the initial upload creation proceeds to process the entire representation and generate a response (see {{upload-creation}}). Its response MUST include the final offset in the `Upload-Offset` header field.
 
 If the `Upload-Complete` request header field is set to false, the client intents to transfer the remaining representation over multiple requests. If the request content was fully received, the upload resource MUST acknowledge the new upload state by sending a response with the `201 (Created)` status code. The response MUST include the offset in the `Upload-Offset` response header field and the `Upload-Complete` response header field set to false. The response SHOULD include the `Upload-Limit` header field with the corresponding limits if existing.
 

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -251,7 +251,7 @@ If both variants are present in the same request, their length values MUST be th
 
 The length might be not be known until the upload is complete.
 
-Note that the length and offset values do not determine whether an upload is complete. Instead, the client uses the `Upload-Complete` ({{upload-complete}}) header field to indicate that a request completes the upload. 
+Note that the length and offset values do not determine whether an upload is complete. Instead, the client uses the `Upload-Complete` ({{upload-complete}}) header field to indicate that a request completes the upload.
 
 ### Limits {#upload-limit}
 

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -353,7 +353,7 @@ Client implementations of draft versions of the protocol MUST ignore a `104 (Upl
 
 The reason both the client and the server are sending and checking the draft version is to ensure that implementations of the final RFC will not accidentally interop with draft implementations, as they will not check the existence of the `Upload-Draft-Interop-Version` header field.
 
-### Examples
+### Examples {#upload-creation-example}
 
 The following example shows an upload creation, where the entire 100 bytes are transferred in the initial request:
 
@@ -425,7 +425,7 @@ A successful response to a `HEAD` request against an upload resource
 - MAY indicate the limits in the `Upload-Limit` header field ({{upload-limit}}), and
 - SHOULD include the `Cache-Control` header field with the value `no-store` to prevent HTTP caching ({{CACHING}}).
 
-### Example
+### Example {#offset-retrieving-example}
 
 The following example shows an offset retrieval request. The server indicates the new offset and that the upload is not complete yet:
 
@@ -474,7 +474,7 @@ The upload resource MUST record the length according to {{upload-length}} if the
 
 While the request content is being received, the server MAY send interim responses with a `104 (Upload Resumption Supported)` status code and the `Upload-Offset` header field set to the current offset to inform the client about the upload progress. These interim responses MUST NOT include the `Location` header field.
 
-### Example
+### Example {#upload-appending-example}
 
 The following example shows an upload append. The client transfers the next 100 bytes at an offset of 100 and does not indicate that the upload is then completed. The server acknowledges the new offset:
 
@@ -508,7 +508,7 @@ Upon receiving a `DELETE` request, the server SHOULD deactivate the upload resou
 
 The server MAY terminate any in-flight requests to the upload resource before sending the response by abruptly terminating their HTTP connection(s) or stream(s).
 
-### Example
+### Example {#upload-cancellation-example}
 
 The following example shows an upload cancellation:
 

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -474,7 +474,7 @@ Upon receiving a `DELETE` request, the server SHOULD deactivate the upload resou
 
 The server MAY terminate any in-flight requests to the upload resource before sending the response by abruptly terminating their HTTP connection(s) or stream(s).
 
-### Example 
+### Example
 
 The following example shows an upload cancellation:
 


### PR DESCRIPTION
This PR tries to improve the draft's readability by introducing a dedicated section about the upload resource. This resource is the main component that enables resumable uploads but is not directly described in the document so far. Additionally, some of the section in the current draft are too long and would benefit from being broken up.

The new section about the upload resource houses a brief description of its responsibilities and the state that the resource needs to keep track of (offset, completeness, length, limits). I also moved the definition of the corresponding headers (Upload-Offset etc) in there as it made sense to me to describe the values and their presentations in the same space. Let me know if you disagree here.

The upload resource section then includes the definition of how the different requests for creating and resuming uploads are handled. Each description is further divided into behavior for the client and server break the huge wall of text into more digestible sections.

In addtion:
- I added a dedicated section about handling concurrent requests, so that the corresponding text does not have to be duplicated in the creation and appending sections.
- I removed the section "Feature Detection" since this is covered by "Upgrading To Resumable Uploads".
- The "Offset values" section has been merged into the "Offset" section.

Since the diff is rather confusing, I recommend to review this PR by reading the rendered section at https://httpwg.org/http-extensions/resumable-upload/upload-resource/draft-ietf-httpbis-resumable-upload.html#name-upload-resource.

Note that this PR is intended to be editorial. Please let me know if I included normative changes by accident.