### PR TITLE
RESUMABLE: remove section about Integrity

### DIFF
--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -765,29 +765,6 @@ Since the codings listed in `Content-Encoding` are a characteristic of the repre
 
 Unlike `Content-Encoding` (see {{Section 8.4.1 of HTTP}}), `Transfer-Encoding` (see {{Section 6.1 of RFC9112}}) is a property of the message, not of the representation. Moreover, transfer codings can be applied in transit (e.g., by proxies). This means that a client does not have to consider the transfer codings to compute the upload offset, while a server is responsible for transfer decoding the message before computing the upload offset. The same applies to the value of `Upload-Length`. Please note that the `Content-Length` header field cannot be used in conjunction with the `Transfer-Encoding` header field.
 
-# Integrity Digests
-
-The integrity of an entire upload or individual upload requests can be verifying using digests from {{DIGEST-FIELDS}}.
-
-## Representation Digests
-
-Representation digests help verify the integrity of the entire representation data that has been uploaded so far, which might stretch across multiple requests.
-
-If the client knows the integrity digest of the entire representation data before creating an upload resource, it can include the `Repr-Digest` header field when creating an upload ({{upload-creation}}). Once the upload is completed, the server can compute the integrity digest of the representation data and compare it to the provided digest. If the digests don't match, the server SHOULD consider the upload failed, not process the representation further, and signal the failure to the client. This way, the integrity of the entire representation data can be protected.
-
-Alternatively, when creating an upload ({{upload-creation}}), the client can ask the server to compute and return the integrity digests using a `Want-Repr-Digest` field conveying the preferred algorithms.
-The response SHOULD include at least one of the requested digests, but might not include it.
-The server SHOULD compute the representation digests using the preferred algorithms once the upload is complete and include the corresponding `Repr-Digest` header field in the response.
-Alternatively, the server can compute the digest continuously during the upload and include the `Repr-Digest` header field in responses to upload creation ({{upload-creation}}) and upload appending requests ({{upload-appending}}) even when the upload is not completed yet.
-This allows the client to simultaneously compute the digest of the transmitted representation data, compare its digest to the server's digest, and spot data integrity issues.
-If an upload is spread across multiple requests, data integrity issues can be found even before the upload is fully completed.
-
-## Content Digests
-
-Content digests help verify the integrity of the content in an individual request.
-
-If the client knows the integrity digest of the content from an upload creation ({{upload-creation}}) or upload appending ({{upload-appending}}) request, it can include the `Content-Digest` header field in the request. Once the request is complete, the server can compute the integrity digest of the content and compare it to the provided digest. If the digests don't match the server SHOULD consider the transfer failed, not append the content to the upload resource, and signal the failure to the client. This way, the integrity of an individual request can be protected.
-
 # Upload Strategies
 
 The definition of the upload creation request ({{upload-creation}}) provides the client with flexibility to choose whether the representation data is fully or partially transferred in the first request, or if no representation data is included at all. Which behavior is best largely depends on the client's capabilities, its desire to avoid data retransmission, and its knowledge about the resource's support for resumable uploads.

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -960,6 +960,7 @@ Reference:
 * Replace uses of term "upload length" with "representation's length".
 * Include `Upload-Limit` in response to limit violation.
 * Clarify that clients might not know limits when starting upload.
+* Remove section covering integrity digests.
 
 ## Since draft-ietf-httpbis-resumable-upload-10
 {:numbered="false"}


### PR DESCRIPTION
While this section was well intentioned, it has not done a great
job of tracking protocol updates in other areas. On closer inspection,
more and more problems reveal themselves. This would take non-trivial
effort to gain consensus and write text that is correct and of equivalent
quality to the other parts of the document.

The integrity aspect is not part of the core resumable upload protocol.
Its possible for people to use the HTTP building blocks like Digest fields
to enhance a deployment and build something that would work. It would be
nice to include text on the topic but without deployment experience we
risk trying to codify something that is not yet well exercised. Delaying
the protocol publication for this topic may hurt to others that do not
intend to use integrity.

As such, this PR proposes to remove the text. By saying nothing on the
topic we do not preclude others from gaining deployment experience and
doing future work to document it (perhaps as an adopted WG item).

Closes #3228