### PR TITLE
can buffer the header / trailer sections

### DIFF
--- a/draft-ietf-httpbis-incremental.md
+++ b/draft-ietf-httpbis-incremental.md
@@ -110,7 +110,9 @@ Upon receiving a header section that includes an Incremental header field with a
 true value, HTTP intermediaries SHOULD NOT buffer the entire message before
 forwarding it.  Instead, intermediaries SHOULD transmit the header section
 downstream and continuously forward the bytes of the message body as they
-arrive.
+arrive. As the Incremental header field indicates only how the message body is
+to be forwarded, intermediaries can still buffer the entire header and trailer
+sections of the message before forwarding it downstream.
 
 The Incremental HTTP header field applies to each HTTP message. Therefore, if
 both the HTTP request and response need to be forwarded incrementally, the

--- a/draft-ietf-httpbis-incremental.md
+++ b/draft-ietf-httpbis-incremental.md
@@ -110,7 +110,7 @@ Upon receiving a header section that includes an Incremental header field with a
 true value, HTTP intermediaries SHOULD NOT buffer the entire message before
 forwarding it.  Instead, intermediaries SHOULD transmit the header section
 downstream and continuously forward the bytes of the message body as they
-arrive. As the Incremental header field indicates only how the message body is
+arrive. As the Incremental header field indicates only how the message content is
 to be forwarded, intermediaries can still buffer the entire header and trailer
 sections of the message before forwarding them downstream.
 

--- a/draft-ietf-httpbis-incremental.md
+++ b/draft-ietf-httpbis-incremental.md
@@ -112,7 +112,7 @@ forwarding it.  Instead, intermediaries SHOULD transmit the header section
 downstream and continuously forward the bytes of the message body as they
 arrive. As the Incremental header field indicates only how the message body is
 to be forwarded, intermediaries can still buffer the entire header and trailer
-sections of the message before forwarding it downstream.
+sections of the message before forwarding them downstream.
 
 The Incremental HTTP header field applies to each HTTP message. Therefore, if
 both the HTTP request and response need to be forwarded incrementally, the


### PR DESCRIPTION
Clarify that incremental delivery is only needed for the message body.

Closes #3054.