### PR TITLE
Resumable Upload: Rename `expires` limit to `max-age`

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -293,9 +293,9 @@ An upload resource MAY enforce one or multiple limits, which are communicated to
 - The `min-size` limit specifies a minimum size for the representation data, counted in bytes. The server MAY NOT create an upload resource if the length ({{upload-length}}) deduced from the upload creation request is smaller than the minimum size or no length can be deduced at all. The value is an Integer.
 - The `max-append-size` limit specifies a maximum size counted in bytes for the request content in a single upload append request ({{upload-appending}}). The server MAY reject requests exceeding this limit and a client SHOULD NOT send larger upload append requests. The value is an Integer.
 - The `min-append-size` limit specifies a minimum size counted in bytes for the request content in a single upload append request ({{upload-appending}}). The server MAY reject requests below this limit and a client SHOULD NOT send such requests. The value is an Integer. Requests completing the upload by including the `Upload-Complete: ?1` header field are exempt from this limit.
-- The `expires` limits specifies the remaining lifetime of the upload resource in seconds counted from the generation of the response. After the resource's lifetime is reached, the server MAY make the upload resource inaccessible and a client SHOULD NOT attempt to access the upload resource. The lifetime MAY be extended but SHOULD NOT be reduced once the upload resource is created. The value is an Integer.
+- The `max-age` limit specifies the remaining lifetime of the upload resource in seconds counted from the generation of the response. After the resource's lifetime is reached, the server MAY make the upload resource inaccessible and a client SHOULD NOT attempt to access the upload resource. The lifetime MAY be extended but SHOULD NOT be reduced. The value is an Integer.
 
-Except for the `expires` limit, the existence of a limit or its value MUST NOT change throughout the lifetime of the upload resource.
+Except for the `max-age` limit, the existence of a limit or its value MUST NOT change throughout the lifetime of the upload resource.
 
 When parsing the `Upload-Limit` header field, unrecognized keys MUST be ignored and MUST NOT fail the parsing to facilitate the addition of new limits in the future.
 


### PR DESCRIPTION
Closes #2940.

The Upload-Limit header can provide the remain lifetime of the upload resource in number of seconds under the `expires` key. However, this name is misleading as it implies that the value is an absolute timestamp. A better name could be `max-age`, which is already used in the [Cache-Control](https://www.rfc-editor.org/rfc/rfc9111.html#name-max-age), [Set-Cookie](https://datatracker.ietf.org/doc/html/rfc6265#autoid-13), and [Alt-Svc](https://datatracker.ietf.org/doc/html/rfc7838#section-3.1) header fields to denominate the lifetime of cookies and cache entries.