### PR TITLE
draft-ietf-httpbis-connect-tcp: fix area, remove keyword(s) for now (…

### DIFF
--- a/draft-ietf-httpbis-connect-tcp.md
+++ b/draft-ietf-httpbis-connect-tcp.md
@@ -5,10 +5,9 @@ category: std
 
 docname: draft-ietf-httpbis-connect-tcp-latest
 ipr: trust200902
-area: art
+area: wit
 submissiontype: IETF
 workgroup: httpbis
-keyword: Internet-Draft
 
 stand_alone: yes
 smart_quotes: no


### PR DESCRIPTION
…see #3046)

keyword "Internet-Draft" does not make any sense, will be flagged by RFC-Editor, and they'll ask for more meaningful one.