### PR TITLE
Ensure that http and host-http prefix rules are enforced on read

### DIFF
--- a/draft-ietf-httpbis-layered-cookies.md
+++ b/draft-ietf-httpbis-layered-cookies.md
@@ -1405,6 +1405,18 @@ boolean _httpOnlyAllowed_, and string _sameSite_:
 
        * cookie's same-site is "`none`".
 
+   * One of the following is true:
+
+       * cookie's name, byte-lowercased, does not start with `__http-`.
+
+       * cookie is Http-prefix compatible.
+
+   * One of the following is true:
+
+       * cookie's name, byte-lowercased, does not start with `__host-http-`.
+
+       * cookie is Http-prefix compatible and Host-prefix compatible.
+
 1. Sort _cookies_ in the following order:
 
    * Cookies whose path's size is greater are listed before cookies whose path's size


### PR DESCRIPTION
To ease deployments of `__Http-` and `__Host-Http-` prefixes, servers need to be sure that changing cookie names today won't enable attacking browsers that don't yet support these semantics once they would start supporting them.

Enforcing the prefix semantics when reading the cookies can help provide these guarantees. (and can avoid complex server-side logic when deploying these prefixes)