### PR TITLE
Treat a Domain attribute matching an IP address host as host-only

### DIFF
--- a/draft-ietf-httpbis-layered-cookies.md
+++ b/draft-ietf-httpbis-layered-cookies.md
@@ -1257,7 +1257,10 @@ boolean _httpOnlyAllowed_, boolean _allowNonHostOnlyCookieForPublicSuffix_, and 
 
     1. If _host_ does not Domain-Match _cookie_'s host, then return null.
 
-    1. Set _cookie_'s host-only to false.
+    1. If _cookie_'s host is an IP address and is host-equal to _host_, then set _cookie_'s
+       host-only to true.
+
+    1. Otherwise, set _cookie_'s host-only to false.
 
 1. Assert: _cookie_'s host is a domain or IP address.
 


### PR DESCRIPTION
Domain-Match only performs suffix matching when the host is a domain, so a
Domain attribute equal to an IP address host reaches exactly the hosts a
host-only cookie reaches. Storing such a cookie as non-host-only gained nothing
and cost something: host-only is part of what distinguishes one cookie from
another, so it could sit alongside an otherwise identical host-only cookie, with
both being sent.

It also made the "__Host-" prefix reject a cookie whose Domain attribute could
not do any of the subdomain spanning that prefix exists to prevent.