### PR TITLE
Address Deb Cooley's unencoded-digest feedback

### DIFF
--- a/draft-ietf-httpbis-unencoded-digest.md
+++ b/draft-ietf-httpbis-unencoded-digest.md
@@ -351,11 +351,13 @@ describe relevant considerations and mitigations.
 A content coding may provide encryption capabilities, for example "aes128gcm"
 ({{?RFC8188}}). Using Unencoded-Digest with such content codings can leak
 information about the original data because header fields are visible to anyone
-who can read the HTTP message. This could be used as a side channel. For
-instance, an attacker that can access Unencoded-Digest values could infer
-details about the unencrypted content without decrypting it if, for example, the
-unencrypted content has a predictable pattern. When the "aes128gcm" content
-coding is used, the security considerations in {{Section 4 of ?RFC8188}} apply.
+who can read the HTTP message. For instance, an attacker that can access
+Unencoded-Digest values could infer details about the unencrypted content
+without decrypting it if, for example, the unencrypted content has a predictable
+pattern. When the "aes128gcm" content coding is used, the security
+considerations in {{Section 4 of ?RFC8188}} apply. Namely, the Unencoded-Digest
+field is considered sensitive information and SHOULD be omitted unless a means
+of encrypting the Unencoded-Digest field is used.
 
 
 # IANA Considerations


### PR DESCRIPTION
Fixes #3455

Drops "This could be used as a side channel." and adds "Namely, the Unencoded-Digest
field is considered sensitive information and SHOULD be omitted unless a means
of encrypting the Unencoded-Digest field is used."