### PR TITLE
no-vary: URI/URL/Caching terminology (fixes #3283)

### DIFF
--- a/draft-ietf-httpbis-no-vary-search.md
+++ b/draft-ietf-httpbis-no-vary-search.md
@@ -112,7 +112,7 @@ This specification defines a proposed HTTP response header field for changing ho
 
 # Introduction
 
-HTTP caching {{HTTP-CACHING}} is based on reusing resources which match across a number of cache keys. One of the most prominent is the presented target URI ({{Section 7.1 of HTTP}}). However, sometimes multiple URIs can represent the same resource. This leads to caches not always being as helpful as they could be: if the cache contains a response under one URI, but the resource is then requested under another, the cached version will be ignored.
+HTTP caching {{HTTP-CACHING}} is based on reusing resources which match across a number of cache keys. One of the most prominent is the presented target URI ({{Section 7.1 of HTTP}}). However, sometimes multiple URIs can represent the same resource. This leads to caches not always being as helpful as they could be: if the cache contains a response under one URI, but the response is then requested under another, the cached version will be ignored.
 
 The `No-Vary-Search` HTTP header field tackles a specific subset of this general problem, for when different URIs that only differ in
 certain query parameters identify the same resource. It allows resources to declare that some or all parts of the query component do not semantically affect the served resource, and thus can be ignored for cache matching purposes. For example, if the order of the query parameters do not affect which resource is identified, this is indicated using


### PR DESCRIPTION
This is an attempt (probably incomplete) to clean up terminology of URIs vs URLs vs resources vs responses etc.

IMHO the goal should be:

- use URL when referencing algorithms and formats in the WHATWG spec,
- use URI when talking about HTTP, Caching and related topics.

...and also explain what's going on wrt this.