### PR TITLE
resumable: clarify greater offset

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -992,6 +992,12 @@ Reference:
 # Changes
 {:removeinrfc="true"}
 
+## Since draft-ietf-httpbis-resumable-upload-11
+{:numbered="false"}
+
+* Clear up different responsibilities of server and upload resource.
+* Relax recommendations on client handling greater offsets.
+
 ## Since draft-ietf-httpbis-resumable-upload-10
 {:numbered="false"}
 


### PR DESCRIPTION
Resolves #3268, making it more explicit that the resource offset is allowed to be greater than what the client sent in its current upload. It also consolidates the rejection behavior for lesser and greater offsets.