### PR TITLE
[RFC6265bis] Accept `max-age=0`

### DIFF
--- a/draft-ietf-httpbis-rfc6265bis.md
+++ b/draft-ietf-httpbis-rfc6265bis.md
@@ -620,9 +620,7 @@ cookie-av         = expires-av / max-age-av / domain-av /
 expires-av        = "Expires" BWS "=" BWS sane-cookie-date
 sane-cookie-date  =
     <IMF-fixdate, defined in [HTTP], Section 5.6.7>
-max-age-av        = "Max-Age" BWS "=" BWS non-zero-digit *DIGIT
-non-zero-digit    = %x31-39
-                      ; digits 1 through 9
+max-age-av        = "Max-Age" BWS "=" BWS 1*DIGIT
 domain-av         = "Domain" BWS "=" BWS domain-value
 domain-value      = <subdomain>
                       ; see details below


### PR DESCRIPTION
As noted in #3375, the server-side requirements for `set-cookie` headers define a grammar that explicitly excludes "0" as a valid value for the `max-age` attribute. This doesn't match either current client behavior, or widespread developer practice for cookie removal (see [1]).

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies