### PR TITLE
Tweak definition of Upload-Limit KVs

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -347,7 +347,7 @@ The following key-value pairs are defined:
 
 Except for the `max-age` limit, the existence of a limit or its value MUST NOT change throughout the lifetime of the upload resource.
 
-Receivers of `Upload-Limit` parse the Dictionary as described in {{Section 4.2 of STRUCTURED-FIELDS}}. Where the Dictionary is successfully parsed, this document places the additional requirement that Dictionary members with unknown keys, or members using known keys with values of unexpected types, MUST be ignored.
+Receivers of `Upload-Limit` parse the Dictionary as described in {{Section 4.2 of STRUCTURED-FIELDS}}. Where the Dictionary is successfully parsed, this document places two additional requirements on Dictionary members. First, a member with an unknown key MUST be ignored. Second, a member with a known key but a value of unexpected type MUST cause the entire `Upload-Limit` header field to be ignored, or alternatively the complete HTTP message MUST be treated as malformed.
 
 A server that supports the creation of a resumable upload resource ({{upload-creation}}) for a target URI MUST include the `Upload-Limit` header field with the corresponding limits in a response to an `OPTIONS` request sent to this target URI. If a server supports the creation of upload resources for any target URI, it SHOULD include the `Upload-Limit` header field with the corresponding limits in a response to an `OPTIONS` request with the `*` target unless the server is not capable of handling `OPTIONS *` requests. If the server does not apply any limits, it MUST use `min-size=0` instead of an empty header value.
 


### PR DESCRIPTION
First, use a list rather than bullets. This helps highlight the key name, and its value type.

Second, borrow text from https://www.rfc-editor.org/rfc/rfc9218#section-4-7 about how we
deal with unknown or known but unexpected things. Unlike RFC 9218, there are no additional
constrains on the allowed values carried in Upload-Limit, so I dropped that clause here. If
someone defines a new one later on, they can declare any additional special behaviour that might be
needed IMO

Fixes #3173
