### PR TITLE
allow use of ?0 and clarify the possibility to add parameters

### DIFF
--- a/draft-ietf-httpbis-incremental.md
+++ b/draft-ietf-httpbis-incremental.md
@@ -112,9 +112,7 @@ A true value ("?1") indicates that the sender requests intermediaries to forward
 the message incrementally, as described below.
 
 A false value ("?0") indicates the default behavior defined in {{HTTP}}, where
-intermediaries might buffer the entire message before forwarding it. This
-behavior is equivalent to the case where the Incremental header field is not
-present.
+intermediaries might buffer the entire message before forwarding it.
 
 Upon receiving a header section that includes an Incremental header field with a
 true value, HTTP intermediaries SHOULD NOT buffer the entire message before


### PR DESCRIPTION
This pull request is an attempt to resolve [part of the discussion on the mailing list during the WGLC](https://lists.w3.org/Archives/Public/ietf-http-wg/2025OctDec/thread.html#msg53), by:
* allowing the use of `?0` (i.e., same as when the header is absent), and
* clarifying that parameters can be added to the boolean values later.