### PR TITLE
RFC6265bis: Address Éric Vyncke's and Roman Danyliw's review issues

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -64,18 +64,49 @@ normative:
   DOM-DOCUMENT-COOKIE:
     target: https://html.spec.whatwg.org/#dom-document-cookie
     title: HTML - Living Standard
-    date: 2021-05-18
     author:
     -
-      org: WHATWG
+      ins: A. van Kesteren
+      name: Anne van Kesteren
+    -
+      ins: D. Denicola
+      name: Domenic Denicola
+    -
+      ins: D. Farolino
+      name: Dominic Farolino
+    -
+      ins: I. Hickson
+      name: Ian Hickson
+    -
+      ins: P. Jägenstedt
+      name: Philip Jägenstedt
+    -
+      ins: S. Pieters
+      name: Simon Pieters
+    ann: WHATWG
   SAMESITE:
     target: https://html.spec.whatwg.org/#same-site
-    title: HTML - Living Standard
-    date: 2021-01-26
+    title: HTML Living Standard
     author:
     -
-      org: WHATWG
-
+      ins: A. van Kesteren
+      name: Anne van Kesteren
+    -
+      ins: D. Denicola
+      name: Domenic Denicola
+    -
+      ins: D. Farolino
+      name: Dominic Farolino
+    -
+      ins: I. Hickson
+      name: Ian Hickson
+    -
+      ins: P. Jägenstedt
+      name: Philip Jägenstedt
+    -
+      ins: S. Pieters
+      name: Simon Pieters
+    ann: WHATWG
 informative:
   RFC3986:
   RFC4648:


### PR DESCRIPTION
Addresses several issues brought up in Roman Danyliw's,https://lists.w3.org/Archives/Public/ietf-http-wg/2025JanMar/0141.html, and Éric Vyncke's, https://lists.w3.org/Archives/Public/ietf-http-wg/2025JanMar/0139.html, reviews.

- Consistently reference whatwg sources
- Bump the example cookie expiration date
- Add "Header" to the cookie header section titles
- Remove "we" from the Document-based requests section