### PR TITLE
No-Vary-Search: rearrange cache efficiency considerations

### DIFF
--- a/draft-ietf-httpbis-no-vary-search.md
+++ b/draft-ietf-httpbis-no-vary-search.md
@@ -425,8 +425,6 @@ If a cache {{HTTP-CACHING}} implements this specification, the presented target 
   * the presented target URI ({{Section 7.1 of HTTP}}) and that of the stored response match, or
   * the presented target URI and that of the stored response are equivalent modulo search variance ({{comparing}}), given the variance obtained ({{obtain-a-url-search-variance}}) from the stored response.
 
-Servers SHOULD send no more than one distinct non-empty value for the `No-Vary-Search` field in response to requests for a given pathname.
-
 Cache implementations MAY fail to reuse a stored response whose target URI matches _only_ modulo URL search variance, if the cache has more recently stored a response which:
 
 * has a target URI which is equal to the presented target URI, excluding the query, and
@@ -434,7 +432,9 @@ Cache implementations MAY fail to reuse a stored response whose target URI match
 * has a `No-Vary-Search` field value different from the stored response being considered for reuse.
 
 {:aside}
-> Caches aren't required to reuse stored responses, generally. However, the above expressly empowers caches to, if it is advantageous for performance or other reasons, search a smaller number of stored responses. Such a cache might take steps like the following to identify a stored response (before checking the other conditions in {{Section 4 of HTTP-CACHING}}):
+> Caches aren't required to reuse stored responses, generally. However, the above expressly empowers caches to, if it is advantageous for performance or other reasons, search a smaller number of stored responses.
+>
+> That is, because caches might store more than one response for a given pathname, they need a way to efficiently look up the No-Vary-Search value without accessing all cached responses. Such a cache might take steps like the following to identify a stored response in a performant way, before checking the other conditions in {{Section 4 of HTTP-CACHING}}:
 >
 > 1. Let exactMatch be cache\[presentedTargetURI\]. If it is a stored response that can be reused, return it.
 > 1. Let targetPath be presentedTargetURI, with query parameters removed.
@@ -444,8 +444,8 @@ Cache implementations MAY fail to reuse a stored response whose target URI match
 > 1. Let searchVariance be obtained ({{obtain-a-url-search-variance}}) from nvsMatch.
 > 1. If nvsMatch's target URI and presentedTargetURI are not equivalent modulo search variance ({{comparing}}) given searchVariance, then return null.
 > 1. If nvsMatch is a stored response that can be reused, return it. Otherwise, return null.
->
-> Such implementations might "miss" some stored responses that could otherwise have been reused. It is therefore useful for servers to avoid sending different values for the `No-Vary-Search` field when possible.
+
+To aid cache implementation efficiency, servers SHOULD NOT send different non-empty values for the `No-Vary-Search` field in response to requests for a given pathname over time, unless there is a need to update how they handle the query component. Doing so would cause cache implementations that use a strategy like the above to miss some stored responses that could otherwise have been reused.
 
 # Security Considerations
 


### PR DESCRIPTION
Closes #3074, by making it clearer that the SHOULD requirement on server operators is in service of playing nicely with certain efficient cache implementation strategies.