### PR TITLE
[Unencoded-Digest] Allow parameterized values.

### DIFF
--- a/draft-ietf-httpbis-unencoded-digest.md
+++ b/draft-ietf-httpbis-unencoded-digest.md
@@ -137,7 +137,11 @@ where each:
   compute the digest;
 * value is a `Byte Sequence` ({{Section 3.3.5 of STRUCTURED-FIELDS}}), that
   conveys an encoded version of the byte output produced by the digest
-  calculation.
+  calculation. The byte sequence may have one or more Parameters
+  ({{Section 3.1.2 of STRUCTURED-FIELDS}}).
+
+  Note that parameters are ignored in processing today, but leave room for
+  future extensions.
 
 For example:
 

--- a/draft-ietf-httpbis-unencoded-digest.md
+++ b/draft-ietf-httpbis-unencoded-digest.md
@@ -138,7 +138,7 @@ where each:
 * value is a `Byte Sequence` ({{Section 3.3.5 of STRUCTURED-FIELDS}}), that
   conveys an encoded version of the byte output produced by the digest
   calculation.
-  
+
   Each Dictionary value can have zero or more Parameters ({{Section 3.1.2 of
   STRUCTURED-FIELDS}}). This specification does not define any Parameters but
   extensions MAY define them. Unknown Parameters MUST be ignored.
@@ -205,7 +205,7 @@ constraints that operate in addition to this specification.
   ascending, relative, weighted preference. It must be in the range 0 to 10
   inclusive. 1 is the least preferred, 10 is the most preferred, and a value of
   0 means "not acceptable".
-  
+
   Each Dictionary value can have zero or more Parameters ({{Section 3.1.2 of
   STRUCTURED-FIELDS}}). This specification does not define any Parameters but
   extensions MAY define them. Unknown Parameters MUST be ignored.

--- a/draft-ietf-httpbis-unencoded-digest.md
+++ b/draft-ietf-httpbis-unencoded-digest.md
@@ -138,7 +138,7 @@ where each:
 * value is a `Byte Sequence` ({{Section 3.3.5 of STRUCTURED-FIELDS}}), that
   conveys an encoded version of the byte output produced by the digest
   calculation.
-
+  
   Each Dictionary value can have zero or more Parameters ({{Section 3.1.2 of
   STRUCTURED-FIELDS}}). This specification does not define any Parameters but
   extensions MAY define them. Unknown Parameters MUST be ignored.
@@ -205,6 +205,10 @@ constraints that operate in addition to this specification.
   ascending, relative, weighted preference. It must be in the range 0 to 10
   inclusive. 1 is the least preferred, 10 is the most preferred, and a value of
   0 means "not acceptable".
+  
+  Each Dictionary value can have zero or more Parameters ({{Section 3.1.2 of
+  STRUCTURED-FIELDS}}). This specification does not define any Parameters but
+  extensions MAY define them. Unknown Parameters MUST be ignored.
 
 Examples:
 

--- a/draft-ietf-httpbis-unencoded-digest.md
+++ b/draft-ietf-httpbis-unencoded-digest.md
@@ -137,11 +137,11 @@ where each:
   compute the digest;
 * value is a `Byte Sequence` ({{Section 3.3.5 of STRUCTURED-FIELDS}}), that
   conveys an encoded version of the byte output produced by the digest
-  calculation. The byte sequence may have one or more Parameters
-  ({{Section 3.1.2 of STRUCTURED-FIELDS}}).
+  calculation.
 
-  Note that parameters are ignored in processing today, but leave room for
-  future extensions.
+  Each Dictionary value can have zero or more Parameters ({{Section 3.1.2 of
+  STRUCTURED-FIELDS}}). This specification does not define any Parameters but
+  extensions MAY define them. Unknown Parameters MUST be ignored.
 
 For example:
 


### PR DESCRIPTION
The spec is currently silent on the subject of parameters, and it seems reasonable to consistently make room for future extension by explicitly defining them as allowed but ignored. This has little practical impact, but hopefully ensures that implementers would treat `sha-256=:...:;options=plz` and `sha-256=:...:` as equivalent declarations.