### PR TITLE
[connect-tcp] Improve recommendation for abrupt TLS termination

### DIFF
--- a/draft-ietf-httpbis-connect-tcp.md
+++ b/draft-ietf-httpbis-connect-tcp.md
@@ -169,8 +169,11 @@ When closing connections, endpoints are subject to the following requirements:
   - If the connection closed gracefully, the endpoint MUST close the send stream gracefully.
   - Otherwise, the endpoint SHOULD close the send stream abruptly, using a mechanism appropriate to the HTTP version:
     - HTTP/3: RESET_STREAM with H3_CONNECT_ERROR
+      - See {{!RFC9000, Section 19.4}} and {{?RFC9114, Section 8.1}}.
     - HTTP/2: RST_STREAM with CONNECT_ERROR
-    - HTTP/1.1 over TLS: a TLS Error Alert
+      - See {{!RFC9113}}, Sections 6.4 and 7.
+    - HTTP/1.1 over TLS: TCP shutdown without a TLS closure alert
+      - See {{!RFC8446, Section 6.1}}.
     - HTTP/1.1 (insecure): TCP RST.
 * When the receive stream is closed abruptly or without a FINAL_DATA capsule received, the endpoint SHOULD send a TCP RST if the TCP subsystem permits it.
 


### PR DESCRIPTION
The current recommendation, to send a TLS Error Alert, is very difficult to implement.  The new, relaxed recommendation allows a broader range of implementations, is much easier to implement, and is equally effective and secure.