### PR TITLE
Require HttpOnly for the "__Http-" and "__Host-Http-" prefixes

### DIFF
--- a/draft-ietf-httpbis-layered-cookies.md
+++ b/draft-ietf-httpbis-layered-cookies.md
@@ -831,7 +831,7 @@ A cookie _cookie_ is **Http-prefix compatible** if:
 
 1. _cookie_'s secure is true; and
 
-1. _cookie_'s http-only is false,
+1. _cookie_'s http-only is true,
 
 
 ## Cookie Store Eviction {#cookie-store-eviction}


### PR DESCRIPTION
Http-prefix compatible required http-only to be false, which is the opposite of
what the prefixes are for. It made "__Http-" and "__Host-Http-" cookies
settable only without an HttpOnly attribute, and rejected the ones set with it,
contradicting the descriptions of both prefixes.

Tests: cookies/prefix/__Http.https.html and
cookies/prefix/__Host-Http.https.html already assert the intended behaviour.