### PR TITLE
Define structured types for header fields

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -794,14 +794,14 @@ Servers SHOULD provide mitigations for Slowloris attacks, such as increasing the
 
 IANA is asked to register the following entries in the "Hypertext Transfer Protocol (HTTP) Field Name Registry":
 
-|----------------------|-----------|-------------------------------------------|
-| Field Name           | Status    |                 Reference                 |
-|----------------------|-----------|-------------------------------------------|
-| Upload-Complete      | permanent | {{upload-complete}} of this document      |
-| Upload-Offset        | permanent | {{upload-offset}} of this document        |
-| Upload-Limit         | permanent | {{upload-limit}} of this document         |
-| Upload-Length        | permanent | {{upload-length}} of this document        |
-|----------------------|-----------|-------------------------------------------|
+|----------------------|-----------|-----------------|-------------------------------------------|
+| Field Name           | Status    | Structured Type |                 Reference                 |
+|----------------------|-----------|-----------------|-------------------------------------------|
+| Upload-Complete      | permanent | Item            | {{upload-complete}} of this document      |
+| Upload-Offset        | permanent | Item            | {{upload-offset}} of this document        |
+| Upload-Limit         | permanent | Dictionary      | {{upload-limit}} of this document         |
+| Upload-Length        | permanent | Item            | {{upload-length}} of this document        |
+|----------------------|-----------|-----------------|-------------------------------------------|
 
 IANA is asked to register the following entry in the "HTTP Status Codes" registry:
 


### PR DESCRIPTION
In https://github.com/httpwg/http-extensions/pull/3027, the reference for structured fields was updated to RFC 9651, which demands that newly registered header fields define their structured fields. This PR adds the missing column.

See https://www.rfc-editor.org/rfc/rfc9651.html#iana and https://www.rfc-editor.org/rfc/rfc9651.html#name-changes-from-rfc-8941 for information about the new column.