### PR TITLE
Update requirements on use of Location during upload creation

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -365,7 +365,7 @@ The server MUST record the length according to {{upload-length}} if the necessar
 
 While the request content is being received, the server MAY send multiple interim responses with a `104 (Upload Resumption Supported)` status code and the `Upload-Offset` header field set to the current offset to inform the client about the upload progress.
 
-Where a response requires a `Location` header field to be included, all interim and final response messages for the same request MUST contain an identical `Location` value. Clients SHOULD verify the `Location` value does not change between response messages.
+Where a response requires a `Location` header field to be included, all interim and final response messages for the same request MUST contain an identical `Location` value. However, final responses including the `Upload-Complete: ?1` header field are exempt from this requirement because they are the result of processing the transferred representation and the `Location` value does not necessarily represent the upload location. Where the `Location` value is expected to be identical across multiple messages, clients SHOULD verify this. If verification fails, clients SHOULD abort the current request and cancel the upload ({{upload-cancellation}}).
 
 If the server does not receive the entire request content, for example because of canceled requests or dropped connections, it SHOULD append as much of the request content as possible to the upload resource. The upload resource MUST NOT be considered complete then.
 


### PR DESCRIPTION
Previously, there were "mixed" requirements on including a Location
in interim or final response to an upload creation request. This
created some annoying dealing with 104 responses depending on
if they were first or not.
   
The PR proposes more consistency. If you're going to generate a
Location, it must always be sent and must always be the same value
in all responses. Only a SHOULD requirement is levied on the client
to check these - making it MUST seems a bit too onerous.
    
Fixes #3183