### PR TITLE
Address genart review feedback

### DIFF
--- a/draft-ietf-httpbis-unencoded-digest.md
+++ b/draft-ietf-httpbis-unencoded-digest.md
@@ -135,8 +135,12 @@ entire selected representation data with no content codings applied ({{Section
 8.4.1 of HTTP}}).
 
 Apart from the content coding concerns, `Unencoded-Digest` behaves similarly
-to `Repr-Digest` ({{Section 3 of DIGEST-FIELDS}}). In the absence of content
-codings, `Unencoded-Digest` is identical to `Repr-Digest`.
+to `Repr-Digest` ({{Section 3 of DIGEST-FIELDS}}).
+
+`Unencoded-Digest` can be sent in messages with and without content codings.
+When there is no content coding, `Unencoded-Digest` acts identically to
+`Repr-Digest`; for the same hashing algorithm the computed value would be the
+same.
 
 `Unencoded-Digest` is a `Dictionary` (see {{Section 3.2 of STRUCTURED-FIELDS}})
 where each:
@@ -290,7 +294,7 @@ ca cc 4b e7 02 00 7e af 07 44
 ~~~
 {: title="GET response with GZIP content coding"}
 
-The second example demonstrates a range request with content negotiation.
+The second example demonstrates a range request that uses content negotiation.
 
 ~~~ http-message
 GET /boringstring HTTP/1.1


### PR DESCRIPTION
While there was some discussion on the [review email thread](https://lists.w3.org/Archives/Public/ietf-http-wg/2026JanMar/0003.html) about expanding on the Accept-Encoding angle, I think that will risk overcomplicating the topic and risk confusing readers. Especially since the Intro tries to make the point that we don't need/want to do something like send `Accept-Encoding: identity`. Instead I tried to do this implicitly by expanding the para on content coding omission a bit.