### PR TITLE
Rename __HostHttp- to __Host-Http- for improved backwards compat

### DIFF
--- a/draft-ietf-httpbis-layered-cookies.md
+++ b/draft-ietf-httpbis-layered-cookies.md
@@ -1305,7 +1305,7 @@ boolean _httpOnlyAllowed_, boolean _allowNonHostOnlyCookieForPublicSuffix_, and 
 
 1. If _cookie_'s name, byte-lowercased, starts with `__http-` and _cookie_ is not Http-prefix compatible, then return null.
 
-1. If _cookie_'s name, byte-lowercased, starts with `__hosthttp-` and _cookie_ is not both Host-prefix compatible and Http-prefix compatible, then return null.
+1. If _cookie_'s name, byte-lowercased, starts with `__host-http-` and _cookie_ is not both Host-prefix compatible and Http-prefix compatible, then return null.
 
 1. If _cookie_'s name is the empty byte sequence and one of the following is true:
 
@@ -1315,7 +1315,7 @@ boolean _httpOnlyAllowed_, boolean _allowNonHostOnlyCookieForPublicSuffix_, and 
 
     * _cookie_'s value, byte-lowercased, starts with `__http-`, or
 
-    * _cookie_'s value, byte-lowercased, starts with `__hosthttp-`,
+    * _cookie_'s value, byte-lowercased, starts with `__host-http-`,
 
    then return null.
 


### PR DESCRIPTION
Following discussions on Matrix, this renames the `__HostHttp-` to be `__Host-Http-`.

While a bit uglier, this makes it easier to deploy this to non-supporting browsers while not losing the characteristics that `__Host-` provides.

Tested in https://github.com/web-platform-tests/wpt/pull/54226 and https://github.com/web-platform-tests/wpt/pull/54260. Relevant cookie store changes in https://github.com/whatwg/cookiestore/pull/286