### PR TITLE
explain what it means to have the incremental signal in both directions

### DIFF
--- a/draft-ietf-httpbis-incremental.md
+++ b/draft-ietf-httpbis-incremental.md
@@ -124,6 +124,12 @@ intermediaries to understand and respect a request to deliver messages
 incrementally. Clients can rely on prior knowledge or probe for support on
 individual resources.
 
+The Incremental header field enables the establishment of a bi-directional byte
+channel over HTTP, as its presence in both requests and responses instructs
+intermediaries to forward early responses ({{Section 7.5 of HTTP}}) and to
+transmit message bodies incrementally in both directions.
+
+
 # Security Considerations
 
 To conserve resources required to handle HTTP requests or connections, it is

--- a/draft-ietf-httpbis-incremental.md
+++ b/draft-ietf-httpbis-incremental.md
@@ -127,7 +127,7 @@ individual resources.
 The Incremental header field enables the establishment of a bidirectional byte
 channel over HTTP, as its presence in both requests and responses instructs
 intermediaries to forward early responses ({{Section 7.5 of HTTP}}) and to
-transmit message bodies incrementally in both directions.
+transmit message contents incrementally in both directions.
 
 
 # Security Considerations

--- a/draft-ietf-httpbis-incremental.md
+++ b/draft-ietf-httpbis-incremental.md
@@ -124,7 +124,7 @@ intermediaries to understand and respect a request to deliver messages
 incrementally. Clients can rely on prior knowledge or probe for support on
 individual resources.
 
-The Incremental header field enables the establishment of a bi-directional byte
+The Incremental header field enables the establishment of a bidirectional byte
 channel over HTTP, as its presence in both requests and responses instructs
 intermediaries to forward early responses ({{Section 7.5 of HTTP}}) and to
 transmit message bodies incrementally in both directions.

--- a/draft-ietf-httpbis-incremental.md
+++ b/draft-ietf-httpbis-incremental.md
@@ -127,7 +127,9 @@ individual resources.
 The Incremental header field facilitates the establishment of a bidirectional
 byte channel over HTTP, as its presence in both requests and responses instructs
 intermediaries to forward early responses ({{Section 7.5 of HTTP}}) and to
-transmit message contents incrementally in both directions.
+transmit message contents incrementally in both directions.  However, when developing
+bidirectional protocols over HTTP, Extended CONNECT {{?RFC8441}}{{?RFC9220}} is
+generally more consistent with HTTP's architecture.
 
 
 # Security Considerations

--- a/draft-ietf-httpbis-incremental.md
+++ b/draft-ietf-httpbis-incremental.md
@@ -124,8 +124,8 @@ intermediaries to understand and respect a request to deliver messages
 incrementally. Clients can rely on prior knowledge or probe for support on
 individual resources.
 
-The Incremental header field enables the establishment of a bidirectional byte
-channel over HTTP, as its presence in both requests and responses instructs
+The Incremental header field facilitates the establishment of a bidirectional
+byte channel over HTTP, as its presence in both requests and responses instructs
 intermediaries to forward early responses ({{Section 7.5 of HTTP}}) and to
 transmit message contents incrementally in both directions.
 


### PR DESCRIPTION
This PR is kind of take-it-or-leave-it, as we already suggest in the Introduction that the aim of the extension is partly to allow endpoints establish a bi-directional channel more gracefully.

However, as the concept of early responses might not be familiar to the readers, it might make sense to clarify the effect explicitly in the section that defined the header field.

WDYT?

Closes #3051.