### PR TITLE
RESUMABLE: Correct terminology around server and resource

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -267,7 +267,7 @@ Client                                       Server
 ~~~
 {: #fig-upload-resume-incomplete title="Resuming an interrupted upload"}
 
-4) The request to append the last part of the representation data has a `Upload-Complete` field value set to true to indicate the complete transfer. Once the remaining representation data is transferred, the server processes the entire representation and responds with whatever the initial request to `/project/123/files` would have produced if the request had transferred the entire representation, e.g. a `200 (OK)` response.
+4) The request to append the last part of the representation data has a `Upload-Complete` field value set to true to indicate the complete transfer. Once the remaining representation data is transferred, the server processes the entire representation and responds with whatever the initial request to `/project/123/files` would have produced if its representation had been fully transferred and processed, e.g. a `200 (OK)` response.
 
 
 ~~~ aasvg


### PR DESCRIPTION
This PR corrects some mistakes around the use of server and resource. They are sometimes mixed up in the document and we could benefit from clearer language around them.

Fixes https://github.com/httpwg/http-extensions/issues/3164: servers, instead of resources, manage things
Fixes https://github.com/httpwg/http-extensions/issues/3181
Fixes https://github.com/httpwg/http-extensions/issues/3189: server generates responses; resources don't respond
Fixes https://github.com/httpwg/http-extensions/issues/3211: `server processes data` instead of `server receives data`.
Fixes https://github.com/httpwg/http-extensions/issues/3209: support for resumable uploads depends on resource, not server