### PR TITLE
Clarify when a server MUST supply an upload-length

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -476,7 +476,7 @@ A successful response to a `HEAD` request against an upload resource
 
 - MUST include the offset in the `Upload-Offset` header field ({{upload-offset}}),
 - MUST include the completeless state in the `Upload-Complete` header field ({{upload-complete}}),
-- MUST include the length in the `Upload-Length` header field if known ({{upload-length}}),
+- MUST include the length in the `Upload-Length` header field unless the client has not supplied one ({{upload-length}}),
 - MUST indicate the limits in the `Upload-Limit` header field ({{upload-limit}}), and
 - SHOULD include the `Cache-Control` header field with the value `no-store` to prevent HTTP caching ({{CACHING}}).
 


### PR DESCRIPTION
We have the requirement "if the client knows the representation data's length,
it SHOULD include the `Upload-Length`". Which means the server can be a position
to either know, or not know the value.

This change makes a minor tweak to the text to highlight that when the server
was given a length it really MUST respond with it but when it didn't get given
one it can't.

Fixes #3187
