### PR TITLE
[connect-tcp] Require close after CONNECT fails

### DIFF
--- a/draft-ietf-httpbis-optimistic-upgrade.md
+++ b/draft-ietf-httpbis-optimistic-upgrade.md
@@ -14,7 +14,7 @@ workgroup: "HTTPBIS"
 keyword:
 venue:
   github: "httpwg/http-extensions"
-updates: 9298
+updates: 9112, 9298
 
 author:
  -
@@ -160,7 +160,7 @@ Future specifications for Upgrade Tokens should restrict their use to "GET" requ
 
 In HTTP/1.1, proxy clients that send CONNECT requests on behalf of untrusted TCP clients MUST wait for a 2xx (Successful) response before forwarding any TCP payload data.  Proxy clients that start forwarding before confirming the response status code are vulnerable to a trivial request smuggling attack ({{request-smuggling}}).
 
-To mitigate the impact of such vulnerable clients, proxy servers MAY close the underlying connection when rejecting an HTTP/1.1 CONNECT request, without processing any further data on that connection.  Note that this behavior will frequently impair the performance of correctly implemented clients, especially when returning a "407 (Proxy Authentication Required)" response.  This performance loss can be be avoided by using HTTP/2 or HTTP/3, which are not vulnerable to this attack.
+At the time of writing, some proxy clients are believed to be vulnerable as described.  When communicating with potentially vulnerable clients, proxy servers MUST close the underlying connection when rejecting an HTTP/1.1 CONNECT request, without processing any further data on that connection.  Note that this mitigation will frequently impair the performance of correctly implemented clients, especially when returning a "407 (Proxy Authentication Required)" response.  This performance loss can be be avoided by using HTTP/2 or HTTP/3, which are not vulnerable to this attack.
 
 # IANA Considerations
 

--- a/draft-ietf-httpbis-optimistic-upgrade.md
+++ b/draft-ietf-httpbis-optimistic-upgrade.md
@@ -160,7 +160,7 @@ Future specifications for Upgrade Tokens should restrict their use to "GET" requ
 
 In HTTP/1.1, proxy clients that send CONNECT requests on behalf of untrusted TCP clients MUST wait for a 2xx (Successful) response before forwarding any TCP payload data.  Proxy clients that start forwarding before confirming the response status code are vulnerable to a trivial request smuggling attack ({{request-smuggling}}).
 
-At the time of writing, some proxy clients are believed to be vulnerable as described.  When communicating with potentially vulnerable clients, proxy servers MUST close the underlying connection when rejecting an HTTP/1.1 CONNECT request, without processing any further data on that connection.  Note that this mitigation will frequently impair the performance of correctly implemented clients, especially when returning a "407 (Proxy Authentication Required)" response.  This performance loss can be be avoided by using HTTP/2 or HTTP/3, which are not vulnerable to this attack.
+At the time of writing, some proxy clients are believed to be vulnerable as described.  When communicating with potentially vulnerable clients, proxy servers MUST close the underlying connection when rejecting an HTTP/1.1 CONNECT request, without processing any further data on that connection.  Note that this mitigation will frequently impair the performance of correctly implemented clients, especially when returning a "407 (Proxy Authentication Required)" response.  This performance loss can be avoided by using HTTP/2 or HTTP/3, which are not vulnerable to this attack.
 
 # IANA Considerations
 


### PR DESCRIPTION
This changes makes it REQUIRED for proxy servers to close the connection after a failed HTTP/1.1 CONNECT ... with a legalistic escape hatch: this requirement only applies "when communicating with potentially vulnerable clients".

Presumably any client is potentially vulnerable unless you know something about it specifically.

See #2739