### PR TITLE
Do not drop a cookie whose value or http-only changed

### DIFF
--- a/draft-ietf-httpbis-layered-cookies.md
+++ b/draft-ietf-httpbis-layered-cookies.md
@@ -1225,7 +1225,9 @@ cookie attribute "wins".
 ### Store a Cookie {#store-a-cookie}
 
 To **Store a Cookie** given a cookie _cookie_, boolean _isSecure_, domain or IP address _host_,
-boolean _httpOnlyAllowed_, boolean _allowNonHostOnlyCookieForPublicSuffix_, and boolean _sameSiteStrictOrLaxAllowed_:
+boolean _httpOnlyAllowed_, boolean _allowNonHostOnlyCookieForPublicSuffix_, and boolean
+_sameSiteStrictOrLaxAllowed_, run these steps. They return _cookie_, or null if _cookie_ was not
+stored or cannot be distinguished from the cookie it replaced:
 
 1. Assert: _cookie_'s name's length + _cookie_'s value's length is not 0 or greater than 4096.
 
@@ -1314,14 +1316,18 @@ boolean _httpOnlyAllowed_, boolean _allowNonHostOnlyCookieForPublicSuffix_, and 
 
    then return null.
 
+1. Let _changed_ be true.
+
 1. If the user agent's cookie store contains a cookie _oldCookie_ whose name is _cookie_'s name,
    host is host-equal to _cookie_'s host, host-only is _cookie_'s host-only, and path is path-equal to _cookie_'s path:
 
     1. If _httpOnlyAllowed_ is false and _oldCookie_'s http-only is true,
        then return null.
 
-    1. If _cookie_'s secure is equal to _oldCookie_'s secure, _cookie_'s same-site is equal to _oldCookie_'s
-       same-site, and _cookie_'s expiry-time is equal to _oldCookie_'s expiry-time, then return null.
+    1. If _cookie_'s value is equal to _oldCookie_'s value, _cookie_'s secure is equal to
+       _oldCookie_'s secure, _cookie_'s http-only is equal to _oldCookie_'s http-only, _cookie_'s
+       same-site is equal to _oldCookie_'s same-site, and _cookie_'s expiry-time is equal to
+       _oldCookie_'s expiry-time, then set _changed_ to false.
 
     1. Set _cookie_'s creation-time to _oldCookie_'s creation-time.
 
@@ -1330,6 +1336,8 @@ boolean _httpOnlyAllowed_, boolean _allowNonHostOnlyCookieForPublicSuffix_, and 
    Note: This algorithm maintains the invariant that there is at most one such cookie.
 
 1. Insert _cookie_ into the user agent's cookie store.
+
+1. If _changed_ is false, then return null.
 
 1. Return _cookie_.
 


### PR DESCRIPTION
Store a Cookie compared secure, same-site, and expiry-time against the cookie
being replaced, but not value or http-only, and returned null without storing
when those matched. That dropped the very common case of a cookie being
reissued with a new value, and silently ignored a newly added HttpOnly
attribute.

Compare value and http-only as well, and always store the cookie, returning
null afterwards to signal that it cannot be distinguished from the cookie it
replaced. As a result last-access-time is refreshed again.

Also document what Store a Cookie returns.

Fixes #3501.

Tests: https://github.com/web-platform-tests/wpt/pull/62161