### PR TITLE
Make clear when examples use hex encoding presentation

### DIFF
--- a/draft-ietf-httpbis-unencoded-digest.md
+++ b/draft-ietf-httpbis-unencoded-digest.md
@@ -231,7 +231,9 @@ Integrity fields can be used in combination to address different and
 complementary needs, particularly the cases described in {{introduction}}.
 
 In the following examples, the unencoded response data is the string "An
-unexceptional string" following by an LF.
+unexceptional string" following by an LF. For presentation purposes, the
+response body is displayed as a sequence of hex-encoded bytes because it
+contains non-printable characters.
 
 The first example demonstrates a request that uses content negotiation.
 


### PR DESCRIPTION
This copies the language from RFC 9530 for consistency.
