### PR TITLE
[resumable] Fix missed value in creation section

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -402,7 +402,7 @@ If the `Upload-Complete` request header field is set to true, the client intends
 
 If the `Upload-Complete` header field is set to false, the client intends to transfer the representation over multiple requests. If the request content was fully received, the server MUST include the `Location` response header field pointing to the upload resource and MUST include the `Upload-Limit` header field with the corresponding limits if existing. Servers are RECOMMENDED to use the `201 (Created)` status code.
 
-The server MUST record the length according to {{upload-length}} if the `Upload-Length` or `Upload-Complete` header fields are included in the request.
+The server MUST record the length according to {{upload-length}} if the `Upload-Length` or `Upload-Complete: ?1` header fields are included in the request.
 
 While the request content is being received, the server MAY send multiple interim responses with a `104 (Upload Resumption Supported)` status code and the `Upload-Offset` header field set to the current offset to inform the client about the upload progress.
 


### PR DESCRIPTION
Fixes a minor issue in the text for server behavior in the creation part. 

If the client sends an empty creation request, i.e. zero byte body and `Upload-Complete: ?0`, it does not make sense for the server to record the length in `Content-Length` given that it will be zero bytes.