### PR TITLE
Rephrase the requirements

### DIFF
--- a/draft-ietf-httpbis-incremental.md
+++ b/draft-ietf-httpbis-incremental.md
@@ -158,7 +158,7 @@ unknown parameters.
 
 # Security Considerations
 
-When receiving an request or response that asks for incremental forwarding,
+When receiving a request or response that asks for incremental forwarding,
 intermediaries might reject the request due to security concerns. The following
 subsections explore typical scenarios under which the intermediaries might
 reject requests.


### PR DESCRIPTION
This pull request is against #3310.

As discussed in https://github.com/httpwg/http-extensions/pull/3310#issuecomment-3440234503, current structure might not be the best that we can achieve.

This pull request adjusts the structure so that in the same section we state:
* An intermediary SHOULD forward incrementally.
* But if it decides outright to not, it MUST generate an error rather than buffering the entire message.
* However, incremental is still an advisory feature, as not all intermediaries are required to support it.