### PR TITLE
RESUMABLE: Describe GET request against upload resource

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -523,7 +523,7 @@ Upload-Complete: ?1
 
 ### Client Behavior
 
-If the client wants to resume the upload after an interruption, it has to know the amount of representation data processed by the upload resource so far. It can fetch the offset by sending a `HEAD` or `GET` request to the upload resource. Using `HEAD` is RECOMMENDED as no response content is needed to resume. Upon a successful response, the client can continue the upload by appending representation data ({{upload-appending}}) starting at the offset indicated by the `Upload-Offset` response header field.
+If the client wants to resume the upload after an interruption, it has to know the amount of representation data processed by the upload resource so far. It can fetch the offset by sending a `HEAD` or `GET` request to the upload resource. Using `HEAD` is RECOMMENDED, since response content is not required for resumption. Upon a successful response, the client can continue the upload by appending representation data ({{upload-appending}}) starting at the offset indicated by the `Upload-Offset` response header field.
 
 The offset can be less than or equal to the number of bytes of representation data that the client has already sent. The client is expected to handle backtracking of a reasonable length. On the other hand, the offset can be greater than the amount of sent representation data if the upload resource obtained additional representation data on behalf of the client. If the client is not able to provide the representation data at the given offset, the upload MUST be considered a failure. The client then MUST NOT continue the upload and SHOULD cancel the upload ({{upload-cancellation}}).
 
@@ -548,7 +548,7 @@ A successful response to a `HEAD` or `GET` request against an upload resource
 
 The resource SHOULD NOT generate a response with the `301 (Moved Permanently)` and `302 (Found)` status codes because clients might follow the redirect without preserving the `HEAD` method.
 
-This document does not place any requirements on the response content for `GET` requests. In particular, the server is not required to respond with the transferred representation data.
+A client does not require response content for an offset retrieval request in order to successfully resume an upload. Therefore, serving response content for a `GET` request is unexpected. Its meaning is not defined by this protocol.
 
 ### Examples {#offset-retrieving-example}
 

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -523,7 +523,7 @@ Upload-Complete: ?1
 
 ### Client Behavior
 
-If the client wants to resume the upload after an interruption, it has to know the amount of representation data processed by the upload resource so far. It can fetch the offset by sending a `HEAD` request to the upload resource. Upon a successful response, the client can continue the upload by appending representation data ({{upload-appending}}) starting at the offset indicated by the `Upload-Offset` response header field.
+If the client wants to resume the upload after an interruption, it has to know the amount of representation data processed by the upload resource so far. It can fetch the offset by sending a `HEAD` or `GET` request to the upload resource. Using `HEAD` is RECOMMENDED as no response content is needed to resume. Upon a successful response, the client can continue the upload by appending representation data ({{upload-appending}}) starting at the offset indicated by the `Upload-Offset` response header field.
 
 The offset can be less than or equal to the number of bytes of representation data that the client has already sent. The client is expected to handle backtracking of a reasonable length. On the other hand, the offset can be greater than the amount of sent representation data if the upload resource obtained additional representation data on behalf of the client. If the client is not able to provide the representation data at the given offset, the upload MUST be considered a failure. The client then MUST NOT continue the upload and SHOULD cancel the upload ({{upload-cancellation}}).
 
@@ -538,7 +538,7 @@ If the client received a response with a
 
 ### Server Behavior {#offset-retrieving-server}
 
-A successful response to a `HEAD` request against an upload resource
+A successful response to a `HEAD` or `GET` request against an upload resource
 
 - MUST include the offset in the `Upload-Offset` header field ({{upload-offset}}),
 - MUST include the `Upload-Complete` header field ({{upload-complete}}) indicating whether a final response was produced from processing the uploaded representation,
@@ -547,6 +547,8 @@ A successful response to a `HEAD` request against an upload resource
 - SHOULD include the `Cache-Control` header field with the value `no-store` to prevent HTTP caching ({{CACHING}}).
 
 The resource SHOULD NOT generate a response with the `301 (Moved Permanently)` and `302 (Found)` status codes because clients might follow the redirect without preserving the `HEAD` method.
+
+This document does not place any requirements on the response content for `GET` requests. In particular, the server is not required to respond with the transferred representation data.
 
 ### Examples {#offset-retrieving-example}
 
@@ -977,6 +979,7 @@ Reference:
 * Redefine Upload-Complete on the server side.
 * Recommend incremental delivery.
 * Clarify `min-size` limit and its client behavior.
+* Describe `GET` requests against upload resource.
 
 ## Since draft-ietf-httpbis-resumable-upload-10
 {:numbered="false"}


### PR DESCRIPTION
Closes https://github.com/httpwg/http-extensions/issues/3214.

This PR updates the document so GET requests are to be handled as HEAD requests. It's explicitly mentioned that no requirements on GET response content is placed:

> This document does not place any requirements on the response content for `GET` requests. In particular, the server is not required to respond with the transferred representation data.

Let me know if that's not needed.