### PR TITLE
QUERY: HTTPDIR/RF review - Redirection (closes #3119)

### DIFF
--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -293,23 +293,28 @@ q=foo&amp;limit=10&amp;sort=-published
       <t>
         In some cases, the server may choose to respond indirectly to the QUERY
         request by redirecting the user agent to a different URI (see
-        <xref target="HTTP" section="15.4"/>). The semantics of the redirect
-        response do not differ from other methods.
+        <xref target="HTTP" section="15.4"/>). The semantics of the various redirect
+        status codes are the same as those defined in in that specification,
       </t>
       <t>
-        For the status code 303 (See Other, <xref target="HTTP" section="15.4.4"/>) in a
-        response to a QUERY request, this specification defines the semantics
+        In particular, the status codes 307 (Temporary Redirect, <xref target="HTTP" format="comma" section="15.4.8"/>) and 308
+        (Permanent Redirect, <xref target="HTTP" format="comma" section="15.4.9"/>) indicate that
+        the target resource resides at a different URI, either temporarily or permanently.
+      </t>
+      <t>
+        Note that in the context of the QUERY method, status codes 301 (Moved Permanently, <xref target="HTTP" format="comma" section="15.4.2"/>)
+        and 302 (Found, <xref target="HTTP" format="comma" section="15.4.3"/>) have exactly the
+        same meaning as status codes 308 and 307, as their only difference in behaviour is restricted
+        to responses to POST requests.
+      </t>
+      <t>
+        For the status code 303 (See Other, <xref target="HTTP" section="15.4.4"/>), this specification defines the semantics
         of the Location response field (<xref target="HTTP" sectionFormat="comma" section="10.2.2"/>) to
         identify an alternate URI that represents the QUERY request, and from which current results
         can be retrieved using a GET request.
       </t>
       <t>
-        On the other hand, response codes such as 307 (Temporary Redirect, <xref target="HTTP" format="comma" section="15.4.8"/>) and 308
-        (Permanent Redirect, <xref target="HTTP" format="comma" section="15.4.9"/>) can be used to request the user agent to redo
-        the QUERY request on the URI specified by the Location field.
-      </t>
-      <t>
-        See <xref target="example.indirect"/> for an example.
+        See <xref target="example.indirect"/> for an example use of the status code 303.
       </t>
     </section>
 

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -309,10 +309,8 @@ q=foo&amp;limit=10&amp;sort=-published
         similar QUERY request to the new target URI referenced by Location.
       </t>
       <t>
-        Note that in the context of the QUERY method, status codes 301 (Moved Permanently, <xref target="HTTP" format="comma" section="15.4.2"/>)
-        and 302 (Found, <xref target="HTTP" format="comma" section="15.4.3"/>) have exactly the
-        same meaning as status codes 308 and 307, as their only difference in behaviour is restricted
-        to responses to POST requests.
+        Note that the exceptions for redirecting a POST as a GET request after a 301 or 302 response
+        do not apply to QUERY requests.
       </t>
       <t>
         For the status code 303 (See Other, <xref target="HTTP" section="15.4.4"/>), this specification defines the semantics

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -297,20 +297,19 @@ q=foo&amp;limit=10&amp;sort=-published
         response do not differ from other methods.
       </t>
       <t>
-        For instance, a 303 (See Other, <xref target="HTTP" section="15.4.4"/>)
-        response would indicate that the Location field identifies an
-        alternate URI from which the results can be retrieved
-        using a GET request (this use case is also covered by the
-        use of the Location response field in a 2xx response).
+        For the status code 303 (See Other, <xref target="HTTP" section="15.4.4"/>) in a
+        response to a QUERY request, this specification defines the semantics
+        of the Location response field (<xref target="HTTP" sectionFormat="comma" section="10.2.2"/>) to
+        identify an alternate URI that represents the QUERY request, and from which current results
+        can be retrieved using a GET request.
       </t>
       <t>
-        On the other hand, response codes 307 (Temporary Redirect, <xref target="HTTP" section="15.4.8"/>) and 308
-        (Permanent Redirect, <xref target="HTTP" section="15.4.9"/>) can be used to request the user agent to redo
+        On the other hand, response codes such as 307 (Temporary Redirect, <xref target="HTTP" format="comma" section="15.4.8"/>) and 308
+        (Permanent Redirect, <xref target="HTTP" format="comma" section="15.4.9"/>) can be used to request the user agent to redo
         the QUERY request on the URI specified by the Location field.
       </t>
       <t>
-        Various non-normative examples of successful
-        QUERY responses are illustrated in <xref target="examples"/>.
+        See <xref target="example.indirect"/> for an example.
       </t>
     </section>
 

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -296,9 +296,17 @@ q=foo&amp;limit=10&amp;sort=-published
         <xref target="HTTP" section="15.4"/>).
       </t>
       <t>
-        In particular, the status codes 307 (Temporary Redirect, <xref target="HTTP" format="comma" section="15.4.8"/>) and 308
-        (Permanent Redirect, <xref target="HTTP" format="comma" section="15.4.9"/>) indicate that
-        the target resource resides at a different URI, either temporarily or permanently.
+        A response with either of the status codes
+        301 (Moved Permanently, <xref target="HTTP" format="comma" section="15.4.2"/>) or
+        308 (Permanent Redirect, <xref target="HTTP" format="comma" section="15.4.9"/>)
+        indicates that the target resource has permanently moved to a different URI referenced by the
+        Location response field (<xref target="HTTP" sectionFormat="comma" section="10.2.2"/>).
+        Likewise, a response with either
+        302 (Found, <xref target="HTTP" format="comma" section="15.4.3"/> or
+        307 (Temporary Redirect, <xref target="HTTP" format="comma" section="15.4.8"/>)
+        indicates that the target resource has temporarily moved. In all four cases, the server is
+        suggesting that the user agent can accomplish its original QUERY request by sending a
+        similar QUERY request to the new target URI referenced by Location.
       </t>
       <t>
         Note that in the context of the QUERY method, status codes 301 (Moved Permanently, <xref target="HTTP" format="comma" section="15.4.2"/>)

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -293,8 +293,7 @@ q=foo&amp;limit=10&amp;sort=-published
       <t>
         In some cases, the server may choose to respond indirectly to the QUERY
         request by redirecting the user agent to a different URI (see
-        <xref target="HTTP" section="15.4"/>). The semantics of the various redirect
-        status codes are the same as those defined in in that specification,
+        <xref target="HTTP" section="15.4"/>).
       </t>
       <t>
         In particular, the status codes 307 (Temporary Redirect, <xref target="HTTP" format="comma" section="15.4.8"/>) and 308

--- a/draft-ietf-httpbis-safe-method-w-body.xml
+++ b/draft-ietf-httpbis-safe-method-w-body.xml
@@ -313,13 +313,11 @@ q=foo&amp;limit=10&amp;sort=-published
         do not apply to QUERY requests.
       </t>
       <t>
-        For the status code 303 (See Other, <xref target="HTTP" section="15.4.4"/>), this specification defines the semantics
-        of the Location response field (<xref target="HTTP" sectionFormat="comma" section="10.2.2"/>) to
-        identify an alternate URI that represents the QUERY request, and from which current results
-        can be retrieved using a GET request.
-      </t>
-      <t>
-        See <xref target="example.indirect"/> for an example use of the status code 303.
+        A response to QUERY with the status code 303 (See Other, <xref target="HTTP" section="15.4.4"/>)
+        indicates that the original query can be accomplished via a normal retrieval request on the URI referenced
+        by the Location response field (<xref target="HTTP" sectionFormat="comma" section="10.2.2"/>).
+        For HTTP, this means sending a GET request to the new target URI, as illustrated by the example
+        in <xref target="example.indirect"/>.
       </t>
     </section>
 


### PR DESCRIPTION
This changes the definition of 303 -> Location to identify the "stored query" for GET, representing _current_ results.

Interestingly enough, this is what the example showed already.
